### PR TITLE
docs: improve project documentation

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,13 @@
+# Frontend
+
+Das Verzeichnis enthält ein kleines Vue-3-Dashboard.
+
+## Befehle
+
+```bash
+npm run dev    # Entwicklungsserver starten
+npm run build  # Produktions-Bundle erstellen
+```
+
+Die gebauten Dateien werden vom Flask-Controller unter `/ui` ausgeliefert.
+

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,18 @@
+# Backend-Quellcode
+
+## Agents
+- `agents/base.py` – `Agent`-Dataclass und `from_file()` zum Einlesen von JSON-Konfigurationen.
+- `agents/__init__.py` – `load_agents()` lädt mehrere Agenten-Configs aus einem Verzeichnis.
+- `agents/templates.py` – `PromptTemplates`-Registry zum Verwalten und Rendern von Prompt-Vorlagen.
+
+## Controller
+- `controller/agent.py` – `ControllerAgent` erweitert `Agent` um Aufgabenverteilung, Blacklist-Verwaltung und Logging.
+- `controller/routes.py` – Zusätzliche HTTP-Routen mit Blueprint unter `/controller`.
+
+## Models
+- `models/pool.py` – `ModelPool` mit `register`, `acquire` und `release` zur Limitierung paralleler LLM-Anfragen.
+
+## Skripte
+- `../ai_agent.py` – Hauptschleife des AI-Agents.
+- `../controller.py` – Flask-Server und Konfigurationsverwaltung.
+


### PR DESCRIPTION
## Summary
- reorganize top-level README with component overview, endpoint tables and extensibility notes
- add backend (src) and frontend READMEs for targeted guidance

## Testing
- `PYTHONPATH=. pytest`
- `cd frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689108945bc0832683827a8dacc70dfd