### PR TITLE
Add Flask controller and endpoint tests

### DIFF
--- a/ai_agent.py
+++ b/ai_agent.py
@@ -1,0 +1,98 @@
+import json
+import os
+import subprocess
+import time
+import urllib.parse
+import urllib.request
+
+# Allow overriding data directory for testing via the DATA_DIR environment variable
+DATA_DIR = os.environ.get("DATA_DIR", "/data")
+LOG_FILE = os.path.join(DATA_DIR, "ai_log.json")
+SUMMARY_FILE = os.path.join(DATA_DIR, "summary.txt")
+STOP_FLAG = os.path.join(DATA_DIR, "stop.flag")
+
+
+def _http_get(url: str):
+    with urllib.request.urlopen(url) as r:
+        return json.loads(r.read().decode())
+
+
+def _http_post(url: str, data: dict, form: bool = False):
+    if form:
+        body = urllib.parse.urlencode(data).encode()
+        headers = {}
+    else:
+        body = json.dumps(data).encode()
+        headers = {"Content-Type": "application/json"}
+    req = urllib.request.Request(url, data=body, headers=headers)
+    with urllib.request.urlopen(req) as r:
+        resp = r.read().decode()
+        try:
+            return json.loads(resp)
+        except Exception:
+            return resp
+
+
+def run_agent(
+    controller: str = "http://localhost:8081",
+    ollama: str = "http://localhost:11434/api/generate",
+    steps: int | None = None,
+    step_delay: int = 0,
+):
+    """Replicate the shell-based ai-agent loop for testing purposes.
+
+    Parameters
+    ----------
+    controller: str
+        Base URL of the controller service.
+    ollama: str
+        URL of the Ollama generate endpoint.
+    steps: int | None
+        Number of iterations to execute. ``None`` runs indefinitely until a
+        stop flag is found.
+    step_delay: int
+        Seconds to sleep between steps.
+    """
+
+    os.makedirs(DATA_DIR, exist_ok=True)
+    with open(LOG_FILE, "w") as f:
+        f.write("[")
+    step = 0
+    while steps is None or step < steps:
+        if os.path.exists(STOP_FLAG):
+            break
+        cfg = _http_get(f"{controller}/next-config")
+        model = cfg.get("model", "")
+        max_len = cfg.get("max_summary_length", 300)
+
+        # Build prompt from previous log output (simplified: empty prompt)
+        prompt = ""
+        with open(SUMMARY_FILE, "w") as f:
+            f.write(prompt)
+
+        resp = _http_post(ollama, {"model": model, "prompt": prompt})
+        cmd = resp.get("response", "") if isinstance(resp, dict) else ""
+        cmd = _http_post(
+            f"{controller}/approve", {"cmd": cmd, "summary": prompt}, form=True
+        )
+        if cmd == "SKIP":
+            step += 1
+            continue
+        proc = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+        entry = {
+            "step": step,
+            "command": cmd,
+            "output": (proc.stdout or "") + (proc.stderr or ""),
+        }
+        with open(LOG_FILE, "a") as f:
+            if step:
+                f.write(",")
+            json.dump(entry, f)
+        step += 1
+        time.sleep(step_delay)
+    with open(LOG_FILE, "a") as f:
+        f.write("]")
+
+
+if __name__ == "__main__":
+    run_agent()

