### PR TITLE
feat(frontend): select prompt templates for agents

### DIFF
--- a/frontend/src/components/Agents.vue
+++ b/frontend/src/components/Agents.vue
@@ -65,7 +65,10 @@
           </td>
           <td>
             <div v-if="editingAgent === name">
-              <input v-model="editableAgent.template" />
+              <select v-model="editableAgent.template" data-test="edit-template">
+                <option value=""></option>
+                <option v-for="t in templateOptions" :key="t" :value="t">{{ t }}</option>
+              </select>
             </div>
             <div v-else>{{ agent.template }}</div>
           </td>
@@ -143,7 +146,10 @@
       <select v-model="newAgent.models" multiple data-test="new-models">
         <option v-for="m in modelOptions" :key="m" :value="m">{{ m }}</option>
       </select>
-      <input v-model="newAgent.template" placeholder="template" />
+      <select v-model="newAgent.template" data-test="new-template">
+        <option value=""></option>
+        <option v-for="t in templateOptions" :key="t" :value="t">{{ t }}</option>
+      </select>
       <input type="number" v-model.number="newAgent.max_summary_length" placeholder="max_summary_length" />
       <input type="number" v-model.number="newAgent.step_delay" placeholder="step_delay" />
       <label><input type="checkbox" v-model="newAgent.auto_restart" />auto_restart</label>
@@ -163,6 +169,7 @@ import { ref, reactive, onMounted } from 'vue';
 
 const agents = ref({});
 const modelOptions = ref([]);
+const templateOptions = ref([]);
 const editingAgent = ref(null);
 const defaultModel = () => ({ name: '', type: '', reasoning: '', sources: [] });
 
@@ -225,6 +232,7 @@ const fetchAgents = async () => {
       };
     }
     modelOptions.value = config.models || [];
+    templateOptions.value = Object.keys(config.prompt_templates || {});
   } catch (error) {
     console.error('Fehler beim Laden der Agenten-Konfiguration:', error);
   }

--- a/frontend/tests/Agents.spec.js
+++ b/frontend/tests/Agents.spec.js
@@ -11,7 +11,8 @@ describe('Agents.vue', () => {
           models: ['m1']
         }
       },
-      models: ['m1', 'm2']
+      models: ['m1', 'm2'],
+      prompt_templates: { tpl1: 'one', tpl2: 'two' }
     };
     const fetchMock = vi.fn(() => Promise.resolve({ json: () => Promise.resolve(mockConfig) }));
     const originalFetch = global.fetch;
@@ -23,8 +24,15 @@ describe('Agents.vue', () => {
     expect(fetchMock).toHaveBeenCalled();
     expect(wrapper.text()).toContain('Bob');
 
+    const newTemplateSelect = wrapper.find('[data-test="new-template"]');
+    expect(newTemplateSelect.exists()).toBe(true);
+    expect(newTemplateSelect.findAll('option')).toHaveLength(3);
+
     await wrapper.find('[data-test="edit"]').trigger('click');
     expect(wrapper.find('select[multiple]').exists()).toBe(true);
+    const editTemplateSelect = wrapper.find('[data-test="edit-template"]');
+    expect(editTemplateSelect.exists()).toBe(true);
+    expect(editTemplateSelect.findAll('option')).toHaveLength(3);
 
     global.fetch = originalFetch;
   });


### PR DESCRIPTION
## Summary
- allow agents to choose a prompt template from existing templates
- cover template dropdown in unit tests

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68924ed347848326a1371f46c3d9f711