### PR TITLE
Add Vue e2e tests for config persistence

### DIFF
--- a/frontend/tests/Agents.spec.js
+++ b/frontend/tests/Agents.spec.js
@@ -36,5 +36,69 @@ describe('Agents.vue', () => {
 
     global.fetch = originalFetch;
   });
+
+  it('adds a new agent and saves configuration', async () => {
+    const mockConfig = {
+      agents: {},
+      models: ['m1', 'm2'],
+      prompt_templates: { tpl1: 'one' }
+    };
+    const fetchMock = vi.fn((url, opts) => {
+      if (!opts) {
+        return Promise.resolve({ json: () => Promise.resolve(mockConfig) });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+    const originalFetch = global.fetch;
+    global.fetch = fetchMock;
+
+    const wrapper = mount(Agents);
+    await flushPromises();
+
+    await wrapper.get('[data-test="new-name"]').setValue('Alice');
+    await wrapper.get('input[placeholder="model.name"]').setValue('modelA');
+    await wrapper.get('input[placeholder="model.type"]').setValue('typeA');
+    await wrapper.get('input[placeholder="model.reasoning"]').setValue('reasonA');
+    await wrapper.get('input[placeholder="model.sources (comma separated)"]').setValue('s1,s2');
+    await wrapper.get('select[data-test="new-models"]').setValue(['m1']);
+    await wrapper.get('select[data-test="new-template"]').setValue('tpl1');
+    await wrapper.get('input[placeholder="max_summary_length"]').setValue('10');
+    await wrapper.get('input[placeholder="step_delay"]').setValue('5');
+    const checkboxes = wrapper.findAll('input[type="checkbox"]');
+    await checkboxes[0].setValue(true);
+    await checkboxes[1].setValue(true);
+    await checkboxes[2].setValue(true);
+    await wrapper.get('input[placeholder="prompt"]').setValue('hi');
+    await wrapper.get('input[placeholder="tasks (comma separated)"]').setValue('t1,t2');
+    await wrapper.get('input[placeholder="purpose"]').setValue('testing');
+    await wrapper.get('input[placeholder="preferred_hardware"]').setValue('GPU');
+    await wrapper.get('[data-test="add"]').trigger('click');
+    await flushPromises();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const postBody = JSON.parse(fetchMock.mock.calls[1][1].body);
+    expect(postBody.agents).toHaveProperty('Alice');
+    expect(postBody.agents.Alice).toEqual({
+      model: {
+        name: 'modelA',
+        type: 'typeA',
+        reasoning: 'reasonA',
+        sources: ['s1', 's2']
+      },
+      models: ['m1'],
+      template: 'tpl1',
+      max_summary_length: 10,
+      step_delay: 5,
+      auto_restart: true,
+      allow_commands: true,
+      controller_active: true,
+      prompt: 'hi',
+      tasks: ['t1', 't2'],
+      purpose: 'testing',
+      preferred_hardware: 'GPU'
+    });
+
+    global.fetch = originalFetch;
+  });
 });
 

--- a/frontend/tests/Models.spec.js
+++ b/frontend/tests/Models.spec.js
@@ -22,10 +22,14 @@ describe('Models.vue', () => {
     await wrapper.get('[data-test="add"]').trigger('click');
     await flushPromises();
     expect(fetchMock).toHaveBeenCalledTimes(2);
+    const addBody = JSON.parse(fetchMock.mock.calls[1][1].body);
+    expect(addBody).toEqual({ models: ['m1', 'm2'] });
     expect(wrapper.text()).toContain('m2');
     await wrapper.find('[data-test="delete"]').trigger('click');
     await flushPromises();
     expect(fetchMock).toHaveBeenCalledTimes(3);
+    const deleteBody = JSON.parse(fetchMock.mock.calls[2][1].body);
+    expect(deleteBody).toEqual({ models: ['m2'] });
     expect(wrapper.text()).not.toContain('m1');
 
     global.fetch = originalFetch;

--- a/frontend/tests/Settings.spec.js
+++ b/frontend/tests/Settings.spec.js
@@ -22,10 +22,9 @@ describe('Settings.vue', () => {
 
     await wrapper.find('select').setValue('Alice');
     await wrapper.find('[data-test="save"]').trigger('click');
-    expect(fetchMock).toHaveBeenLastCalledWith(
-      '/config/active_agent',
-      expect.objectContaining({ method: 'POST' })
-    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const body = JSON.parse(fetchMock.mock.calls[1][1].body);
+    expect(body).toEqual({ active_agent: 'Alice' });
 
     global.fetch = originalFetch;
   });

--- a/frontend/tests/Tasks.spec.js
+++ b/frontend/tests/Tasks.spec.js
@@ -1,0 +1,46 @@
+import { mount, flushPromises } from '@vue/test-utils';
+import { describe, it, expect, vi } from 'vitest';
+import Tasks from '../src/components/Tasks.vue';
+
+describe('Tasks.vue', () => {
+  it('adds a task and persists it', async () => {
+    const mockConfig = { tasks: [] };
+    const fetchMock = vi.fn(async (url, opts) => {
+      if (!opts) {
+        return Promise.resolve({ json: () => Promise.resolve(mockConfig) });
+      }
+      const body = Object.fromEntries(opts.body.entries());
+      if (body.add_task) {
+        mockConfig.tasks.push({
+          task: body.task_text,
+          agent: body.task_agent,
+          template: body.task_template
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+    const originalFetch = global.fetch;
+    global.fetch = fetchMock;
+
+    const wrapper = mount(Tasks);
+    await flushPromises();
+
+    await wrapper.get('.task-form input[placeholder="Task"]').setValue('t2');
+    await wrapper.get('.task-form input[placeholder="Agent (optional)"]').setValue('Bob');
+    await wrapper.get('.task-form input[placeholder="Template (optional)"]').setValue('tpl1');
+    await wrapper.get('.task-form button').trigger('click');
+    await flushPromises();
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const bodyEntries = Object.fromEntries(fetchMock.mock.calls[1][1].body.entries());
+    expect(bodyEntries).toMatchObject({
+      add_task: '1',
+      task_text: 't2',
+      task_agent: 'Bob',
+      task_template: 'tpl1'
+    });
+    expect(wrapper.text()).toContain('t2');
+
+    global.fetch = originalFetch;
+  });
+});

--- a/frontend/tests/Templates.spec.js
+++ b/frontend/tests/Templates.spec.js
@@ -1,0 +1,34 @@
+import { mount, flushPromises } from '@vue/test-utils';
+import { describe, it, expect, vi } from 'vitest';
+import Templates from '../src/components/Templates.vue';
+
+describe('Templates.vue', () => {
+  it('adds and saves templates', async () => {
+    const mockConfig = { prompt_templates: { tpl1: 'one' } };
+    const fetchMock = vi.fn((url, opts) => {
+      if (!opts) {
+        return Promise.resolve({ json: () => Promise.resolve(mockConfig) });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+    const originalFetch = global.fetch;
+    global.fetch = fetchMock;
+
+    const wrapper = mount(Templates);
+    await flushPromises();
+
+    await wrapper.get('input[placeholder="name"]').setValue('tpl2');
+    await wrapper.get('textarea[placeholder="template"]').setValue('two');
+    await wrapper.get('.template-form button').trigger('click');
+    const saveButton = wrapper.findAll('button').find(b => b.text() === 'Save Templates');
+    await saveButton.trigger('click');
+    await flushPromises();
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const bodyEntries = Object.fromEntries(fetchMock.mock.calls[1][1].body.entries());
+    const templates = JSON.parse(bodyEntries.prompt_templates);
+    expect(templates).toHaveProperty('tpl2', 'two');
+
+    global.fetch = originalFetch;
+  });
+});


### PR DESCRIPTION
## Summary
- add agent creation test verifying all fields persist to config
- assert models and settings posts include correct JSON
- add e2e specs for template and task management

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892cb03c52883268cb7ffec6b70c75c