### PR TITLE
feat: expand agent model info and controls

### DIFF
--- a/frontend/src/components/Pipeline.vue
+++ b/frontend/src/components/Pipeline.vue
@@ -3,22 +3,18 @@
     <h2>Pipeline</h2>
     <ul v-if="config">
       <li v-for="(name, idx) in config.pipeline_order" :key="name">
-        {{ name }}
-        <button @click="moveAgent(name, 'up')" :disabled="idx === 0">↑</button>
-        <button @click="moveAgent(name, 'down')" :disabled="idx === config.pipeline_order.length - 1">↓</button>
+        <div class="agent-header">
+          {{ name }}
+          <button @click="moveAgent(name, 'up')" :disabled="idx === 0">↑</button>
+          <button @click="moveAgent(name, 'down')" :disabled="idx === config.pipeline_order.length - 1">↓</button>
+          <button @click="toggleAgent(name)">
+            {{ config.agents[name]?.controller_active ? 'Deactivate' : 'Activate' }}
+          </button>
+          <button v-if="config.active_agent === name" @click="stop">Stop</button>
+        </div>
+        <pre>{{ agentLogs[name] }}</pre>
       </li>
     </ul>
-    <div class="log-section">
-      <h2>Logs</h2>
-      <button @click="loadControllerLog">Load Controller Log</button>
-      <pre v-if="controllerLog">{{ controllerLog }}</pre>
-    </div>
-    <div class="control-section">
-      <h2>Control</h2>
-      <button @click="stop">Stop</button>
-      <button @click="restart">Restart</button>
-      <a :href="base + '/export'" target="_blank">Export logs</a>
-    </div>
   </section>
 </template>
 
@@ -27,11 +23,22 @@ import { ref, onMounted } from 'vue';
 
 const base = '';
 const config = ref(null);
-const controllerLog = ref('');
+const agentLogs = ref({});
 
 async function loadConfig() {
   const res = await fetch(base + '/config');
   config.value = await res.json();
+  await loadLogs();
+}
+
+async function loadLogs() {
+  if (!config.value) return;
+  const logs = {};
+  for (const name of config.value.pipeline_order) {
+    const res = await fetch(`${base}/agent/${encodeURIComponent(name)}/log`);
+    logs[name] = await res.text();
+  }
+  agentLogs.value = logs;
 }
 
 async function moveAgent(name, direction) {
@@ -42,18 +49,13 @@ async function moveAgent(name, direction) {
   await loadConfig();
 }
 
-async function loadControllerLog() {
-  const res = await fetch(base + '/controller/status');
-  const data = await res.json();
-  controllerLog.value = Array.isArray(data) ? data.join('\n') : JSON.stringify(data);
+async function toggleAgent(name) {
+  await fetch(`${base}/agent/${encodeURIComponent(name)}/toggle_active`, { method: 'POST' });
+  await loadConfig();
 }
 
 async function stop() {
   await fetch(base + '/stop', { method: 'POST' });
-}
-
-async function restart() {
-  await fetch(base + '/restart', { method: 'POST' });
 }
 
 onMounted(loadConfig);
@@ -61,10 +63,17 @@ onMounted(loadConfig);
 
 <style scoped>
 li {
-  margin-bottom: 5px;
+  margin-bottom: 20px;
 }
-.log-section,
-.control-section {
-  margin-top: 20px;
+.agent-header {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+pre {
+  background: #f4f4f4;
+  padding: 10px;
+  max-height: 200px;
+  overflow-y: auto;
 }
 </style>

--- a/frontend/src/components/Settings.vue
+++ b/frontend/src/components/Settings.vue
@@ -6,7 +6,13 @@
         <option v-for="name in agentOptions" :key="name" :value="name">{{ name }}</option>
       </select>
     </label>
-    <button @click="save">Save</button>
+    <button @click="save" data-test="save">Save</button>
+
+    <div class="log-section">
+      <h3>Logs</h3>
+      <button @click="loadControllerLog" data-test="load-log">Load Controller Log</button>
+      <pre v-if="controllerLog">{{ controllerLog }}</pre>
+    </div>
   </div>
 </template>
 
@@ -15,6 +21,7 @@ import { ref, onMounted } from 'vue';
 
 const activeAgent = ref('');
 const agentOptions = ref([]);
+const controllerLog = ref('');
 
 const fetchSettings = async () => {
   try {
@@ -39,12 +46,25 @@ const save = async () => {
   }
 };
 
+const loadControllerLog = async () => {
+  try {
+    const res = await fetch('/controller/status');
+    const data = await res.json();
+    controllerLog.value = Array.isArray(data) ? data.join('\n') : JSON.stringify(data);
+  } catch (err) {
+    console.error('Failed to load controller log:', err);
+  }
+};
+
 onMounted(fetchSettings);
 </script>
 
 <style scoped>
 label {
   margin-right: 10px;
+}
+.log-section {
+  margin-top: 20px;
 }
 </style>
 

--- a/frontend/tests/Settings.spec.js
+++ b/frontend/tests/Settings.spec.js
@@ -21,7 +21,7 @@ describe('Settings.vue', () => {
     expect(wrapper.find('select').element.value).toBe('Bob');
 
     await wrapper.find('select').setValue('Alice');
-    await wrapper.find('button').trigger('click');
+    await wrapper.find('[data-test="save"]').trigger('click');
     expect(fetchMock).toHaveBeenLastCalledWith(
       '/config/active_agent',
       expect.objectContaining({ method: 'POST' })


### PR DESCRIPTION
## Summary
- support descriptive model information alongside model selections
- move controller logs to settings view
- add per-agent controls with logs and activation toggles

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689245ee9ba88326ba0718f6f1e9bdc2