### PR TITLE
Remove agent provider field

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,7 +3,6 @@
     "default": {
       "model": "llama3",
       "models": [],
-      "provider": "ollama",
       "template": "default",
       "max_summary_length": 300,
       "step_delay": 10,
@@ -24,7 +23,6 @@
         ]
       },
       "models": [],
-      "provider": "ollama",
       "template": "default",
       "max_summary_length": 300,
       "step_delay": 10,
@@ -48,7 +46,6 @@
         ]
       },
       "models": [],
-      "provider": "ollama",
       "template": "default",
       "max_summary_length": 300,
       "step_delay": 10,
@@ -72,7 +69,6 @@
         ]
       },
       "models": [],
-      "provider": "ollama",
       "template": "default",
       "max_summary_length": 300,
       "step_delay": 10,
@@ -94,7 +90,6 @@
         ]
       },
       "models": [],
-      "provider": "ollama",
       "template": "default",
       "max_summary_length": 300,
       "step_delay": 10,
@@ -116,7 +111,6 @@
         ]
       },
       "models": [],
-      "provider": "ollama",
       "template": "default",
       "max_summary_length": 300,
       "step_delay": 10,
@@ -139,7 +133,6 @@
         ]
       },
       "models": [],
-      "provider": "ollama",
       "template": "default",
       "max_summary_length": 300,
       "step_delay": 10,
@@ -161,7 +154,6 @@
         ]
       },
       "models": [],
-      "provider": "ollama",
       "template": "default",
       "max_summary_length": 300,
       "step_delay": 10,

--- a/controller/controller.py
+++ b/controller/controller.py
@@ -49,7 +49,6 @@ def agent_summary_file(agent: str) -> str:
 default_agent_config = {
     "model": "llama3",
     "models": [],
-    "provider": "ollama",
     "template": "default",
     "max_summary_length": 300,
     "step_delay": 10,

--- a/data/config.json
+++ b/data/config.json
@@ -2,7 +2,6 @@
   "agents": {
     "default": {
       "model": "llama3",
-      "provider": "ollama",
       "template": "default",
       "max_summary_length": 300,
       "step_delay": 10,
@@ -11,7 +10,8 @@
       "controller_active": true,
       "prompt": "",
       "tasks": []
-    }
+  }
+
   },
   "active_agent": "default",
   "prompt_templates": {

--- a/frontend/tests/Agents.spec.js
+++ b/frontend/tests/Agents.spec.js
@@ -4,7 +4,7 @@ import Agents from '../src/components/Agents.vue';
 
 describe('Agents.vue', () => {
   it('loads agents and enters edit mode', async () => {
-    const mockConfig = { agents: { Bob: { model: 'm1', provider: 'p1' } }, models: ['m1', 'm2'] };
+    const mockConfig = { agents: { Bob: { model: 'm1' } }, models: ['m1', 'm2'] };
     const fetchMock = vi.fn(() => Promise.resolve({ json: () => Promise.resolve(mockConfig) }));
     const originalFetch = global.fetch;
     global.fetch = fetchMock;

--- a/src/agents/base.py
+++ b/src/agents/base.py
@@ -16,8 +16,6 @@ class Agent:
     ----------
     name:
         Name of the agent. Used as key in registries.
-    provider:
-        Identifier for the LLM provider (e.g. "openai", "ollama").
     model:
         Name of the model to use.
     prompt_template:
@@ -28,7 +26,6 @@ class Agent:
     """
 
     name: str
-    provider: str
     model: str
     prompt_template: str
     config_path: str
@@ -57,7 +54,7 @@ class Agent:
         with path.open("r", encoding="utf-8") as fh:
             data: Dict[str, Any] = json.load(fh)
 
-        required = ["name", "provider", "model", "prompt_template"]
+        required = ["name", "model", "prompt_template"]
         missing = [key for key in required if key not in data]
         if missing:
             raise ValueError(
@@ -66,7 +63,6 @@ class Agent:
 
         return cls(
             name=data["name"],
-            provider=data["provider"],
             model=data["model"],
             prompt_template=data["prompt_template"],
             config_path=str(path),

--- a/src/controller/routes.py
+++ b/src/controller/routes.py
@@ -9,7 +9,6 @@ from ..models import ModelPool
 
 controller_agent = ControllerAgent(
     name="controller",
-    provider="internal",
     model="none",
     prompt_template="",
     config_path="",

--- a/tests/test_controller_agent.py
+++ b/tests/test_controller_agent.py
@@ -5,7 +5,6 @@ from src.controller.agent import ControllerAgent
 def create_agent() -> ControllerAgent:
     return ControllerAgent(
         name="controller",
-        provider="internal",
         model="none",
         prompt_template="",
         config_path="",

--- a/tests/test_dashboard_manager.py
+++ b/tests/test_dashboard_manager.py
@@ -23,7 +23,6 @@ def make_request(form: Dict[str, str]) -> Request:
 DEFAULT_AGENT = {
     "model": "m",
     "models": [],
-    "provider": "p",
     "template": "",
     "max_summary_length": 0,
     "step_delay": 0,


### PR DESCRIPTION
## Summary
- drop provider attribute from `Agent` and controller defaults
- clean up controller routes for providerless agents
- update Agents dashboard to only select models

## Testing
- `pytest`
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68921e31add883268a1c3c6835081b14