### PR TITLE
fix: connect agent to controller via service name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,9 @@ services:
       - ./data:/data
     environment:
       - PYTHONPATH=/app
-      - CONTROLLER_URL=http://host.docker.internal:8081
+      - CONTROLLER_URL=http://controller:8081
+    depends_on:
+      - controller
     ports:
       - "5689:5689"  # Port freigeben
     command: >


### PR DESCRIPTION
## Summary
- use controller service name in docker-compose so `ai-agent` can reach controller
- ensure `ai-agent` depends on controller start-up

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893556bf4e4832694cb5494699d999b