### PR TITLE
feat: add model management UI

### DIFF
--- a/config.json
+++ b/config.json
@@ -207,6 +207,7 @@
       "models": []
     }
   ],
+  "models": [],
   "tasks": [],
   "pipeline_order": [
     "Backend Developer",

--- a/controller/controller.py
+++ b/controller/controller.py
@@ -70,6 +70,7 @@ default_config = {
         {"type": "lmstudio", "url": "http://localhost:1234/v1/completions", "models": []},
         {"type": "openai", "url": "https://api.openai.com/v1/chat/completions", "models": []},
     ],
+    "models": [],
     "tasks": [],
     "pipeline_order": [],
 }
@@ -168,6 +169,8 @@ def read_config():
             cfg["prompt_templates"].update(user_cfg["prompt_templates"])
         if "api_endpoints" in user_cfg:
             cfg["api_endpoints"] = user_cfg["api_endpoints"]
+        if "models" in user_cfg:
+            cfg["models"] = user_cfg.get("models", [])
         if "tasks" in user_cfg:
             cfg["tasks"] = user_cfg.get("tasks", [])
         if "pipeline_order" in user_cfg:
@@ -271,6 +274,32 @@ def update_api_endpoints():
     ]
     write_config(cfg)
     return jsonify({"api_endpoints": cfg["api_endpoints"]})
+
+
+@app.route("/config/models", methods=["POST"])
+def update_models():
+    """Update available models in the configuration."""
+    data = request.get_json(silent=True) or {}
+    models = data.get("models")
+    if not isinstance(models, list):
+        return jsonify({"error": "models must be a list"}), 400
+    cfg = read_config()
+    cfg["models"] = [m for m in models if m]
+    write_config(cfg)
+    return jsonify({"models": cfg["models"]})
+
+
+@app.route("/config/agents", methods=["POST"])
+def update_agents():
+    """Persist agent configuration."""
+    data = request.get_json(silent=True) or {}
+    agents = data.get("agents")
+    if not isinstance(agents, dict):
+        return jsonify({"error": "agents must be a dict"}), 400
+    cfg = read_config()
+    cfg["agents"] = agents
+    write_config(cfg)
+    return jsonify({"agents": cfg["agents"]})
 
 
 @app.route("/approve", methods=["POST"])

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -17,9 +17,10 @@ import Agents from './components/Agents.vue';
 import Tasks from './components/Tasks.vue';
 import Templates from './components/Templates.vue';
 import Endpoints from './components/Endpoints.vue';
+import Models from './components/Models.vue';
 
-const tabs = ['Pipeline', 'Agents', 'Tasks', 'Templates', 'Endpoints'];
-const tabComponents = { Pipeline, Agents, Tasks, Templates, Endpoints };
+const tabs = ['Pipeline', 'Agents', 'Tasks', 'Templates', 'Endpoints', 'Models'];
+const tabComponents = { Pipeline, Agents, Tasks, Templates, Endpoints, Models };
 const currentTab = ref('Pipeline');
 </script>
 

--- a/frontend/src/components/Models.vue
+++ b/frontend/src/components/Models.vue
@@ -1,0 +1,69 @@
+<template>
+  <div>
+    <h2>Models</h2>
+    <ul>
+      <li v-for="(model, index) in models" :key="index">
+        {{ model }}
+        <button @click="removeModel(index)" data-test="delete">Delete</button>
+      </li>
+    </ul>
+    <input v-model="newModel" placeholder="New model" data-test="new-name" />
+    <button @click="addModel" data-test="add">Add</button>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue';
+
+const models = ref([]);
+const newModel = ref('');
+
+const fetchModels = async () => {
+  try {
+    const response = await fetch('/config');
+    const config = await response.json();
+    models.value = config.models || [];
+  } catch (err) {
+    console.error('Failed to load models:', err);
+  }
+};
+
+const persistModels = async () => {
+  try {
+    await fetch('/config/models', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ models: models.value })
+    });
+  } catch (err) {
+    console.error('Failed to save models:', err);
+  }
+};
+
+const addModel = async () => {
+  if (!newModel.value) return;
+  models.value.push(newModel.value);
+  newModel.value = '';
+  await persistModels();
+};
+
+const removeModel = async (index) => {
+  models.value.splice(index, 1);
+  await persistModels();
+};
+
+onMounted(fetchModels);
+</script>
+
+<style scoped>
+ul {
+  padding: 0;
+}
+li {
+  list-style: none;
+  margin-bottom: 4px;
+}
+button {
+  margin-left: 8px;
+}
+</style>

