### PR TITLE
docs: detail architecture and APIs

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -1,5 +1,23 @@
 # AI-Agent
 
-Dieses Verzeichnis enthält den Python-basierten AI-Agenten.
-Das Skript [`ai_agent.py`](ai_agent.py) pollt den Controller,
-verarbeitet Aufgaben und führt bestätigte Kommandos aus.
+Dieses Verzeichnis enthält den Python-basierten Agenten, der periodisch den Controller abfragt und Aufgaben ausführt.
+
+## Architektur
+
+- `ai_agent.py` implementiert Hilfsfunktionen (`_http_get`, `_http_post`) mit Retry.
+- `run_agent()` bildet die Hauptschleife:
+  - fragt den Controller über `GET /next-config` nach Konfiguration und Aufgaben,
+  - erzeugt über `PromptTemplates` Prompts für den gewünschten LLM,
+  - nutzt `ModelPool`, um parallele Anfragen pro Provider zu begrenzen,
+  - protokolliert Ausgaben in `ai_log_<agent>.json` und Zusammenfassungen in `summary_<agent>.txt` im Datenverzeichnis,
+  - stoppt sauber, sobald eine `stop.flag`-Datei existiert.
+
+## API-Endpunkte
+
+Der Agent selbst stellt keine eigenen HTTP-Routen bereit, sondern konsumiert folgende Schnittstellen des Controllers bzw. der LLM-Provider:
+
+| Endpoint | Methode | Zweck |
+|---------|--------|-------|
+| `/next-config` | GET | Nächste Agenten-Konfiguration inkl. Aufgaben und Templates abrufen. |
+| `/approve` | POST | Genehmigte Shell-Kommandos und Zusammenfassungen an den Controller melden. |
+| `<LLM-URL>` | POST | Aufruf des konfigurierten LLM-Providers (z. B. Ollama, LM Studio, OpenAI). |

--- a/controller/README.md
+++ b/controller/README.md
@@ -1,5 +1,38 @@
 # Controller
 
 Dieses Verzeichnis bündelt den Flask-basierten Controller.
-Das Skript [`controller.py`](controller.py) verwaltet Konfiguration,
-HTTP-Endpunkte und Log-Export.
+
+## Architektur
+
+- `controller.py` startet einen Flask-Server, lädt `config.json` aus dem Datenverzeichnis und registriert das Blueprint `src/controller/routes.py`.
+- Der Controller verwaltet Aufgaben, Agenten, Blacklist und bietet Log- sowie Exportfunktionen.
+- `DashboardManager` rendert das HTML-Dashboard; ein gebautes Vue-Frontend wird aus `/ui` ausgeliefert.
+- Standardpfade für Daten (`config.json`, `control_log.json`, `blacklist.txt`) können über die Umgebungsvariable `DATA_DIR` angepasst werden.
+
+## API-Endpunkte
+
+### Kernrouten (`controller/controller.py`)
+
+| Endpoint | Methode | Beschreibung |
+|----------|--------|--------------|
+| `/next-config` | GET | Liefert die aktive Agentenkonfiguration samt Aufgaben. |
+| `/config` | GET | Gibt die komplette Controller-Konfiguration zurück. |
+| `/approve` | POST | Übermittelt freigegebene Befehle; Blacklist wird geprüft. |
+| `/issues` | GET | Holt GitHub-Issues und reiht sie optional als Aufgaben ein. |
+| `/set_theme` | POST | Speichert das gewählte Dashboard-Theme im Cookie. |
+| `/` | GET/POST | HTML-Dashboard; POST verarbeitet Formaktionen wie Pipeline- oder Task-Updates. |
+| `/agent/<name>/toggle_active` | POST | Schaltet den `controller_active`-Status eines Agents um. |
+| `/agent/<name>/log` | GET | Liefert die letzten Logeinträge eines Agents. |
+| `/stop` | POST | Legt `stop.flag` an und stoppt laufende Agenten. |
+| `/restart` | POST | Entfernt `stop.flag` zum Neustart. |
+| `/export` | GET | Download von Logs und Konfigurationen als ZIP. |
+| `/ui` / `/ui/<pfad>` | GET | Serviert das gebaute Vue-Frontend. |
+| `/llm_status` | GET | Prüft konfigurierte LLM-Endpunkte per HEAD-Anfrage. |
+
+### Blueprint-Routen (`src/controller/routes.py`)
+
+| Endpoint | Methode | Beschreibung |
+|----------|--------|--------------|
+| `/controller/next-task` | GET | Nächste nicht geblockte Aufgabe des Controller-Agenten. |
+| `/controller/blacklist` | GET/POST | Listet oder ergänzt Einträge der Blacklist. |
+| `/controller/status` | GET | Gibt den internen Log-Status des Controller-Agenten zurück. |

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,6 +1,28 @@
 # Frontend
 
-Das Verzeichnis enthält ein kleines Vue-3-Dashboard.
+Das Verzeichnis enthält ein Vue-3-Dashboard zur Steuerung und Überwachung der Agenten.
+
+## Architektur
+
+- Vite-Projekt mit Einstiegspunkt `src/main.js`.
+- `App.vue` bietet eine Tab-Navigation und bindet die Komponenten `Pipeline.vue`, `Agents.vue`, `Tasks.vue` und `Templates.vue` ein.
+- Jede Komponente kommuniziert per `fetch` mit dem Flask-Controller.
+- Nach `npm run build` werden die Dateien in `dist/` erzeugt und vom Controller unter `/ui` ausgeliefert.
+
+## API-Endpunkte
+
+Das Dashboard nutzt folgende HTTP-Schnittstellen des Controllers:
+
+| Endpoint | Methode | Zweck |
+|----------|--------|------|
+| `/config` | GET | Aktuelle Konfiguration laden. |
+| `/` | POST | Formularaktionen für Pipeline, Tasks oder Templates auslösen. |
+| `/agent/<name>/toggle_active` | POST | Aktiv-Status eines Agents ändern. |
+| `/agent/<name>/log` | GET | Logdatei eines Agents abrufen. |
+| `/controller/status` | GET | Controller-Log abrufen. |
+| `/stop` | POST | Laufende Agenten stoppen. |
+| `/restart` | POST | `stop.flag` entfernen und Neustart veranlassen. |
+| `/export` | GET | Logs und Konfigurationen als ZIP herunterladen. |
 
 ## Befehle
 
@@ -10,4 +32,3 @@ npm run build  # Produktions-Bundle erstellen
 ```
 
 Die gebauten Dateien werden vom Flask-Controller unter `/ui` ausgeliefert.
-


### PR DESCRIPTION
## Summary
- document AI agent architecture and controller/LLM endpoints it consumes
- expand Flask controller docs with architecture details and complete HTTP API overview
- describe Vue dashboard structure and the endpoints it uses

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891f5c6c80c8326ac9c51a45ded38f9