### PR TITLE
Add GitHub issues endpoint and dashboard link

### DIFF
--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -34,6 +34,7 @@ def test_dashboard_get(client):
     assert "Bevorzugte Hardware: CPU" in html
     assert "🔀 Pipeline Order" in html
     assert "<li>Architect</li>" in html
+    assert "GitHub Issues" in html
 
 def test_dashboard_post(client):
     resp = client.post("/", data={}, follow_redirects=True)
@@ -78,3 +79,12 @@ def test_restart(client):
 def test_export(client):
     resp = client.get("/export")
     assert resp.status_code == 200
+
+
+def test_issues_route(client, monkeypatch):
+    view_globals = client.application.view_functions["issues"].__globals__
+    sample = [{"number": 1, "title": "Test", "html_url": "http://example.com"}]
+    monkeypatch.setitem(view_globals, "fetch_issues", lambda repo, token: sample)
+    resp = client.get("/issues?repo=foo/bar")
+    assert resp.status_code == 200
+    assert resp.get_json() == sample

--- a/themes/default.html
+++ b/themes/default.html
@@ -64,6 +64,7 @@
 <body>
   <header>
     <h1>Agent Controller Dashboard</h1>
+    <p><a href="/issues{% if github_repo %}?repo={{ github_repo }}{% endif %}" style="color:white;">GitHub Issues</a></p>
   </header>
   <div class="container">
     <section>


### PR DESCRIPTION
## Summary
- add `fetch_issues` helper to retrieve open issues from GitHub
- expose `/issues` route with optional task enqueueing and link from dashboard
- test the new functionality

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890f4175d988326987a007259a2f013