### PR TITLE
Add context manager for model pool

### DIFF
--- a/tests/test_model_pool.py
+++ b/tests/test_model_pool.py
@@ -1,4 +1,5 @@
 import asyncio
+import pytest
 
 from src.models import ModelPool
 
@@ -10,3 +11,17 @@ def test_model_pool_status():
     status = pool.status()
     assert status == {"prov": {"mod": {"limit": 2, "in_use": 1, "waiters": 0}}}
     pool.release("prov", "mod")
+
+
+async def _use_slot(pool: ModelPool) -> None:
+    async with pool.slot("prov", "mod"):
+        assert pool.status()["prov"]["mod"]["in_use"] == 1
+        raise RuntimeError("boom")
+
+
+def test_context_manager_releases_on_error():
+    pool = ModelPool()
+    pool.register("prov", "mod", limit=1)
+    with pytest.raises(RuntimeError):
+        asyncio.run(_use_slot(pool))
+    assert pool.status()["prov"]["mod"]["in_use"] == 0


### PR DESCRIPTION
## Summary
- add an async context manager `slot` to `ModelPool` for automatic acquire/release
- cover `slot` behaviour with unit tests ensuring resources are released even on errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68925c32e9488326a655315b9e1bc39b