### PR TITLE
Use HTTP helper for agent logs

### DIFF
--- a/tests/test_add_task_endpoint.py
+++ b/tests/test_add_task_endpoint.py
@@ -28,8 +28,13 @@ def test_add_task_and_next_config(tmp_path, monkeypatch):
 
 def test_agent_log_endpoint(tmp_path, monkeypatch):
     client, cfg_file = setup(tmp_path, monkeypatch)
-    log = tmp_path / "ai_log_default.json"
-    log.write_text("hello")
+
+    class DummyResp:
+        status_code = 200
+        content = b"hello"
+        headers = {"Content-Type": "text/plain"}
+
+    monkeypatch.setattr(cc, "_http_get", lambda url: DummyResp())
     resp = client.get("/agent/default/log")
     assert resp.status_code == 200
     assert resp.data.decode() == "hello"


### PR DESCRIPTION
## Summary
- fetch agent log via HTTP helper `_http_get`
- forward upstream content type and 404 status
- handle errors by returning 502

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893d78bd6408326821f2ecf00c758af