--- a/frontend/tests/Agents.spec.js
+++ b/frontend/tests/Agents.spec.js
@@ -4,7 +4,7 @@ import Agents from '../src/components/Agents.vue';
 
 describe('Agents.vue', () => {
   it('loads agents and enters edit mode', async () => {
-    const mockConfig = { agents: { Bob: { model: 'm1', provider: 'p1' } } };
+    const mockConfig = { agents: { Bob: { model: 'm1', provider: 'p1' } }, models: ['m1', 'm2'] };
     const fetchMock = vi.fn(() => Promise.resolve({ json: () => Promise.resolve(mockConfig) }));
     const originalFetch = global.fetch;
     global.fetch = fetchMock;
@@ -15,8 +15,8 @@ describe('Agents.vue', () => {
     expect(fetchMock).toHaveBeenCalled();
     expect(wrapper.text()).toContain('Bob');
 
-    await wrapper.find('button').trigger('click');
-    expect(wrapper.find('input').exists()).toBe(true);
+    await wrapper.find('[data-test="edit"]').trigger('click');
+    expect(wrapper.find('select').exists()).toBe(true);
 
     global.fetch = originalFetch;
   });

--- a/frontend/tests/App.spec.js
+++ b/frontend/tests/App.spec.js
@@ -13,7 +13,8 @@ describe('App.vue', () => {
           Agents: stub('agents'),
           Tasks: stub('tasks'),
           Templates: stub('templates'),
-          Endpoints: stub('endpoints')
+          Endpoints: stub('endpoints'),
+          Models: stub('models')
         }
       }
     });
@@ -22,5 +23,7 @@ describe('App.vue', () => {
     expect(wrapper.find('.agents').exists()).toBe(true);
     await wrapper.findAll('button')[4].trigger('click');
     expect(wrapper.find('.endpoints').exists()).toBe(true);
+    await wrapper.findAll('button')[5].trigger('click');
+    expect(wrapper.find('.models').exists()).toBe(true);
   });
 });

--- a/frontend/tests/Endpoints.spec.js
+++ b/frontend/tests/Endpoints.spec.js
@@ -6,6 +6,7 @@ describe('Endpoints.vue', () => {
   it('can add and remove endpoints', async () => {
     const mockConfig = {
       api_endpoints: [{ type: 't1', url: 'u1', models: ['m1'] }],
+      models: ['m1', 'm2', 'm3'],
     };
     const fetchMock = vi.fn((url, opts) => {
       if (!opts) {
@@ -25,7 +26,7 @@ describe('Endpoints.vue', () => {
 
     await wrapper.get('[data-test="new-type"]').setValue('t2');
     await wrapper.get('[data-test="new-url"]').setValue('u2');
-    await wrapper.get('[data-test="new-models"]').setValue('m2,m3');
+    await wrapper.get('[data-test="new-models"]').setValue(['m2', 'm3']);
     await wrapper.get('[data-test="add"]').trigger('click');
     await flushPromises();
     expect(fetchMock).toHaveBeenCalledTimes(2);

--- a/frontend/tests/Models.spec.js
+++ b/frontend/tests/Models.spec.js
@@ -1,0 +1,33 @@
+import { mount, flushPromises } from '@vue/test-utils';
+import { describe, it, expect, vi } from 'vitest';
+import Models from '../src/components/Models.vue';
+
+describe('Models.vue', () => {
+  it('can add and remove models', async () => {
+    const mockConfig = { models: ['m1'] };
+    const fetchMock = vi.fn((url, opts) => {
+      if (!opts) {
+        return Promise.resolve({ json: () => Promise.resolve(mockConfig) });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+    const originalFetch = global.fetch;
+    global.fetch = fetchMock;
+
+    const wrapper = mount(Models);
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('m1');
+    await wrapper.get('[data-test="new-name"]').setValue('m2');
+    await wrapper.get('[data-test="add"]').trigger('click');
+    await flushPromises();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(wrapper.text()).toContain('m2');
+    await wrapper.find('[data-test="delete"]').trigger('click');
+    await flushPromises();
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(wrapper.text()).not.toContain('m1');
+
+    global.fetch = originalFetch;
+  });
+});


### PR DESCRIPTION
## Summary
- manage available LLM models in a new dashboard tab
- use shared model list via combo boxes for agents and endpoints
- allow adding or removing agents with persistence

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68921a95a4ec8326b4487ec0495417df