### PR TITLE
Fix missing logs in Vue frontend

### DIFF
--- a/agent/ai_agent.py
+++ b/agent/ai_agent.py
@@ -12,7 +12,10 @@ from src.models import ModelPool
 from src.agents.templates import PromptTemplates
 
 # Allow overriding data directory for testing via the DATA_DIR environment variable
-DATA_DIR = os.environ.get("DATA_DIR", "/data")
+# Fall back to the project root so controller and agent share the same files
+DATA_DIR = os.environ.get(
+    "DATA_DIR", os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+)
 STOP_FLAG = os.path.join(DATA_DIR, "stop.flag")
 
 


### PR DESCRIPTION
## Summary
- Unify agent and controller data directories so logs are written where the controller expects them.

## Testing
- `pytest -q`
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68927dc3e44c8326b3a9fa9a8ec3cbc3