### PR TITLE
feat: add model pool with concurrency limits

### DIFF
--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,0 +1,5 @@
+"""Model management utilities."""
+
+from .pool import ModelPool
+
+__all__ = ["ModelPool"]

--- a/src/models/pool.py
+++ b/src/models/pool.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+"""Concurrency control for model requests.
+
+The :class:`ModelPool` coordinates access to LLM models so that only a
+configured number of concurrent requests per (provider, model) pair are
+executed. Additional requests are queued in a thread- and asyncio-safe
+manner and resumed when a slot becomes free.
+"""
+
+from collections import deque
+from dataclasses import dataclass, field
+import asyncio
+import threading
+from typing import Deque, Dict, Tuple
+
+
+Key = Tuple[str, str]
+
+
+@dataclass
+class _QueueEntry:
+    """Bookkeeping for a single model."""
+
+    limit: int
+    in_use: int = 0
+    waiters: Deque[asyncio.Future] = field(default_factory=deque)
+
+
+class ModelPool:
+    """Simple pool limiting parallel LLM requests.
+
+    The pool keeps track of active requests per model and queues additional
+    callers. It is safe to use from multiple asyncio tasks or threads.
+    """
+
+    def __init__(self) -> None:
+        self._pools: Dict[Key, _QueueEntry] = {}
+        self._lock = threading.Lock()
+
+    def register(self, provider: str, model: str, limit: int = 1) -> None:
+        """Register a ``(provider, model)`` pair with an optional limit.
+
+        Parameters
+        ----------
+        provider, model:
+            Identifier for the LLM provider and the specific model.
+        limit:
+            Maximum number of concurrent requests allowed for the model.
+        """
+
+        key = (provider, model)
+        with self._lock:
+            if key not in self._pools:
+                self._pools[key] = _QueueEntry(limit=limit)
+
+    async def acquire(self, provider: str, model: str) -> None:
+        """Wait until a slot for ``(provider, model)`` becomes available."""
+
+        key = (provider, model)
+        while True:
+            with self._lock:
+                entry = self._pools.get(key)
+                if entry is None:
+                    # Auto-register unknown models with default limit 1
+                    entry = _QueueEntry(limit=1)
+                    self._pools[key] = entry
+                if entry.in_use < entry.limit:
+                    entry.in_use += 1
+                    return
+                fut = asyncio.get_running_loop().create_future()
+                entry.waiters.append(fut)
+            await fut
+            # A slot has been reserved for us; simply return.
+            return
+
+    def release(self, provider: str, model: str) -> None:
+        """Release a slot previously acquired."""
+
+        key = (provider, model)
+        with self._lock:
+            entry = self._pools.get(key)
+            if entry is None:
+                raise KeyError(f"Model {provider}/{model} not registered")
+            if entry.waiters:
+                fut = entry.waiters.popleft()
+                # Transfer slot directly to waiting task without
+                # adjusting ``in_use``.
+            else:
+                entry.in_use -= 1
+                return
+        # Wake the next waiter outside the lock to avoid deadlocks
+        fut.set_result(True)

--- a/tests/models/test_pool.py
+++ b/tests/models/test_pool.py
@@ -1,0 +1,45 @@
+import asyncio
+
+from src.models import ModelPool
+
+
+def test_parallel_acquire_is_serialized():
+    pool = ModelPool()
+    pool.register("openai", "gpt")
+    order: list[str] = []
+
+    async def worker(name: str, delay: float):
+        await pool.acquire("openai", "gpt")
+        order.append(f"start{name}")
+        await asyncio.sleep(delay)
+        order.append(f"end{name}")
+        pool.release("openai", "gpt")
+
+    async def main() -> None:
+        await asyncio.gather(worker("1", 0.05), worker("2", 0.05))
+
+    asyncio.run(main())
+    assert order == ["start1", "end1", "start2", "end2"]
+
+
+def test_release_unblocks_next_waiter():
+    pool = ModelPool()
+    pool.register("openai", "gpt")
+    started = []
+
+    async def first():
+        await pool.acquire("openai", "gpt")
+        started.append("first")
+        await asyncio.sleep(0.05)
+        pool.release("openai", "gpt")
+
+    async def second():
+        await pool.acquire("openai", "gpt")
+        started.append("second")
+        pool.release("openai", "gpt")
+
+    async def main() -> None:
+        await asyncio.gather(first(), second())
+
+    asyncio.run(main())
+    assert started == ["first", "second"]


### PR DESCRIPTION
## Summary
- add `ModelPool` to manage concurrent LLM requests using per-model queues
- expose new model utilities package
- test serialized access and proper release with parallel tasks

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68909a0a8ac4832688d8c404897524f0