### PR TITLE
feat: improve e2e startup reliability

### DIFF
--- a/frontend/e2e/endpoints.spec.js
+++ b/frontend/e2e/endpoints.spec.js
@@ -12,9 +12,12 @@ test('Echtintegration: Frontend und Python-Backend', async ({ page, request }) =
   await page.goto('/ui/');
   await page.waitForLoadState('networkidle');
   await page.click('text=Endpoints');
-  
+
+  // Warte auf die Antwort des /config-Endpunkts, bevor Elemente geprüft werden
+  await page.waitForResponse(r => r.url().endsWith('/config') && r.ok());
+
   // Warte darauf, dass mindestens eine Zeile in der Tabelle gerendert wird
-  await page.waitForSelector('tbody tr', { timeout: 20000 });
+  await page.waitForSelector('tbody tr', { timeout: 30000 });
   const row = page.locator('tbody tr').first();
   
   // 3. Überprüfen, ob der initiale Endpunkt korrekt angezeigt wird

--- a/frontend/run-e2e.cjs
+++ b/frontend/run-e2e.cjs
@@ -1,39 +1,76 @@
 // run-e2e.cjs
 const { exec } = require('child_process');
+const http = require('http');
+const path = require('path');
+
+const rootDir = path.resolve(__dirname, '..');
+
+// Helfer zum Warten auf den Controller-Endpunkt
+function waitFor(url, { retries = 30, interval = 1000 } = {}) {
+  return new Promise((resolve, reject) => {
+    const attempt = () => {
+      http
+        .get(url, res => {
+          // Wir brauchen den Body nicht, müssen ihn aber konsumieren
+          res.resume();
+          if (res.statusCode === 200) {
+            resolve();
+          } else if (retries > 0) {
+            setTimeout(() => attempt(--retries), interval);
+          } else {
+            reject(new Error(`Unexpected status ${res.statusCode}`));
+          }
+        })
+        .on('error', err => {
+          if (retries > 0) {
+            setTimeout(() => attempt(--retries), interval);
+          } else {
+            reject(err);
+          }
+        });
+    };
+    attempt();
+  });
+}
 
 // Starte Docker-Container im Hintergrund
-exec('docker-compose up -d', (err, stdout, stderr) => {
+exec('docker-compose up -d', { cwd: rootDir }, async (err, stdout, stderr) => {
   if (err) {
     console.error('Fehler beim Starten der Docker-Container:', err);
     process.exit(1);
   }
   console.log(stdout);
-  console.log('Docker-Container gestartet. Warte 10 Sekunden, bis die Backends bereit sind...');
+  console.log('Docker-Container gestartet. Warte, bis der Controller erreichbar ist...');
 
-  // Warte 10 Sekunden (ggf. anpassen falls länger nötig)
-  setTimeout(() => {
-    console.log('Starte die Playwright-Tests...');
-    
-    // Starte die E2E-Tests
-    const testProcess = exec('npx playwright test', (err, stdout, stderr) => {
-      if (err) {
-        console.error('Fehler beim Ausführen der Tests:', err);
-        cleanup();
-        process.exit(1);
-      }
-      console.log(stdout);
+  try {
+    await waitFor('http://localhost:8081/config');
+  } catch (e) {
+    console.error('Controller nicht erreichbar:', e);
+    cleanup();
+    process.exit(1);
+  }
+
+  console.log('Starte die Playwright-Tests...');
+
+  // Starte die E2E-Tests
+  const testProcess = exec('npx playwright test', { cwd: __dirname }, (err, stdout, stderr) => {
+    if (err) {
+      console.error('Fehler beim Ausführen der Tests:', err);
       cleanup();
-    });
-    
-    // Leitet die Ausgabe des Testprozesses weiter:
-    testProcess.stdout.pipe(process.stdout);
-    testProcess.stderr.pipe(process.stderr);
-  }, 10000);
+      process.exit(1);
+    }
+    console.log(stdout);
+    cleanup();
+  });
+
+  // Leitet die Ausgabe des Testprozesses weiter:
+  testProcess.stdout.pipe(process.stdout);
+  testProcess.stderr.pipe(process.stderr);
 });
 
 // Funktion zum Herunterfahren der Docker-Container
 function cleanup() {
-  exec('docker-compose down', (err, stdout, stderr) => {
+  exec('docker-compose down', { cwd: rootDir }, (err, stdout, stderr) => {
     if (err) {
       console.error('Fehler beim Herunterfahren der Docker-Container:', err);
       process.exit(1);


### PR DESCRIPTION
## Summary
- poll `/config` before running Playwright in run-e2e script
- ensure Playwright uses frontend folder and wait for controller readiness
- wait for `/config` response in endpoints e2e test before asserting table

## Testing
- `npx playwright test` *(fails: expect(initialConfigResponse.ok()).toBeTruthy())*


------
https://chatgpt.com/codex/tasks/task_e_689367675d4083269d19183f744d270a