### PR TITLE
feat: expand dashboard for pipeline templates and tasks

### DIFF
--- a/controller/controller.py
+++ b/controller/controller.py
@@ -227,6 +227,8 @@ def next_config():
     agent_cfg["api_endpoints"] = cfg.get("api_endpoints", [])
     agent_cfg["prompt_templates"] = cfg.get("prompt_templates", {})
     agent_cfg["tasks"] = [task_entry["task"]] if task_entry else agent_cfg.get("tasks", [])
+    if task_entry and task_entry.get("template"):
+        agent_cfg["template"] = task_entry.get("template")
     return jsonify(agent_cfg)
 
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,6 +1,18 @@
 <template>
   <div class="container">
     <h1>Agent Controller Dashboard</h1>
+
+    <section>
+      <h2>Pipeline</h2>
+      <ul v-if="config">
+        <li v-for="(name, idx) in config.pipeline_order" :key="name">
+          {{ name }}
+          <button @click="moveAgent(name, 'up')" :disabled="idx === 0">↑</button>
+          <button @click="moveAgent(name, 'down')" :disabled="idx === config.pipeline_order.length - 1">↓</button>
+        </li>
+      </ul>
+    </section>
+
     <section>
       <h2>Agents</h2>
       <div v-if="config">
@@ -15,6 +27,60 @@
         </div>
       </div>
     </section>
+
+    <section>
+      <h2>Templates</h2>
+      <div v-for="(text, name) in templates" :key="name" class="template">
+        <label>{{ name }}</label>
+        <textarea v-model="templates[name]"></textarea>
+        <button @click="deleteTemplate(name)">Delete</button>
+      </div>
+      <div class="template-form">
+        <input v-model="newTemplate.name" placeholder="name" />
+        <textarea v-model="newTemplate.text" placeholder="template"></textarea>
+        <button @click="addTemplate">Add</button>
+      </div>
+      <button @click="saveTemplates">Save Templates</button>
+    </section>
+
+    <section>
+      <h2>Tasks</h2>
+      <div v-if="config">
+        <div v-for="(t, idx) in config.tasks" :key="idx" class="task">
+          <div v-if="editingIndex !== idx">
+            <span>
+              {{ t.task }} ({{ t.agent || 'auto' }}<span v-if="t.template">, template: {{ t.template }}</span>)
+            </span>
+            <button @click="startTask(idx)">Start</button>
+            <button @click="taskAction(idx, 'move_up')" :disabled="idx===0">↑</button>
+            <button @click="taskAction(idx, 'move_down')" :disabled="idx===config.tasks.length-1">↓</button>
+            <button @click="taskAction(idx, 'skip')">Skip</button>
+            <button @click="editTask(idx)">Edit</button>
+          </div>
+          <div v-else>
+            <input v-model="taskText" placeholder="Task" />
+            <input v-model="taskAgent" placeholder="Agent (optional)" />
+            <input v-model="taskTemplate" placeholder="Template (optional)" />
+            <button @click="saveTask(idx)">Save</button>
+            <button @click="cancelEdit">Cancel</button>
+          </div>
+        </div>
+        <div class="task-form">
+          <h3>Add Task</h3>
+          <input v-model="taskText" placeholder="Task" />
+          <input v-model="taskAgent" placeholder="Agent (optional)" />
+          <input v-model="taskTemplate" placeholder="Template (optional)" />
+          <button @click="addTask">Add</button>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Logs</h2>
+      <button @click="loadControllerLog">Load Controller Log</button>
+      <pre v-if="controllerLog">{{ controllerLog }}</pre>
+    </section>
+
     <section>
       <h2>Control</h2>
       <button @click="stop">Stop</button>
@@ -29,11 +95,20 @@ import { ref, onMounted } from 'vue';
 
 const base = '';
 const config = ref(null);
+const templates = ref({});
 const logs = ref({});
