### PR TITLE
Add agent configuration loader and tests

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -1,0 +1,35 @@
+"""Agent factory utilities."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+
+from .base import Agent
+
+
+def load_agents(config_dir: str | Path = "config/agents") -> Dict[str, Agent]:
+    """Load all agent configurations from ``config_dir``.
+
+    Parameters
+    ----------
+    config_dir:
+        Directory containing one JSON file per agent configuration.
+
+    Returns
+    -------
+    dict[str, Agent]
+        Mapping of agent name to :class:`Agent` instances.
+    """
+
+    agents: Dict[str, Agent] = {}
+    path = Path(config_dir)
+    if not path.exists():
+        return agents
+    for cfg_file in sorted(path.glob("*.json")):
+        agent = Agent.from_file(cfg_file)
+        agents[agent.name] = agent
+    return agents
+
+
+__all__ = ["Agent", "load_agents"]

--- a/src/agents/base.py
+++ b/src/agents/base.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+"""Base definitions for agent configuration."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict
+import json
+
+
+@dataclass(slots=True)
+class Agent:
+    """Configuration for a single agent.
+
+    Parameters
+    ----------
+    name:
+        Name of the agent. Used as key in registries.
+    provider:
+        Identifier for the LLM provider (e.g. "openai", "ollama").
+    model:
+        Name of the model to use.
+    prompt_template:
+        Template string used to build prompts for the agent.
+    config_path:
+        Path to the JSON configuration file from which the agent was
+        instantiated. Stored for debugging and tracing purposes.
+    """
+
+    name: str
+    provider: str
+    model: str
+    prompt_template: str
+    config_path: str
+
+    @classmethod
+    def from_file(cls, path: str | Path) -> "Agent":
+        """Create an :class:`Agent` from a JSON configuration file.
+
+        Parameters
+        ----------
+        path:
+            Path to a JSON file containing the agent definition.
+
+        Returns
+        -------
+        Agent
+            The agent configuration loaded from the file.
+
+        Raises
+        ------
+        ValueError
+            If the JSON file is missing required fields.
+        """
+
+        path = Path(path)
+        with path.open("r", encoding="utf-8") as fh:
+            data: Dict[str, Any] = json.load(fh)
+
+        required = ["name", "provider", "model", "prompt_template"]
+        missing = [key for key in required if key not in data]
+        if missing:
+            raise ValueError(
+                f"Missing required fields {missing!r} in agent config {path!s}"
+            )
+
+        return cls(
+            name=data["name"],
+            provider=data["provider"],
+            model=data["model"],
+            prompt_template=data["prompt_template"],
+            config_path=str(path),
+        )

--- a/src/agents/tests/test_agent_base.py
+++ b/src/agents/tests/test_agent_base.py
@@ -1,0 +1,45 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from src.agents import Agent, load_agents
+
+
+def _write_config(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def test_load_agents(tmp_path: Path):
+    cfg_dir = tmp_path / "config/agents"
+    data = {
+        "name": "demo",
+        "provider": "openai",
+        "model": "gpt-3.5",
+        "prompt_template": "Hello {name}",
+    }
+    _write_config(cfg_dir / "demo.json", data)
+
+    agents = load_agents(cfg_dir)
+
+    assert "demo" in agents
+    agent = agents["demo"]
+    assert agent.name == "demo"
+    assert agent.provider == "openai"
+    assert agent.model == "gpt-3.5"
+    assert agent.prompt_template == "Hello {name}"
+    assert Path(agent.config_path).samefile(cfg_dir / "demo.json")
+
+
+def test_missing_required_fields(tmp_path: Path):
+    cfg_path = tmp_path / "missing.json"
+    # Missing 'provider' and 'model'
+    data = {
+        "name": "broken",
+        "prompt_template": "template",
+    }
+    _write_config(cfg_path, data)
+
+    with pytest.raises(ValueError):
+        Agent.from_file(cfg_path)


### PR DESCRIPTION
## Summary
- add Agent dataclass to represent agent configuration and load from JSON
- implement load_agents factory to gather all agent configurations
- test agent loading and validation logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689098faa8d08326b6259b90b5031313