### PR TITLE
feat: allow specifying model lists

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,6 +2,7 @@
   "agents": {
     "default": {
       "model": "llama3",
+      "models": [],
       "provider": "ollama",
       "template": "default",
       "max_summary_length": 300,
@@ -180,19 +181,23 @@
   "api_endpoints": [
     {
       "type": "ollama",
-      "url": "http://localhost:11434/api/generate"
+      "url": "http://localhost:11434/api/generate",
+      "models": []
     },
     {
       "type": "ollama",
-      "url": "http://192.168.178.88:11434/api/generate"
+      "url": "http://192.168.178.88:11434/api/generate",
+      "models": []
     },
     {
       "type": "lmstudio",
-      "url": "http://localhost:1234/v1/completions"
+      "url": "http://localhost:1234/v1/completions",
+      "models": []
     },
     {
       "type": "openai",
-      "url": "https://api.openai.com/v1/chat/completions"
+      "url": "https://api.openai.com/v1/chat/completions",
+      "models": []
     }
   ],
   "tasks": [],

--- a/controller/controller.py
+++ b/controller/controller.py
@@ -48,6 +48,7 @@ def agent_summary_file(agent: str) -> str:
 
 default_agent_config = {
     "model": "llama3",
+    "models": [],
     "provider": "ollama",
     "template": "default",
     "max_summary_length": 300,
@@ -64,10 +65,10 @@ default_config = {
     "active_agent": "default",
     "prompt_templates": {"default": "{task}"},
     "api_endpoints": [
-        {"type": "ollama", "url": "http://localhost:11434/api/generate"},
-        {"type": "ollama", "url": "http://192.168.178.88:11434/api/generate"},
-        {"type": "lmstudio", "url": "http://localhost:1234/v1/completions"},
-        {"type": "openai", "url": "https://api.openai.com/v1/chat/completions"},
+        {"type": "ollama", "url": "http://localhost:11434/api/generate", "models": []},
+        {"type": "ollama", "url": "http://192.168.178.88:11434/api/generate", "models": []},
+        {"type": "lmstudio", "url": "http://localhost:1234/v1/completions", "models": []},
+        {"type": "openai", "url": "https://api.openai.com/v1/chat/completions", "models": []},
     ],
     "tasks": [],
     "pipeline_order": [],
@@ -260,7 +261,11 @@ def update_api_endpoints():
         return jsonify({"error": "api_endpoints must be a list"}), 400
     cfg = read_config()
     cfg["api_endpoints"] = [
-        {"type": ep.get("type", ""), "url": ep.get("url", "")}
+        {
+            "type": ep.get("type", ""),
+            "url": ep.get("url", ""),
+            "models": [m for m in ep.get("models", []) if m],
+        }
         for ep in endpoints
         if ep.get("url")
     ]

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -134,6 +134,8 @@ class DashboardManager:
                         agent_cfg[key] = int(val)
                     except Exception:
                         pass
+                elif isinstance(default, list):
+                    agent_cfg[key] = [m.strip() for m in val.split(",") if m.strip()]
                 elif isinstance(default, str):
                     agent_cfg[key] = val
 
@@ -145,12 +147,19 @@ class DashboardManager:
                     continue
                 typ = req.form.get(f"endpoint_type_{i}") or ep.get("type")
                 url = req.form.get(f"endpoint_url_{i}") or ep.get("url")
+                models_field = req.form.get(f"endpoint_models_{i}")
+                if models_field is None:
+                    models_list = ep.get("models", [])
+                else:
+                    models_list = [m.strip() for m in models_field.split(",") if m.strip()]
                 if typ and url:
-                    endpoints.append({"type": typ, "url": url})
+                    endpoints.append({"type": typ, "url": url, "models": models_list})
             new_type = req.form.get("new_endpoint_type")
             new_url = req.form.get("new_endpoint_url")
+            new_models_field = req.form.get("new_endpoint_models")
+            new_models = [m.strip() for m in (new_models_field or "").split(",") if m.strip()]
             if req.form.get("add_endpoint") and new_url:
-                endpoints.append({"type": new_type or self.providers[0], "url": new_url})
+                endpoints.append({"type": new_type or self.providers[0], "url": new_url, "models": new_models})
             cfg["api_endpoints"] = endpoints
 
     def _update_templates(self, cfg: Dict[str, Any], req: Request) -> None:

--- a/tests/test_dashboard_manager.py
+++ b/tests/test_dashboard_manager.py
@@ -22,6 +22,7 @@ def make_request(form: Dict[str, str]) -> Request:
 
 DEFAULT_AGENT = {
     "model": "m",
+    "models": [],
     "provider": "p",
     "template": "",
     "max_summary_length": 0,
@@ -49,12 +50,15 @@ def test_reorder_and_tasks():
 
 
 def test_handle_new_agent_and_endpoints():
-    cfg = {"agents": {}, "pipeline_order": [], "api_endpoints": [{"type": "ollama", "url": "old"}]}
+    cfg = {"agents": {}, "pipeline_order": [], "api_endpoints": [{"type": "ollama", "url": "old", "models": []}]}
     dm = DashboardManager(DummyConfig(cfg), DEFAULT_AGENT, ["ollama"])
 
     dm._handle_new_agent(cfg, make_request({"new_agent": "agent1"}))
     assert "agent1" in cfg["agents"]
     assert cfg["pipeline_order"] == ["agent1"]
 
-    dm._update_endpoints(cfg, make_request({"api_endpoints_form": "1", "endpoint_url_0": "new"}))
-    assert cfg["api_endpoints"][0]["url"] == "new"
+    dm._update_agent_config(cfg, make_request({"agent": "agent1", "models": "a,b"}))
+    assert cfg["agents"]["agent1"]["models"] == ["a", "b"]
+
+    dm._update_endpoints(cfg, make_request({"api_endpoints_form": "1", "endpoint_url_0": "new", "endpoint_models_0": "x"}))
+    assert cfg["api_endpoints"][0] == {"type": "ollama", "url": "new", "models": ["x"]}

--- a/tests/test_update_api_endpoints.py
+++ b/tests/test_update_api_endpoints.py
@@ -7,7 +7,7 @@ def test_update_api_endpoints(tmp_path, monkeypatch):
     monkeypatch.setattr(cc, "CONFIG_FILE", str(cfg))
     cc.config_provider = cc.FileConfig(cc.read_config, cc.write_config)
     with cc.app.test_client() as client:
-        resp = client.post('/config/api_endpoints', json={"api_endpoints": [{"type": "x", "url": "y"}]})
+        resp = client.post('/config/api_endpoints', json={"api_endpoints": [{"type": "x", "url": "y", "models": ["m1", "m2"]}]})
         assert resp.status_code == 200
         saved = json.loads(cfg.read_text())
-        assert saved["api_endpoints"] == [{"type": "x", "url": "y"}]
+        assert saved["api_endpoints"] == [{"type": "x", "url": "y", "models": ["m1", "m2"]}]


### PR DESCRIPTION
## Summary
- allow agents and API endpoints to include a list of supported models
- persist endpoint model data via `/config/api_endpoints`
- update dashboard manager and config examples for new model lists

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68921531302c8326a84b2397d88af7b8