### PR TITLE
Activate controller blueprints and model pool limits

### DIFF
--- a/agent/ai_agent.py
+++ b/agent/ai_agent.py
@@ -115,6 +115,14 @@ def run_agent(
             step = 0
         model = cfg.get("model", "")
         provider = cfg.get("provider", "ollama")
+        # Allow optional limit per provider/model from configuration
+        limit = (
+            cfg.get("model_limit")
+            or cfg.get("limit")
+            or cfg.get("concurrency_limit")
+            or 1
+        )
+        pool.register(provider, model, limit)
         max_len = cfg.get("max_summary_length", 300)
 
         # Build prompt from template or explicit prompt

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,7 @@
+"""Ensure project root is importable for tests."""
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/controller/controller.py
+++ b/controller/controller.py
@@ -15,6 +15,14 @@ from datetime import datetime
 
 app = Flask(__name__)
 
+# Register additional controller blueprint routes
+try:
+    from src.controller.routes import bp as controller_bp
+except Exception:  # pragma: no cover - fallback when packaged differently
+    from controller.routes import bp as controller_bp  # type: ignore
+
+app.register_blueprint(controller_bp)
+
 # Daten- und Konfigurationsdateien
 DATA_DIR = os.environ.get("DATA_DIR", "/data")
 CONFIG_FILE = os.path.join(DATA_DIR, "config.json")
@@ -23,8 +31,7 @@ BLACKLIST_FILE = os.path.join(DATA_DIR, "blacklist.txt")
 
 # Optional Vue frontend distribution directory
 FRONTEND_DIST = os.path.join(os.path.dirname(__file__), "frontend", "dist")
-sys.path.append(os.path.join(os.path.dirname(__file__), "src"))
-from dashboard import DashboardManager, FileConfig
+from src.dashboard import DashboardManager, FileConfig
 
 
 def agent_log_file(agent: str) -> str:

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""Top-level package for project modules used in tests."""


### PR DESCRIPTION
## Summary
- register `/controller` blueprint with Flask app and cleanly import dashboard module
- allow agents to register provider/model concurrency limits via ModelPool
- add test harness files so `src` package can be imported in tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689118d305e88326b3ecf7e76fa0d5c3