### PR TITLE
feat: add Playwright e2e test for settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ yarn-error.log*
 # Frontend build artefacts
 /frontend/node_modules/
 /frontend/dist/
+/frontend/test-results/
+/frontend/playwright-report/
 /data/ai_log_Architect.json
 /blacklist.txt
 /control_log.json

--- a/frontend/e2e/settings.spec.js
+++ b/frontend/e2e/settings.spec.js
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+
+test('change active agent persists via API', async ({ page }) => {
+  const config = {
+    active_agent: 'Architect',
+    agents: { Architect: {}, Developer: {} }
+  };
+
+  await page.route('**/config', route => {
+    if (route.request().method() === 'GET') {
+      route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify(config)
+      });
+    } else {
+      route.continue();
+    }
+  });
+
+  let savedBody = null;
+  await page.route('**/config/active_agent', async route => {
+    savedBody = await route.request().postDataJSON();
+    route.fulfill({ status: 200, body: '{}' });
+  });
+
+  await page.goto('/');
+  await page.click('text=Einstellungen');
+  const select = page.locator('select');
+  await expect(select).toHaveValue('Architect');
+
+  await select.selectOption('Developer');
+  await page.click('[data-test="save"]');
+
+  expect(savedBody).toEqual({ active_agent: 'Developer' });
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "vue": "^3.4.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.54.2",
         "@vitejs/plugin-vue": "^5.0.0",
         "@vue/test-utils": "^2.4.0",
         "jsdom": "^24.0.0",
@@ -637,6 +638,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.2.tgz",
+      "integrity": "sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -2426,6 +2443,53 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
+      "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
+      "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,19 +3,26 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "scripts": {
-    "dev": "vite",
-    "build": "vite build",
-    "test": "vitest run"
-  },
+    "scripts": {
+      "dev": "vite",
+      "build": "vite build",
+      "test": "vitest run",
+      "test:e2e": "playwright test"
+    },
   "dependencies": {
     "vue": "^3.4.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.54.2",
     "@vitejs/plugin-vue": "^5.0.0",
-    "vite": "^5.0.0",
     "@vue/test-utils": "^2.4.0",
     "jsdom": "^24.0.0",
+    "vite": "^5.0.0",
     "vitest": "^1.0.0"
+  },
+  "vitest": {
+    "test": {
+      "exclude": ["e2e/**"]
+    }
   }
 }

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -1,0 +1,14 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  webServer: {
+    command: 'npm run dev',
+    port: 5173,
+    reuseExistingServer: !process.env.CI,
+  },
+  use: {
+    baseURL: 'http://localhost:5173',
+    headless: true,
+  },
+});

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,7 +4,8 @@ import vue from '@vitejs/plugin-vue';
 export default defineConfig({
   plugins: [vue()],
   test: {
-    environment: 'jsdom'
+    environment: 'jsdom',
+    exclude: ['e2e/**', 'node_modules/**']
   },
   server: {
     proxy: {


### PR DESCRIPTION
## Summary
- integrate Playwright into Vue frontend and add npm script
- add Settings e2e test verifying active agent persists via API
- ignore Playwright artifacts and exclude e2e from unit tests

## Testing
- `pytest`
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_6893406a8b14832690cc51f71cd83d6c