### PR TITLE
Wait for network idle and adjust base path for frontend e2e tests

### DIFF
--- a/frontend/e2e/endpoints.spec.js
+++ b/frontend/e2e/endpoints.spec.js
@@ -9,7 +9,8 @@ test('Echtintegration: Frontend und Python-Backend', async ({ page, request }) =
   expect(initialConfig.api_endpoints[0].type).toBe('lmstudio');
 
   // 2. Frontend öffnen und den Endpunkte-Bereich aufrufen
-  await page.goto('/');
+  await page.goto('/ui/');
+  await page.waitForLoadState('networkidle');
   await page.click('text=Endpoints');
   
   // Warte darauf, dass mindestens eine Zeile in der Tabelle gerendert wird

--- a/frontend/e2e/settings.spec.js
+++ b/frontend/e2e/settings.spec.js
@@ -23,7 +23,8 @@ test('change active agent persists via API', async ({ page }) => {
     route.fulfill({ status: 200, body: '{}' });
   });
 
-  await page.goto('/');
+  await page.goto('/ui/');
+  await page.waitForLoadState('networkidle');
   await page.click('text=Einstellungen');
   const select = page.locator('select');
   await expect(select).toHaveValue('Architect');


### PR DESCRIPTION
## Summary
- ensure Playwright tests load `/ui/` and wait for `networkidle` before interacting

## Testing
- `curl -s http://localhost:8081/config | python -c 'import sys,json; d=json.load(sys.stdin); print(json.dumps(d["api_endpoints"], indent=2))'`
- `pytest`
- `npm test`
- `npm run test:e2e` *(fails: e2e/endpoints.spec.js:3:1 › Echtintegration: Frontend und Python-Backend)*

------
https://chatgpt.com/codex/tasks/task_e_689351ccf2308326a057d1ffa2274aea