### PR TITLE
Add configurable prompt support to controller and AI agent

### DIFF
--- a/ai_agent.py
+++ b/ai_agent.py
@@ -65,8 +65,8 @@ def run_agent(
         model = cfg.get("model", "")
         max_len = cfg.get("max_summary_length", 300)
 
-        # Build prompt from previous log output (simplified: empty prompt)
-        prompt = ""
+        # Build prompt from config or previous log output
+        prompt = cfg.get("prompt", "")
         with open(SUMMARY_FILE, "w") as f:
             f.write(prompt)
 

--- a/controller.py
+++ b/controller.py
@@ -19,15 +19,23 @@ default_config = {
     "auto_restart": False,
     "allow_commands": True,
     "controller_active": True,
+    "prompt": "",
 }
 
 
 def read_config():
-    if not os.path.exists(CONFIG_FILE):
-        with open(CONFIG_FILE, "w") as f:
-            json.dump(default_config, f, indent=2)
-    with open(CONFIG_FILE) as f:
-        return json.load(f)
+    cfg = default_config.copy()
+    if os.path.exists(CONFIG_FILE):
+        with open(CONFIG_FILE) as f:
+            try:
+                user_cfg = json.load(f)
+            except Exception:
+                user_cfg = {}
+        cfg.update(user_cfg)
+    # Persist any new defaults such as newly added fields
+    with open(CONFIG_FILE, "w") as f:
+        json.dump(cfg, f, indent=2)
+    return cfg
 
 
 @app.route("/next-config")

--- a/tests/test_ai_agent.py
+++ b/tests/test_ai_agent.py
@@ -13,12 +13,19 @@ def start_controller(tmp_path, monkeypatch):
     server = make_server("127.0.0.1", 0, controller.app)
     thread = threading.Thread(target=server.serve_forever)
     thread.start()
-    return server, thread
+    return server, thread, controller
 
 
-def start_ollama_server():
+def start_ollama_server(prompts):
     class Handler(BaseHTTPRequestHandler):
         def do_POST(self):
+            length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(length)
+            try:
+                data = json.loads(body.decode())
+            except Exception:
+                data = {}
+            prompts.append(data.get("prompt"))
             self.send_response(200)
             self.send_header("Content-Type", "application/json")
             self.end_headers()
@@ -34,8 +41,15 @@ def start_ollama_server():
 
 
 def test_ai_agent_simulation(tmp_path, monkeypatch):
-    ctrl_server, ctrl_thread = start_controller(tmp_path, monkeypatch)
-    ollama_server, ollama_thread = start_ollama_server()
+    ctrl_server, ctrl_thread, controller = start_controller(tmp_path, monkeypatch)
+    prompts = []
+    ollama_server, ollama_thread = start_ollama_server(prompts)
+
+    # Create a config containing a custom prompt
+    prompt = "hello model"
+    cfg = controller.default_config.copy()
+    cfg["prompt"] = prompt
+    (tmp_path / "config.json").write_text(json.dumps(cfg))
 
     monkeypatch.setenv("DATA_DIR", str(tmp_path))
     ai_agent = importlib.import_module("ai_agent")
@@ -50,6 +64,7 @@ def test_ai_agent_simulation(tmp_path, monkeypatch):
     data = json.loads(log_path.read_text())
     assert data[0]["command"] == "echo hi"
     assert "hi" in data[0]["output"]
+    assert prompts[0] == prompt
 
     ctrl_server.shutdown()
     ollama_server.shutdown()

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -33,6 +33,15 @@ def test_dashboard_post(client):
     resp = client.post("/", data={}, follow_redirects=True)
     assert resp.status_code == 200
 
+
+def test_update_prompt(client):
+    cfg = client.get("/next-config").get_json()
+    cfg["prompt"] = "custom prompt"
+    resp = client.post("/", data=cfg, follow_redirects=True)
+    assert resp.status_code == 200
+    resp = client.get("/next-config")
+    assert resp.get_json()["prompt"] == "custom prompt"
+
 def test_stop(client):
     resp = client.post("/stop")
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- allow setting a `prompt` in the controller config and persist it to `config.json`
- have `ai_agent` use the configured prompt when requesting the model
- test that controller and agent propagate the prompt correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68908c8ad9d483268b6af41cfada9393