### PR TITLE
Add integration tests for backend modules

### DIFF
--- a/tests/test_agent_controller_integration.py
+++ b/tests/test_agent_controller_integration.py
@@ -1,0 +1,56 @@
+import json
+import importlib
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from werkzeug.serving import make_server
+
+
+def test_agent_runs_against_controller(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    cc = importlib.import_module("controller.controller")
+    ai = importlib.import_module("agent.ai_agent")
+    importlib.reload(cc)
+    importlib.reload(ai)
+
+    cfg_file = tmp_path / "config.json"
+    config = {
+        "agents": {"default": {}},
+        "active_agent": "default",
+        "tasks": [{"task": "do"}],
+        "api_endpoints": [{"type": "lmstudio", "url": ""}],
+        "prompt_templates": {},
+    }
+    cfg_file.write_text(json.dumps(config))
+    (tmp_path / "default_team_config.json").write_text("{}")
+
+    monkeypatch.setattr(cc, "DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(cc, "CONFIG_FILE", str(cfg_file))
+    cc.config_provider = cc.FileConfig(cc.read_config, cc.write_config)
+
+    class LLMHandler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'"ok"')
+
+    llm_server = HTTPServer(("localhost", 0), LLMHandler)
+    threading.Thread(target=llm_server.serve_forever, daemon=True).start()
+    llm_url = f"http://localhost:{llm_server.server_port}"
+    config["api_endpoints"][0]["url"] = llm_url
+    cfg_file.write_text(json.dumps(config))
+
+    server = make_server("localhost", 0, cc.app)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    controller_url = f"http://localhost:{server.server_port}"
+
+    ai.run_agent(controller=controller_url, endpoints={"lmstudio": llm_url}, steps=1, step_delay=0)
+
+    summary = (tmp_path / "summary_default.txt").read_text()
+    assert "ok" in summary
+    saved = json.loads(cfg_file.read_text())
+    assert saved["tasks"] == []
+
+    server.shutdown()
+    llm_server.shutdown()

--- a/tests/test_approve_endpoint.py
+++ b/tests/test_approve_endpoint.py
@@ -1,0 +1,39 @@
+import json
+import importlib
+
+
+def setup_client(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    cc = importlib.import_module("controller.controller")
+    importlib.reload(cc)
+    cfg_file = tmp_path / "config.json"
+    cfg_file.write_text(
+        json.dumps({
+            "agents": {"default": {}},
+            "active_agent": "default",
+            "tasks": [],
+            "api_endpoints": [],
+            "prompt_templates": {},
+        })
+    )
+    (tmp_path / "default_team_config.json").write_text("{}")
+    monkeypatch.setattr(cc, "DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(cc, "CONFIG_FILE", str(cfg_file))
+    monkeypatch.setattr(cc, "BLACKLIST_FILE", str(tmp_path / "blacklist.txt"))
+    monkeypatch.setattr(cc, "CONTROL_LOG", str(tmp_path / "control_log.json"))
+    cc.config_provider = cc.FileConfig(cc.read_config, cc.write_config)
+    return cc.app.test_client(), tmp_path
+
+
+def test_approve_writes_log_and_blacklist(tmp_path, monkeypatch):
+    client, path = setup_client(tmp_path, monkeypatch)
+    resp = client.post("/approve", data={"cmd": "ls", "summary": "list"})
+    assert resp.status_code == 200
+    assert resp.data.decode() == "ls"
+
+    blacklist = (path / "blacklist.txt").read_text().strip().splitlines()
+    assert blacklist == ["ls"]
+
+    log = (path / "control_log.json").read_text()
+    assert "\"received\": \"ls\"" in log
+    assert "\"summary\": \"list\"" in log

--- a/tests/test_dashboard_handle_post.py
+++ b/tests/test_dashboard_handle_post.py
@@ -1,0 +1,27 @@
+from tests.test_dashboard_manager import DummyConfig, make_request, DEFAULT_AGENT
+from src.dashboard import DashboardManager
+
+
+def test_handle_post_updates_config():
+    cfg = {"agents": {}, "pipeline_order": [], "tasks": [], "api_endpoints": [], "prompt_templates": {}}
+    dm = DashboardManager(DummyConfig(cfg), DEFAULT_AGENT, ["ollama"])
+    form = {
+        "new_agent": "agent1",
+        "set_active": "agent1",
+        "add_task": "1",
+        "task_text": "task1",
+        "task_agent": "agent1",
+        "agent": "agent1",
+        "models": "m1,m2",
+        "api_endpoints_form": "1",
+        "add_endpoint": "1",
+        "new_endpoint_type": "lmstudio",
+        "new_endpoint_url": "http://llm",
+        "new_endpoint_models": "x",
+    }
+    dm.handle_post(make_request(form))
+    updated = dm.config.read()
+    assert updated["active_agent"] == "agent1"
+    assert updated["tasks"][0]["task"] == "task1"
+    assert updated["agents"]["agent1"]["models"] == ["m1", "m2"]
+    assert updated["api_endpoints"][0] == {"type": "lmstudio", "url": "http://llm", "models": ["x"]}


### PR DESCRIPTION
## Summary
- cover /approve endpoint to ensure blacklisting and control logging
- verify ai_agent and controller interaction in a live workflow
- exercise DashboardManager.handle_post for combined updates

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689324405a3c8326ad973bd686f2f6ad