### PR TITLE
chore: persist config models

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ Ananta ist ein modulares Multi-Agenten-System mit einem Flask-basierten Controll
 2. **Agentenlauf** – `agent/ai_agent.py` pollt `/next-config`, erstellt Prompts und ruft LLMs auf; Ergebnisse werden über `/approve` bestätigt und ausgeführt.
 3. **Dashboard** – Vue-UI und HTML-Views nutzen Endpunkte wie `/config` oder `/agent/<name>/log`, um Status anzuzeigen und Eingriffe zu ermöglichen.
 
+## Persistenz der Konfiguration
+
+- `docker-compose.yml` mountet jetzt das Verzeichnis `./data` in beide Container und setzt `DATA_DIR=/data` für den Controller.
+- Beim ersten Start kopiert der Controller die `default_team_config.json` in dieses Verzeichnis und arbeitet anschließend nur noch dort.
+- Manuelle Änderungen an `config.json` oder den über die GUI hinzugefügten `models` bleiben dadurch über Container-Neustarts hinaus erhalten.
+
 ## Erweiterbarkeit
 
 - Zusätzliche Agenten-JSON-Dateien über `load_agents()` einbinden.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,10 @@ services:
     working_dir: /app
     volumes:
       - .:/app
+      - ./data:/data
     environment:
       - PYTHONPATH=/app
+      - DATA_DIR=/data
     command: >
       sh -c "pip install flask requests && python -m controller.controller"
     ports:


### PR DESCRIPTION
## Summary
- mount persistent data directory and use DATA_DIR in docker-compose to keep config across restarts
- load default_team_config.json once into DATA_DIR and preserve user-configured models during startup
- document new configuration persistence strategy

## Testing
- `pytest`
- manual config read/write test to verify model persistence

------
https://chatgpt.com/codex/tasks/task_e_6892846bd1b88326b9efe0c9eade7c0c