### PR TITLE
Add LLM access overview and management

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -27,6 +27,7 @@ Dieses Dokument fasst die Gesamtarchitektur des Ananta-Dashboards zusammen und l
 | `/stop`, `/restart` | POST | Legt `stop.flag` an bzw. entfernt ihn. |
 | `/export` | GET | Exportiert Logs und Konfigurationen als ZIP. |
 | `/ui`, `/ui/<pfad>` | GET | Serviert das gebaute Vue-Frontend. |
+| `/controller/models` | GET/POST | Übersicht und Registrierung von LLM-Modell-Limits. |
 
 ## Entwicklungsbefehle
 

--- a/src/README.md
+++ b/src/README.md
@@ -10,7 +10,7 @@
 - `controller/routes.py` – Zusätzliche HTTP-Routen mit Blueprint unter `/controller`.
 
 ## Models
-- `models/pool.py` – `ModelPool` mit `register`, `acquire` und `release` zur Limitierung paralleler LLM-Anfragen.
+- `models/pool.py` – `ModelPool` mit `register`, `acquire`, `release` und `status` zur Limitierung und Einsicht paralleler LLM-Anfragen.
 
 ## Skripte
 - `../agent/ai_agent.py` – Hauptschleife des AI-Agents.

--- a/tests/test_controller_routes.py
+++ b/tests/test_controller_routes.py
@@ -1,5 +1,6 @@
 from flask import Flask
 from src.controller import routes
+from src.models import ModelPool
 
 
 def setup_app():
@@ -8,6 +9,7 @@ def setup_app():
     routes.controller_agent.tasks = []
     routes.controller_agent.blacklist.clear()
     routes.controller_agent._log.clear()
+    routes.model_pool = ModelPool()
     return app
 
 
@@ -33,3 +35,16 @@ def test_next_task_and_blacklist():
     data = resp.get_json()
     assert "assigned:one" in data
     assert "blacklisted:two" in data
+
+
+def test_model_routes():
+    app = setup_app()
+    client = app.test_client()
+
+    resp = client.post(
+        "/controller/models", json={"provider": "p", "model": "m", "limit": 2}
+    )
+    assert resp.status_code == 204
+
+    resp = client.get("/controller/models")
+    assert resp.get_json() == {"p": {"m": {"limit": 2, "in_use": 0, "waiters": 0}}}

--- a/tests/test_model_pool.py
+++ b/tests/test_model_pool.py
@@ -1,0 +1,12 @@
+import asyncio
+
+from src.models import ModelPool
+
+
+def test_model_pool_status():
+    pool = ModelPool()
+    pool.register("prov", "mod", limit=2)
+    asyncio.run(pool.acquire("prov", "mod"))
+    status = pool.status()
+    assert status == {"prov": {"mod": {"limit": 2, "in_use": 1, "waiters": 0}}}
+    pool.release("prov", "mod")


### PR DESCRIPTION
## Summary
- add `ModelPool.status()` to inspect concurrency limits for LLM providers and models
- expose `/controller/models` endpoint to view and register model limits
- document model management API and expand tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891fe5444988326bc116c176d8345ff