### PR TITLE
Enable managing LLM endpoints from UI and API

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Ananta ist ein modulares Multi-Agenten-System mit einem Flask-basierten Controll
 | -------- | ------- | ------------ |
 | `/next-config` | GET | Nächste Agenten-Konfiguration inkl. Aufgaben & Templates. |
 | `/config` | GET | Gesamte Controller-Konfiguration als JSON. |
+| `/config/api_endpoints` | POST | Aktualisiert die LLM-Endpunkte in `config.json`. |
 | `/approve` | POST | Validiert und führt Agenten-Vorschläge aus. |
 | `/issues` | GET | Holt GitHub-Issues und reiht Aufgaben ein. |
 | `/set_theme` | POST | Speichert Dashboard-Theme im Cookie. |

--- a/controller/controller.py
+++ b/controller/controller.py
@@ -251,6 +251,23 @@ def full_config():
     return jsonify(read_config())
 
 
+@app.route("/config/api_endpoints", methods=["POST"])
+def update_api_endpoints():
+    """Update API endpoints in the configuration."""
+    data = request.get_json(silent=True) or {}
+    endpoints = data.get("api_endpoints")
+    if not isinstance(endpoints, list):
+        return jsonify({"error": "api_endpoints must be a list"}), 400
+    cfg = read_config()
+    cfg["api_endpoints"] = [
+        {"type": ep.get("type", ""), "url": ep.get("url", "")}
+        for ep in endpoints
+        if ep.get("url")
+    ]
+    write_config(cfg)
+    return jsonify({"api_endpoints": cfg["api_endpoints"]})
+
+
 @app.route("/approve", methods=["POST"])
 def approve():
     cmd = request.form.get("cmd", "").strip()

--- a/frontend/tests/Endpoints.spec.js
+++ b/frontend/tests/Endpoints.spec.js
@@ -3,9 +3,14 @@ import { describe, it, expect, vi } from 'vitest';
 import Endpoints from '../src/components/Endpoints.vue';
 
 describe('Endpoints.vue', () => {
-  it('loads endpoints and enters edit mode', async () => {
+  it('can add and remove endpoints', async () => {
     const mockConfig = { api_endpoints: [{ type: 't1', url: 'u1' }] };
-    const fetchMock = vi.fn(() => Promise.resolve({ json: () => Promise.resolve(mockConfig) }));
+    const fetchMock = vi.fn((url, opts) => {
+      if (!opts) {
+        return Promise.resolve({ json: () => Promise.resolve(mockConfig) });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
     const originalFetch = global.fetch;
     global.fetch = fetchMock;
 
@@ -15,8 +20,17 @@ describe('Endpoints.vue', () => {
     expect(fetchMock).toHaveBeenCalled();
     expect(wrapper.text()).toContain('t1');
 
-    await wrapper.find('button').trigger('click');
-    expect(wrapper.find('input').exists()).toBe(true);
+    await wrapper.get('[data-test="new-type"]').setValue('t2');
+    await wrapper.get('[data-test="new-url"]').setValue('u2');
+    await wrapper.get('[data-test="add"]').trigger('click');
+    await flushPromises();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(wrapper.text()).toContain('t2');
+
+    await wrapper.findAll('[data-test="delete"]')[0].trigger('click');
+    await flushPromises();
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(wrapper.text()).not.toContain('t1');
 
     global.fetch = originalFetch;
   });

--- a/tests/test_update_api_endpoints.py
+++ b/tests/test_update_api_endpoints.py
@@ -1,0 +1,13 @@
+import json
+import controller.controller as cc
+
+def test_update_api_endpoints(tmp_path, monkeypatch):
+    cfg = tmp_path / "config.json"
+    cfg.write_text(json.dumps({"api_endpoints": []}))
+    monkeypatch.setattr(cc, "CONFIG_FILE", str(cfg))
+    cc.config_provider = cc.FileConfig(cc.read_config, cc.write_config)
+    with cc.app.test_client() as client:
+        resp = client.post('/config/api_endpoints', json={"api_endpoints": [{"type": "x", "url": "y"}]})
+        assert resp.status_code == 200
+        saved = json.loads(cfg.read_text())
+        assert saved["api_endpoints"] == [{"type": "x", "url": "y"}]


### PR DESCRIPTION
## Summary
- add `/config/api_endpoints` route to modify stored endpoints
- allow frontend users to add, delete, and persist LLM endpoints
- cover endpoint management with frontend and backend tests

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892036d92048326b1346411554ab97e