### PR TITLE
feat(frontend): add agent log viewer

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -19,9 +19,10 @@ import Templates from './components/Templates.vue';
 import Endpoints from './components/Endpoints.vue';
 import Models from './components/Models.vue';
 import Settings from './components/Settings.vue';
+import AgentLogViewer from './components/AgentLogViewer.vue';
 
-const tabs = ['Pipeline', 'Agents', 'Tasks', 'Templates', 'Endpoints', 'Models', 'Einstellungen'];
-const tabComponents = { Pipeline, Agents, Tasks, Templates, Endpoints, Models, Einstellungen: Settings };
+const tabs = ['Pipeline', 'Agents', 'Tasks', 'Templates', 'Endpoints', 'Models', 'Einstellungen', 'Logs'];
+const tabComponents = { Pipeline, Agents, Tasks, Templates, Endpoints, Models, Einstellungen: Settings, Logs: AgentLogViewer };
 const currentTab = ref('Pipeline');
 </script>
 

--- a/frontend/src/components/AgentLogViewer.vue
+++ b/frontend/src/components/AgentLogViewer.vue
@@ -1,0 +1,134 @@
+<template>
+  <div class="agent-log-viewer">
+    <h2>Agent Log</h2>
+    <div class="controls">
+      <label>
+        Agent:
+        <select v-model="selectedAgent">
+          <option v-for="name in agentOptions" :key="name" :value="name">{{ name }}</option>
+        </select>
+      </label>
+    </div>
+    <div class="log-container">
+      <div v-if="loading">Lade Logs...</div>
+      <div v-else-if="error">{{ error }}</div>
+      <ul v-else>
+        <li
+          v-for="(entry, idx) in logs"
+          :key="idx"
+          class="log-entry"
+          @click="detail = entry"
+        >
+          {{ entry.raw }}
+        </li>
+      </ul>
+    </div>
+    <div v-if="detail" class="log-detail">
+      <h3>Details</h3>
+      <p><strong>Zeit:</strong> {{ detail.timestamp }}</p>
+      <p><strong>Level:</strong> {{ detail.level }}</p>
+      <pre>{{ detail.message }}</pre>
+      <button @click="detail = null">Schließen</button>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'AgentLogViewer',
+  data() {
+    return {
+      logs: [],
+      agentOptions: [],
+      selectedAgent: 'default',
+      pollInterval: null,
+      loading: false,
+      error: '',
+      detail: null
+    };
+  },
+  methods: {
+    async fetchAgents() {
+      try {
+        const res = await fetch('/config');
+        if (!res.ok) throw new Error(await res.text());
+        const cfg = await res.json();
+        this.agentOptions = Object.keys(cfg.agents || {});
+        if (!this.agentOptions.includes(this.selectedAgent)) {
+          this.selectedAgent = this.agentOptions[0] || 'default';
+        }
+      } catch (e) {
+        console.error('Fehler beim Laden der Agenten:', e);
+        this.error = 'Fehler beim Laden der Agenten';
+      }
+    },
+    parseLine(line) {
+      const m = line.match(/^(\S+\s+\S+)\s+(\w+)\s+(.*)$/);
+      if (m) {
+        return { timestamp: m[1], level: m[2], message: m[3], raw: line };
+      }
+      return { raw: line, timestamp: '', level: '', message: line };
+    },
+    async fetchLogs() {
+      this.loading = true;
+      this.error = '';
+      try {
+        const res = await fetch(`/agent/${encodeURIComponent(this.selectedAgent)}/log`);
+        if (!res.ok) throw new Error(await res.text());
+        const text = await res.text();
+        this.logs = text
+          .split(/\r?\n/)
+          .filter(Boolean)
+          .map(this.parseLine);
+      } catch (e) {
+        console.error('Fehler beim Abrufen der Logs: ', e);
+        this.error = 'Fehler beim Abrufen der Logs';
+        this.logs = [];
+      } finally {
+        this.loading = false;
+      }
+    }
+  },
+  async mounted() {
+    await this.fetchAgents();
+    await this.fetchLogs();
+    this.pollInterval = setInterval(this.fetchLogs, 5000);
+  },
+  beforeUnmount() {
+    clearInterval(this.pollInterval);
+  },
+  watch: {
+    selectedAgent() {
+      this.fetchLogs();
+    }
+  }
+};
+</script>
+
+<style scoped>
+.agent-log-viewer {
+  background-color: #f9f9f9;
+  border: 1px solid #ddd;
+  padding: 1rem;
+  max-height: 400px;
+  overflow: hidden;
+}
+.log-container {
+  max-height: 250px;
+  overflow-y: auto;
+  margin-top: 0.5rem;
+}
+.log-entry {
+  cursor: pointer;
+  white-space: pre-wrap;
+}
+.log-entry:hover {
+  background: #eee;
+}
+.log-detail {
+  margin-top: 1rem;
+  border-top: 1px solid #ccc;
+  padding-top: 0.5rem;
+}
+</style>
+

--- a/frontend/tests/AgentLogViewer.spec.js
+++ b/frontend/tests/AgentLogViewer.spec.js
@@ -1,0 +1,31 @@
+import { mount, flushPromises } from '@vue/test-utils';
+import { describe, it, expect, vi } from 'vitest';
+import AgentLogViewer from '../src/components/AgentLogViewer.vue';
+
+describe('AgentLogViewer.vue', () => {
+  it('lädt Agenten und Logs', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn((url) => {
+      if (url === '/config') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ agents: { default: {}, other: {} } }) });
+      }
+      if (url === '/agent/default/log') {
+        return Promise.resolve({ ok: true, text: () => Promise.resolve('2024 INFO test') });
+      }
+      return Promise.resolve({ ok: true, text: () => Promise.resolve('') });
+    });
+    const originalFetch = global.fetch;
+    global.fetch = fetchMock;
+
+    const wrapper = mount(AgentLogViewer);
+    await flushPromises();
+
+    expect(fetchMock).toHaveBeenCalledWith('/config');
+    expect(fetchMock).toHaveBeenCalledWith('/agent/default/log');
+    expect(wrapper.find('.log-entry').text()).toContain('test');
+
+    wrapper.unmount();
+    global.fetch = originalFetch;
+    vi.useRealTimers();
+  });
+});

--- a/frontend/tests/App.spec.js
+++ b/frontend/tests/App.spec.js
@@ -15,7 +15,8 @@ describe('App.vue', () => {
           Templates: stub('templates'),
           Endpoints: stub('endpoints'),
           Models: stub('models'),
-          Settings: stub('settings')
+          Settings: stub('settings'),
+          AgentLogViewer: stub('logs')
         }
       }
     });


### PR DESCRIPTION
## Summary
- add AgentLogViewer component with polling, error handling, and detail view
- extend App tabs with new Logs view
- test log viewer rendering and integration

## Testing
- `npm --prefix frontend test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689277eccdf0832691884259f67c142c