--- a/controller.py
+++ b/controller.py
@@ -1,0 +1,141 @@
+from flask import Flask, request, jsonify, render_template_string, send_file, redirect
+import json, os, zipfile, io
+from datetime import datetime
+
+app = Flask(__name__)
+
+# Allow overriding data directory for testing via the DATA_DIR environment variable
+DATA_DIR = os.environ.get("DATA_DIR", "/data")
+CONFIG_FILE = os.path.join(DATA_DIR, "config.json")
+LOG_FILE = os.path.join(DATA_DIR, "ai_log.json")
+CONTROL_LOG = os.path.join(DATA_DIR, "control_log.json")
+BLACKLIST_FILE = os.path.join(DATA_DIR, "blacklist.txt")
+SUMMARY_FILE = os.path.join(DATA_DIR, "summary.txt")
+
+default_config = {
+    "model": "llama3",
+    "max_summary_length": 300,
+    "step_delay": 10,
+    "auto_restart": False,
+    "allow_commands": True,
+    "controller_active": True,
+}
+
+
+def read_config():
+    if not os.path.exists(CONFIG_FILE):
+        with open(CONFIG_FILE, "w") as f:
+            json.dump(default_config, f, indent=2)
+    with open(CONFIG_FILE) as f:
+        return json.load(f)
+
+
+@app.route("/next-config")
+def next_config():
+    cfg = read_config()
+    return jsonify(cfg)
+
+
+@app.route("/approve", methods=["POST"])
+def approve():
+    cmd = request.form.get("cmd", "").strip()
+    summary = request.form.get("summary", "").strip()
+    with open(BLACKLIST_FILE, "a+") as f:
+        f.seek(0)
+        if any(line.strip() == cmd for line in f):
+            return "SKIP"
+        f.write(cmd + "\n")
+    with open(CONTROL_LOG, "a") as f:
+        json.dump({
+            "received": cmd,
+            "summary": summary,
+            "approved": "OK",
+            "timestamp": datetime.utcnow().isoformat()
+        }, f)
+        f.write(",\n")
+    return cmd
+
+
+@app.route("/", methods=["GET", "POST"])
+def dashboard():
+    if request.method == "POST":
+        config = read_config()
+        for key in default_config:
+            val = request.form.get(key)
+            if isinstance(default_config[key], bool):
+                config[key] = (val or "").lower() == "true"
+            elif isinstance(default_config[key], int):
+                try:
+                    config[key] = int(val)
+                except Exception:
+                    pass
+            elif isinstance(default_config[key], str):
+                if val is not None:
+                    config[key] = val
+        with open(CONFIG_FILE, "w") as f:
+            json.dump(config, f, indent=2)
+        return redirect("/")
+    cfg = read_config()
+    try:
+        summary = open(SUMMARY_FILE).read()
+    except Exception:
+        summary = ""
+    try:
+        log = open(LOG_FILE).read()[-4000:]
+    except Exception:
+        log = "Kein Log"
+    return render_template_string(TEMPLATE, config=cfg, summary=summary, log=log)
+
+
+@app.route("/stop", methods=["POST"])
+def stop():
+    open(f"{DATA_DIR}/stop.flag", "w").close()
+    return "OK"
+
+
+@app.route("/restart", methods=["POST"])
+def restart():
+    try:
+        os.remove(f"{DATA_DIR}/stop.flag")
+    except Exception:
+        pass
+    return "OK"
+
+
+@app.route("/export")
+def export_logs():
+    mem = io.BytesIO()
+    with zipfile.ZipFile(mem, "w") as zf:
+        for name in [
+            "config.json",
+            "ai_log.json",
+            "control_log.json",
+            "blacklist.txt",
+            "summary.txt",
+        ]:
+            path = os.path.join(DATA_DIR, name)
+            if os.path.exists(path):
+                zf.write(path, arcname=name)
+    mem.seek(0)
+    return send_file(mem, as_attachment=True, download_name="export.zip", mimetype="application/zip")
+
+
+TEMPLATE = """<!doctype html><html><head><title>Agent Controller</title>
+<style>{% raw %}body{font-family:sans-serif;padding:2em;}input{width:100%;margin:4px;}{% endraw %}</style></head><body>
+<h1>🕹 Konfiguration</h1>
+<form method="post">
+  {% for key,val in config.items() %}
+    <label>{{ key }}:</label><input name="{{ key }}" value="{{ val }}" />
+  {% endfor %}
+  <button type="submit">✅ Speichern</button>
+</form>
+<h2>📄 Zusammenfassung</h2><pre>{{ summary }}</pre>
+<h2>📝 Letzter Log</h2><pre>{{ log }}</pre>
+<form method="post" action="/stop"><button>🛑 Stop Agent</button></form>
+<form method="post" action="/restart"><button>♻️ Restart Agent</button></form>
+<a href="/export"><button>📦 Export Logs</button></a>
+</body></html>"""
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8081)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: "3.8"
+
+services:
+  controller:
+    image: python:3.11-slim
+    working_dir: /app
+    volumes:
+      - .:/app
+      - ./data:/data
+    command: >
+      sh -c "pip install flask requests && python controller.py"
+    ports:
+      - "8081:8081"
+
+  ai-agent:
+    image: python:3.11-slim
+    working_dir: /app
+    volumes:
+      - .:/app
+      - ./data:/data
+    command: >
+      sh -c "python ai_agent.py"
+    depends_on:
+      - controller

