### PR TITLE
Fix Playwright e2e in Docker Compose

### DIFF
--- a/data/config.json
+++ b/data/config.json
@@ -163,7 +163,8 @@
   "api_endpoints": [
     {
       "type": "lmstudio",
-      "url": "http://host.docker.internal:1234/v1/chat/completions"
+      "url": "http://host.docker.internal:1234/v1/chat/completions",
+      "models": []
     }
   ],
   "tasks": [],
@@ -176,5 +177,8 @@
     "DevOps Engineer",
     "Scrum Master / Product Owner"
   ],
-  "models": []
+  "models": [
+    "m1",
+    "m2"
+  ]
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,8 +41,9 @@ services:
     volumes:
       - ./frontend:/app
     command: >
-      bash -c "npm install && npm run test:e2e"
+      bash -c "npm ci && npm run test:e2e"
     depends_on:
       - controller
     environment:
       - NODE_ENV=test
+      - BACKEND_URL=http://controller:8081

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 
+const backendUrl = process.env.BACKEND_URL || 'http://localhost:8081'
+
 export default defineConfig({
   plugins: [vue()],
   test: {
@@ -10,21 +12,21 @@ export default defineConfig({
   server: {
     proxy: {
       '/config': {
-        target: 'http://localhost:8081',
+        target: backendUrl,
         changeOrigin: true
       },
       '/next-config': {
-        target: 'http://localhost:8081',
+        target: backendUrl,
         changeOrigin: true
       },
-      '/agent': 'http://localhost:8081',
-      '/stop': 'http://localhost:8081',
-      '/restart': 'http://localhost:8081',
-      '/export': 'http://localhost:8081'
+      '/agent': backendUrl,
+      '/stop': backendUrl,
+      '/restart': backendUrl,
+      '/export': backendUrl
     }
   },
   base: '/ui/',
   build: {
     outDir: 'dist'
   }
-});
+})


### PR DESCRIPTION
## Summary
- parameterize backend URL via BACKEND_URL in Vite and tests
- add default models and endpoint skeleton for tests
- run e2e tests through docker-compose with npm ci

## Testing
- `BACKEND_URL=http://localhost:8081 npm --prefix frontend run test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_68938c4a78c8832695b87f5ddeed50b8