### PR TITLE
feat(frontend): add endpoint management UI

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -16,9 +16,10 @@ import Pipeline from './components/Pipeline.vue';
 import Agents from './components/Agents.vue';
 import Tasks from './components/Tasks.vue';
 import Templates from './components/Templates.vue';
+import Endpoints from './components/Endpoints.vue';
 
-const tabs = ['Pipeline', 'Agents', 'Tasks', 'Templates'];
-const tabComponents = { Pipeline, Agents, Tasks, Templates };
+const tabs = ['Pipeline', 'Agents', 'Tasks', 'Templates', 'Endpoints'];
+const tabComponents = { Pipeline, Agents, Tasks, Templates, Endpoints };
 const currentTab = ref('Pipeline');
 </script>
 

--- a/frontend/src/components/Endpoints.vue
+++ b/frontend/src/components/Endpoints.vue
@@ -1,0 +1,96 @@
+<template>
+  <div>
+    <h2>API Endpoints</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Type</th>
+          <th>URL</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="(endpoint, index) in endpoints" :key="index">
+          <td>
+            <div v-if="editingIndex === index">
+              <input v-model="editableEndpoint.type" />
+            </div>
+            <div v-else>
+              {{ endpoint.type }}
+            </div>
+          </td>
+          <td>
+            <div v-if="editingIndex === index">
+              <input v-model="editableEndpoint.url" />
+            </div>
+            <div v-else>
+              {{ endpoint.url }}
+            </div>
+          </td>
+          <td>
+            <button v-if="editingIndex !== index" @click="startEditing(index, endpoint)">Edit</button>
+            <div v-else>
+              <button @click="saveEndpoint(index)">Save</button>
+              <button @click="cancelEditing">Cancel</button>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script setup>
+import { ref, reactive, onMounted } from 'vue';
+
+const endpoints = ref([]);
+const editingIndex = ref(null);
+const editableEndpoint = reactive({ type: '', url: '' });
+
+const fetchEndpoints = async () => {
+  try {
+    const response = await fetch('/config');
+    const config = await response.json();
+    endpoints.value = config.api_endpoints || [];
+  } catch (error) {
+    console.error('Failed to load endpoints:', error);
+  }
+};
+
+const startEditing = (index, endpoint) => {
+  editingIndex.value = index;
+  editableEndpoint.type = endpoint.type;
+  editableEndpoint.url = endpoint.url;
+};
+
+const cancelEditing = () => {
+  editingIndex.value = null;
+  editableEndpoint.type = '';
+  editableEndpoint.url = '';
+};
+
+const saveEndpoint = async (index) => {
+  endpoints.value[index] = { ...editableEndpoint };
+  // Placeholder for future backend update request
+  cancelEditing();
+};
+
+onMounted(fetchEndpoints);
+</script>
+
+<style scoped>
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+table, th, td {
+  border: 1px solid #ccc;
+}
+th, td {
+  padding: 8px;
+  text-align: left;
+}
+button {
+  margin-right: 5px;
+}
+</style>

--- a/frontend/tests/App.spec.js
+++ b/frontend/tests/App.spec.js
@@ -12,12 +12,15 @@ describe('App.vue', () => {
           Pipeline: stub('pipeline'),
           Agents: stub('agents'),
           Tasks: stub('tasks'),
-          Templates: stub('templates')
+          Templates: stub('templates'),
+          Endpoints: stub('endpoints')
         }
       }
     });
     expect(wrapper.find('.pipeline').exists()).toBe(true);
     await wrapper.findAll('button')[1].trigger('click');
     expect(wrapper.find('.agents').exists()).toBe(true);
+    await wrapper.findAll('button')[4].trigger('click');
+    expect(wrapper.find('.endpoints').exists()).toBe(true);
   });
 });

--- a/frontend/tests/Endpoints.spec.js
+++ b/frontend/tests/Endpoints.spec.js
@@ -1,0 +1,23 @@
+import { mount, flushPromises } from '@vue/test-utils';
+import { describe, it, expect, vi } from 'vitest';
+import Endpoints from '../src/components/Endpoints.vue';
+
+describe('Endpoints.vue', () => {
+  it('loads endpoints and enters edit mode', async () => {
+    const mockConfig = { api_endpoints: [{ type: 't1', url: 'u1' }] };
+    const fetchMock = vi.fn(() => Promise.resolve({ json: () => Promise.resolve(mockConfig) }));
+    const originalFetch = global.fetch;
+    global.fetch = fetchMock;
+
+    const wrapper = mount(Endpoints);
+    await flushPromises();
+
+    expect(fetchMock).toHaveBeenCalled();
+    expect(wrapper.text()).toContain('t1');
+
+    await wrapper.find('button').trigger('click');
+    expect(wrapper.find('input').exists()).toBe(true);
+
+    global.fetch = originalFetch;
+  });
+});


### PR DESCRIPTION
## Summary
- add `Endpoints` component to manage LLM API endpoints
- expose new `Endpoints` tab in dashboard
- cover endpoints UI with tests

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68920157385c832689e8ff8c7feb85a7