### PR TITLE
Add template and endpoint management

### DIFF
--- a/src/agents/templates.py
+++ b/src/agents/templates.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+"""Simple prompt template management."""
+
+from dataclasses import dataclass, field
+from typing import Dict
+
+
+@dataclass
+class PromptTemplates:
+    """Manage named prompt templates.
+
+    The class stores a mapping of template names to template strings and
+    provides a :meth:`render` method which formats a template with provided
+    keyword arguments.
+    """
+
+    templates: Dict[str, str] = field(default_factory=dict)
+
+    def add(self, name: str, template: str) -> None:
+        """Register or update a template."""
+        self.templates[name] = template
+
+    def render(self, template_name: str, **kwargs: str) -> str:
+        """Render a template by ``template_name`` with ``kwargs``.
+
+        Missing template names return an empty string.
+        """
+        text = self.templates.get(template_name, "")
+        try:
+            return text.format(**kwargs)
+        except Exception:
+            # In case of formatting errors, return the template verbatim
+            return text

--- a/tests/agents/test_templates.py
+++ b/tests/agents/test_templates.py
@@ -1,0 +1,9 @@
+from src.agents.templates import PromptTemplates
+
+
+def test_render_and_add():
+    mgr = PromptTemplates()
+    mgr.add("hello", "Hi {name}")
+    assert mgr.render("hello", name="Bob") == "Hi Bob"
+    # Unknown templates yield empty string
+    assert mgr.render("missing", name="Bob") == ""

--- a/tests/test_ai_agent.py
+++ b/tests/test_ai_agent.py
@@ -53,8 +53,14 @@ def run_agent_for_provider(tmp_path, monkeypatch, provider):
     prompt = "hello model"
     cfg = json.loads(json.dumps(controller.default_config))
     agent = cfg["active_agent"]
-    cfg["agents"][agent]["prompt"] = prompt
     cfg["agents"][agent]["provider"] = provider
+    cfg["agents"][agent]["template"] = "default"
+    cfg["agents"][agent]["tasks"] = [prompt]
+    cfg["prompt_templates"]["default"] = "{task}"
+    if provider == "ollama":
+        cfg["api_endpoints"]["ollama"] = f"http://127.0.0.1:{ollama_server.server_port}"
+    else:
+        cfg["api_endpoints"]["lmstudio"] = f"http://127.0.0.1:{lmstudio_server.server_port}"
     (tmp_path / "config.json").write_text(json.dumps(cfg))
 
     monkeypatch.setenv("DATA_DIR", str(tmp_path))
@@ -62,13 +68,9 @@ def run_agent_for_provider(tmp_path, monkeypatch, provider):
     importlib.reload(ai_agent)
 
     ctrl_url = f"http://127.0.0.1:{ctrl_server.server_port}"
-    ollama_url = f"http://127.0.0.1:{ollama_server.server_port}"
-    lmstudio_url = f"http://127.0.0.1:{lmstudio_server.server_port}"
 
     ai_agent.run_agent(
         controller=ctrl_url,
-        ollama=ollama_url,
-        lmstudio=lmstudio_url,
         steps=1,
         step_delay=0,
     )

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -36,9 +36,12 @@ def test_dashboard_post(client):
 
 def test_update_prompt(client):
     cfg = client.get("/next-config").get_json()
-    cfg["prompt"] = "custom prompt"
-    cfg["tasks"] = "\n".join(cfg.get("tasks", []))
-    resp = client.post("/", data=cfg, follow_redirects=True)
+    data = {
+        "agent": cfg["agent"],
+        "prompt": "custom prompt",
+        "tasks": "",
+    }
+    resp = client.post("/", data=data, follow_redirects=True)
     assert resp.status_code == 200
     resp = client.get("/next-config")
     assert resp.get_json()["prompt"] == "custom prompt"


### PR DESCRIPTION
## Summary
- introduce `PromptTemplates` for reusable prompt management
- allow controller to edit API endpoints and prompt templates via the dashboard
- update agent loop to use configurable endpoints, templates and ModelPool coordination

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890cb0bf0e083269f50bca9f7613637