### PR TITLE
feat: add configurable API endpoints and template selection

### DIFF
--- a/tests/test_ai_agent.py
+++ b/tests/test_ai_agent.py
@@ -58,9 +58,13 @@ def run_agent_for_provider(tmp_path, monkeypatch, provider):
     cfg["agents"][agent]["tasks"] = [prompt]
     cfg["prompt_templates"]["default"] = "{task}"
     if provider == "ollama":
-        cfg["api_endpoints"]["ollama"] = f"http://127.0.0.1:{ollama_server.server_port}"
+        cfg["api_endpoints"] = [
+            {"type": "ollama", "url": f"http://127.0.0.1:{ollama_server.server_port}"}
+        ]
     else:
-        cfg["api_endpoints"]["lmstudio"] = f"http://127.0.0.1:{lmstudio_server.server_port}"
+        cfg["api_endpoints"] = [
+            {"type": "lmstudio", "url": f"http://127.0.0.1:{lmstudio_server.server_port}"}
+        ]
     (tmp_path / "config.json").write_text(json.dumps(cfg))
 
     monkeypatch.setenv("DATA_DIR", str(tmp_path))

--- a/tests/test_default_config.py
+++ b/tests/test_default_config.py
@@ -1,0 +1,10 @@
+import controller
+
+
+def test_default_api_endpoints():
+    endpoints = controller.default_config["api_endpoints"]
+    lmstudio = [ep for ep in endpoints if ep["type"] == "lmstudio"]
+    assert len(lmstudio) == 1
+    ollama = [ep for ep in endpoints if ep["type"] == "ollama"]
+    assert any(ep["url"].startswith("http://192.168.178.88:11434") for ep in ollama)
+


### PR DESCRIPTION
## Summary
- allow selecting prompt templates per agent via dropdown
- manage API endpoints as typed list with add/remove controls
- include network ollama endpoint and single LMStudio endpoint by default

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890ceac8ba483269b1cbf940e365692