### PR TITLE
feat: support multiple agents in controller

### DIFF
--- a/tests/test_ai_agent.py
+++ b/tests/test_ai_agent.py
@@ -47,9 +47,10 @@ def run_agent_for_provider(tmp_path, monkeypatch, provider):
     lmstudio_server, lmstudio_thread = start_model_server(prompts_lmstudio)
 
     prompt = "hello model"
-    cfg = controller.default_config.copy()
-    cfg["prompt"] = prompt
-    cfg["provider"] = provider
+    cfg = json.loads(json.dumps(controller.default_config))
+    agent = cfg["active_agent"]
+    cfg["agents"][agent]["prompt"] = prompt
+    cfg["agents"][agent]["provider"] = provider
     (tmp_path / "config.json").write_text(json.dumps(cfg))
 
     monkeypatch.setenv("DATA_DIR", str(tmp_path))
@@ -68,7 +69,7 @@ def run_agent_for_provider(tmp_path, monkeypatch, provider):
         step_delay=0,
     )
 
-    log_path = tmp_path / "ai_log.json"
+    log_path = tmp_path / f"ai_log_{agent}.json"
     data = json.loads(log_path.read_text())
 
     ctrl_server.shutdown()

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -37,6 +37,7 @@ def test_dashboard_post(client):
 def test_update_prompt(client):
     cfg = client.get("/next-config").get_json()
     cfg["prompt"] = "custom prompt"
+    cfg["tasks"] = "\n".join(cfg.get("tasks", []))
     resp = client.post("/", data=cfg, follow_redirects=True)
     assert resp.status_code == 200
     resp = client.get("/next-config")


### PR DESCRIPTION
## Summary
- add multi-agent configuration, tasks, and log management to controller
- handle active agent logging in ai_agent
- adjust tests for new multi-agent features

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890bcad761483268cd4b65f4e677fa2