+const controllerLog = ref('');
+const newTemplate = ref({ name: '', text: '' });
+const taskText = ref('');
+const taskAgent = ref('');
+const taskTemplate = ref('');
+const editingIndex = ref(-1);
 
 async function loadConfig() {
   const res = await fetch(base + '/config');
-  config.value = await res.json();
+  const data = await res.json();
+  config.value = data;
+  templates.value = JSON.parse(JSON.stringify(data.prompt_templates || {}));
 }
 
 async function toggle(name) {
@@ -57,6 +132,90 @@ async function restart() {
   await fetch(base + '/restart', { method: 'POST' });
 }
 
+async function moveAgent(name, direction) {
+  const form = new FormData();
+  form.append('move_agent', name);
+  form.append('direction', direction);
+  await fetch(base + '/', { method: 'POST', body: form });
+  await loadConfig();
+}
+
+function addTemplate() {
+  if (newTemplate.value.name) {
+    templates.value[newTemplate.value.name] = newTemplate.value.text;
+    newTemplate.value = { name: '', text: '' };
+  }
+}
+
+function deleteTemplate(name) {
+  delete templates.value[name];
+}
+
+async function saveTemplates() {
+  const form = new FormData();
+  form.append('prompt_templates', JSON.stringify(templates.value));
+  await fetch(base + '/', { method: 'POST', body: form });
+  await loadConfig();
+}
+
+function editTask(idx) {
+  editingIndex.value = idx;
+  const t = config.value.tasks[idx];
+  taskText.value = t.task;
+  taskAgent.value = t.agent || '';
+  taskTemplate.value = t.template || '';
+}
+
+function cancelEdit() {
+  editingIndex.value = -1;
+  taskText.value = '';
+  taskAgent.value = '';
+  taskTemplate.value = '';
+}
+
+async function saveTask(idx) {
+  const form = new FormData();
+  form.append('task_action', 'update');
+  form.append('task_idx', idx);
+  form.append('task_text', taskText.value);
+  form.append('task_agent', taskAgent.value);
+  form.append('task_template', taskTemplate.value);
+  await fetch(base + '/', { method: 'POST', body: form });
+  await loadConfig();
+  cancelEdit();
+}
+
+async function addTask() {
+  const form = new FormData();
+  form.append('add_task', '1');
+  form.append('task_text', taskText.value);
+  form.append('task_agent', taskAgent.value);
+  form.append('task_template', taskTemplate.value);
+  await fetch(base + '/', { method: 'POST', body: form });
+  await loadConfig();
+  taskText.value = '';
+  taskAgent.value = '';
+  taskTemplate.value = '';
+}
+
+async function taskAction(idx, action) {
+  const form = new FormData();
+  form.append('task_action', action);
+  form.append('task_idx', idx);
+  await fetch(base + '/', { method: 'POST', body: form });
+  await loadConfig();
+}
+
+async function startTask(idx) {
+  await taskAction(idx, 'start');
+}
+
+async function loadControllerLog() {
+  const res = await fetch(base + '/controller/status');
+  const data = await res.json();
+  controllerLog.value = Array.isArray(data) ? data.join('\n') : JSON.stringify(data);
+}
+
 onMounted(loadConfig);
 </script>
 
@@ -65,9 +224,16 @@ onMounted(loadConfig);
   font-family: Arial, sans-serif;
   margin: 20px;
 }
-.agent {
+.agent,
+.task,
+.template {
   border: 1px solid #ddd;
   padding: 10px;
   margin-bottom: 10px;
 }
+textarea {
+  width: 100%;
+  min-height: 60px;
+}
 </style>
+

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -83,11 +83,26 @@ class DashboardManager:
                     tasks.insert(0, task)
                 elif task_action == "skip":
                     tasks.pop(idx)
+                elif task_action == "update":
+                    text = req.form.get("task_text", "").strip()
+                    agent_field = req.form.get("task_agent", "").strip() or None
+                    template_field = req.form.get("task_template", "").strip() or None
+                    if text:
+                        tasks[idx] = {
+                            "task": text,
+                            "agent": agent_field,
+                            "template": template_field,
+                        }
         elif req.form.get("add_task"):
             text = req.form.get("task_text", "").strip()
             agent_field = req.form.get("task_agent", "").strip() or None
+            template_field = req.form.get("task_template", "").strip() or None
             if text:
-                tasks.append({"task": text, "agent": agent_field})
+                tasks.append({
+                    "task": text,
+                    "agent": agent_field,
+                    "template": template_field,
+                })
 
     def _handle_new_agent(self, cfg: Dict[str, Any], req: Request) -> None:
         new_agent = req.form.get("new_agent", "").strip()


### PR DESCRIPTION
## Summary
- enhance dashboard to manage agent pipeline order
- allow creating and editing prompt templates and tasks with optional template assignment
- expose per-task templates to agents from controller

## Testing
- `npm run build --prefix frontend`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891b4c187e48326a2ae7ec747f0c1ea