--- a/tests/test_ai_agent.py
+++ b/tests/test_ai_agent.py
@@ -1,0 +1,57 @@
+import importlib
+import json
+import os
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from werkzeug.serving import make_server
+
+
+def start_controller(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    controller = importlib.import_module("controller")
+    importlib.reload(controller)
+    server = make_server("127.0.0.1", 0, controller.app)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.start()
+    return server, thread
+
+
+def start_ollama_server():
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'{"response": "echo hi"}')
+
+        def log_message(self, format, *args):
+            pass
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.start()
+    return server, thread
+
+
+def test_ai_agent_simulation(tmp_path, monkeypatch):
+    ctrl_server, ctrl_thread = start_controller(tmp_path, monkeypatch)
+    ollama_server, ollama_thread = start_ollama_server()
+
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    ai_agent = importlib.import_module("ai_agent")
+    importlib.reload(ai_agent)
+
+    ctrl_url = f"http://127.0.0.1:{ctrl_server.server_port}"
+    ollama_url = f"http://127.0.0.1:{ollama_server.server_port}"
+
+    ai_agent.run_agent(controller=ctrl_url, ollama=ollama_url, steps=1, step_delay=0)
+
+    log_path = tmp_path / "ai_log.json"
+    data = json.loads(log_path.read_text())
+    assert data[0]["command"] == "echo hi"
+    assert "hi" in data[0]["output"]
+
+    ctrl_server.shutdown()
+    ollama_server.shutdown()
+    ctrl_thread.join()
+    ollama_thread.join()

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,0 +1,46 @@
+import importlib
+import os
+import sys
+import pytest
+
+# Ensure the repository root is on the Python path
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    """Provide a Flask test client with a temporary DATA_DIR."""
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    controller = importlib.import_module("controller")
+    importlib.reload(controller)
+    controller.app.config["TESTING"] = True
+    with controller.app.test_client() as client:
+        yield client
+
+def test_next_config(client):
+    resp = client.get("/next-config")
+    assert resp.status_code == 200
+
+def test_approve(client):
+    resp = client.post("/approve", data={"cmd": "echo hi", "summary": "summary"})
+    assert resp.status_code == 200
+
+def test_dashboard_get(client):
+    resp = client.get("/")
+    assert resp.status_code == 200
+
+def test_dashboard_post(client):
+    resp = client.post("/", data={}, follow_redirects=True)
+    assert resp.status_code == 200
+
+def test_stop(client):
+    resp = client.post("/stop")
+    assert resp.status_code == 200
+
+def test_restart(client):
+    resp = client.post("/restart")
+    assert resp.status_code == 200
+
+def test_export(client):
+    resp = client.get("/export")
+    assert resp.status_code == 200

--- a/tests/test_docker_compose.py
+++ b/tests/test_docker_compose.py
@@ -1,0 +1,8 @@
+import yaml
+from pathlib import Path
+
+def test_services_present():
+    compose = yaml.safe_load(Path('docker-compose.yml').read_text())
+    services = compose.get('services', {})
+    assert 'controller' in services
+    assert 'ai-agent' in services


### PR DESCRIPTION
## Summary
- implement a Flask `controller` application with configurable data directory and endpoints for config retrieval, command approval, dashboard, stopping/restarting, and exporting logs
- add pytest suite verifying each endpoint responds with HTTP 200
- add a Python `ai_agent` module simulating the shell loop and a test that mocks the Ollama API to verify the agent executes and logs commands
- add a docker-compose setup to run controller and agent services together

## Testing
- `pip install flask requests pyyaml -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fe542e7f0832687e7a6f286fe03a0