### PR TITLE
Add controller agent with REST API and tests

### DIFF
--- a/src/controller/__init__.py
+++ b/src/controller/__init__.py
@@ -1,0 +1,31 @@
+"""Task controller package and compatibility layer for the legacy controller.
+
+The repository contains a ``controller.py`` module at the project root used
+by various tests. To avoid import conflicts, this package mirrors the
+public attributes of that module so ``import controller`` continues to work
+whether the legacy module or this package is picked up first on
+``sys.path``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import importlib.util
+from types import ModuleType
+
+from .agent import ControllerAgent
+
+__all__ = ["ControllerAgent"]
+
+# Expose symbols from the legacy controller.py if it exists
+# Path to the legacy module at repository root
+_root = Path(__file__).resolve().parents[2] / "controller.py"
+if _root.exists():
+    spec = importlib.util.spec_from_file_location("_legacy_controller", _root)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)  # type: ignore[attr-defined]
+    for name in dir(module):
+        if not name.startswith("_"):
+            globals()[name] = getattr(module, name)
+            __all__.append(name)

--- a/src/controller/agent.py
+++ b/src/controller/agent.py
@@ -1,0 +1,42 @@
+"""Controller agent managing tasks and blacklist."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional, Set
+
+try:  # pragma: no cover - import fallbacks
+    from ..agents.base import Agent
+except Exception:  # If imported as top-level ``controller`` package
+    from src.agents.base import Agent  # type: ignore
+
+
+@dataclass
+class ControllerAgent(Agent):
+    """Agent responsible for distributing tasks and tracking a blacklist."""
+
+    tasks: List[str] = field(default_factory=list)
+    blacklist: Set[str] = field(default_factory=set)
+    _log: List[str] = field(default_factory=list)
+
+    def assign_task(self) -> Optional[str]:
+        """Return the next non-blacklisted task and log the assignment."""
+
+        while self.tasks:
+            task = self.tasks.pop(0)
+            if task in self.blacklist:
+                continue
+            self._log.append(f"assigned:{task}")
+            return task
+        return None
+
+    def update_blacklist(self, entry: str) -> None:
+        """Add ``entry`` to the blacklist and log the update."""
+
+        self.blacklist.add(entry)
+        self._log.append(f"blacklisted:{entry}")
+
+    def log_status(self) -> List[str]:
+        """Return a copy of the internal log."""
+
+        return list(self._log)

--- a/src/controller/routes.py
+++ b/src/controller/routes.py
@@ -1,0 +1,45 @@
+"""HTTP routes exposing controller functionality."""
+
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, request
+
+from .agent import ControllerAgent
+
+controller_agent = ControllerAgent(
+    name="controller",
+    provider="internal",
+    model="none",
+    prompt_template="",
+    config_path="",
+)
+
+bp = Blueprint("controller", __name__, url_prefix="/controller")
+
+
+@bp.route("/next-task", methods=["GET"])
+def next_task() -> object:
+    """Return the next available task from the controller agent."""
+
+    task = controller_agent.assign_task()
+    return jsonify({"task": task})
+
+
+@bp.route("/blacklist", methods=["GET", "POST"])
+def blacklist() -> object:
+    """Get or update the blacklist."""
+
+    if request.method == "POST":
+        data = request.get_json(silent=True) or {}
+        entry = data.get("task")
+        if entry:
+            controller_agent.update_blacklist(entry)
+        return ("", 204)
+    return jsonify(sorted(controller_agent.blacklist))
+
+
+@bp.route("/status", methods=["GET"])
+def status() -> object:
+    """Return the controller agent log."""
+
+    return jsonify(controller_agent.log_status())

--- a/tests/controller/test_controller_agent.py
+++ b/tests/controller/test_controller_agent.py
@@ -1,0 +1,45 @@
+import os
+import sys
+
+from flask import Flask
+import pytest
+
+# Ensure repository root is at the beginning of sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from src.controller.routes import bp as controller_bp, controller_agent
+
+
+@pytest.fixture()
+def client():
+    app = Flask(__name__)
+    app.register_blueprint(controller_bp)
+    controller_agent.tasks = ["one", "two"]
+    controller_agent.blacklist.clear()
+    controller_agent._log.clear()
+    with app.test_client() as client:
+        yield client, controller_agent
+
+
+def test_assign_task(client):
+    client, agent = client
+    resp = client.get("/controller/next-task")
+    assert resp.status_code == 200
+    assert resp.get_json() == {"task": "one"}
+    resp = client.get("/controller/next-task")
+    assert resp.get_json() == {"task": "two"}
+    resp = client.get("/controller/next-task")
+    assert resp.get_json() == {"task": None}
+
+
+def test_blacklist(client):
+    client, agent = client
+    # Reset tasks
+    agent.tasks = ["one", "two"]
+    resp = client.post("/controller/blacklist", json={"task": "one"})
+    assert resp.status_code == 204
+    resp = client.get("/controller/next-task")
+    assert resp.get_json() == {"task": "two"}
+    resp = client.get("/controller/blacklist")
+    assert resp.get_json() == ["one"]
+    assert agent.log_status() == ["blacklisted:one", "assigned:two"]


### PR DESCRIPTION
## Summary
- add `ControllerAgent` for task assignment, blacklisting, and logging
- expose controller REST endpoints `/controller/next-task`, `/controller/blacklist`, and `/controller/status`
- verify task distribution and blacklist handling with Flask tests

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68909b5bc2ac8326954d92e3f4498db1