### PR TITLE
Expose agent details and pipeline order in dashboard

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -72,6 +72,7 @@ def load_team_config(path: str) -> dict:
         if not role:
             continue
         cfg = default_agent_config.copy()
+        cfg["role"] = role
         model_info = agent.get("model", {})
         if isinstance(model_info, dict):
             cfg["model"] = model_info.get("name", cfg.get("model"))
@@ -276,6 +277,7 @@ def dashboard():
         log=log,
         providers=PROVIDERS,
         boolean_fields=BOOLEAN_FIELDS,
+        pipeline_order=cfg.get("pipeline_order", []),
     )
 
 
@@ -323,13 +325,22 @@ TEMPLATE = """<!doctype html><html><head><title>Agent Controller</title>
 <div class="agent-grid">
 {% for name, cfg in config['agents'].items() %}
   <div class="agent-card {% if name == active %}active{% endif %}">
-    <div><strong>{{ name }}</strong></div>
+    <div><strong>Rolle: {{ cfg.get('role', name) }}</strong></div>
     <div>{{ cfg['model'] }} via {{ cfg['provider'] }}</div>
+    {% if cfg.get('purpose') %}<div>Zweck: {{ cfg['purpose'] }}</div>{% endif %}
+    {% if cfg.get('preferred_hardware') %}<div>Bevorzugte Hardware: {{ cfg['preferred_hardware'] }}</div>{% endif %}
     <form method="post"><input type="hidden" name="set_active" value="{{ name }}"/><button>Aktivieren</button></form>
   </div>
 {% endfor %}
 </div>
 <form method="post"><input name="new_agent" placeholder="Neuer Agent"/><button>Agent hinzufügen</button></form>
+
+<h2>🔀 Pipeline Order</h2>
+<ol>
+{% for agent in pipeline_order %}
+  <li>{{ agent }}</li>
+{% endfor %}
+</ol>
 
 <h2>📋 Tasks</h2>
 <ul>

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -28,6 +28,12 @@ def test_approve(client):
 def test_dashboard_get(client):
     resp = client.get("/")
     assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert "Rolle: Architect" in html
+    assert "Zweck:" in html
+    assert "Bevorzugte Hardware: CPU" in html
+    assert "🔀 Pipeline Order" in html
+    assert "<li>Architect</li>" in html
 
 def test_dashboard_post(client):
     resp = client.post("/", data={}, follow_redirects=True)


### PR DESCRIPTION
## Summary
- Show each agent's role, purpose, and preferred hardware in the Agents section
- Display team pipeline order as an ordered list in the dashboard
- Parse role from team config and expose pipeline order to the template

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890e39513a48326ad04a109e0eace31