### PR TITLE
Persist agent logs with timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Ananta ist ein modulares Multi-Agenten-System mit einem Flask-basierten Controll
 | `/set_theme` | POST | Speichert Dashboard-Theme im Cookie. |
 | `/` | GET/POST | HTML-Dashboard für Pipeline- und Agentenverwaltung. |
 | `/agent/<name>/toggle_active` | POST | Schaltet `controller_active` eines Agents um. |
-| `/agent/<name>/log` | GET | Liefert Logdatei eines Agents. |
+| `/agent/<name>/log` | GET | Liefert zeitgestempelte Logdatei eines Agents. |
 | `/stop`, `/restart` | POST | Legt `stop.flag` an bzw. entfernt ihn. |
 | `/export` | GET | Exportiert Logs und Konfigurationen als ZIP. |
 | `/ui`, `/ui/<pfad>` | GET | Serviert das gebaute Vue-Frontend. |
@@ -58,7 +58,7 @@ Ananta ist ein modulares Multi-Agenten-System mit einem Flask-basierten Controll
 
 1. **Startup** – Controller initialisiert `config.json` und optional `default_team_config.json`; `ModelPool` registriert Limits.
 2. **Agentenlauf** – `agent/ai_agent.py` pollt `/next-config`, erstellt Prompts und ruft LLMs auf; Ergebnisse werden über `/approve` bestätigt und ausgeführt.
-3. **Dashboard** – Vue-UI und HTML-Views nutzen Endpunkte wie `/config` oder `/agent/<name>/log`, um Status anzuzeigen und Eingriffe zu ermöglichen.
+3. **Dashboard** – Vue-UI und HTML-Views nutzen Endpunkte wie `/config` oder `/agent/<name>/log`, um zeitgestempelte Statusinformationen anzuzeigen und Eingriffe zu ermöglichen.
 
 ## Persistenz der Konfiguration
 

--- a/agent/README.md
+++ b/agent/README.md
@@ -9,7 +9,7 @@ Dieses Verzeichnis enthält den Python-basierten Agenten, der periodisch den Con
   - fragt den Controller über `GET /next-config` nach Konfiguration und Aufgaben,
   - erzeugt über `PromptTemplates` Prompts für den gewünschten LLM,
   - nutzt `ModelPool`, um parallele Anfragen pro Provider zu begrenzen,
-  - protokolliert Ausgaben in `ai_log_<agent>.json` und Zusammenfassungen in `summary_<agent>.txt` im Datenverzeichnis,
+  - protokolliert zeitgestempelte Ausgaben im Format `<YYYY-MM-DD HH:MM:SS> LEVEL Nachricht` in `ai_log_<agent>.json` und Zusammenfassungen in `summary_<agent>.txt` im Datenverzeichnis,
   - stoppt sauber, sobald eine `stop.flag`-Datei existiert.
 
 ## API-Endpunkte

--- a/agent/ai_agent.py
+++ b/agent/ai_agent.py
@@ -31,9 +31,17 @@ class ControllerAgent:
     def __init__(self, name: str):
         self.name = name
         self._log: list[str] = []
+        self._log_file, _ = _agent_files(name)
+        os.makedirs(os.path.dirname(self._log_file), exist_ok=True)
+        if os.path.exists(self._log_file):
+            with open(self._log_file, "r", encoding="utf-8") as f:
+                self._log.extend(line.rstrip("\n") for line in f)
 
-    def log_status(self, message: str):
-        self._log.append(str(message))
+    def log_status(self, message: str, level: str = "INFO"):
+        entry = f"{time.strftime('%Y-%m-%d %H:%M:%S')} {level} {message}"
+        self._log.append(entry)
+        with open(self._log_file, "a", encoding="utf-8") as f:
+            f.write(entry + "\n")
 
 
 # Registrierte Agenteninstanzen, die über den HTTP-Endpunkt abgefragt werden können

--- a/controller/README.md
+++ b/controller/README.md
@@ -22,7 +22,7 @@ Dieses Verzeichnis bündelt den Flask-basierten Controller.
 | `/set_theme` | POST | Speichert das gewählte Dashboard-Theme im Cookie. |
 | `/` | GET/POST | HTML-Dashboard; POST verarbeitet Formaktionen wie Pipeline- oder Task-Updates. |
 | `/agent/<name>/toggle_active` | POST | Schaltet den `controller_active`-Status eines Agents um. |
-| `/agent/<name>/log` | GET | Liefert die letzten Logeinträge eines Agents. |
+| `/agent/<name>/log` | GET | Liefert zeitgestempelte Logeinträge eines Agents aus dem Datenverzeichnis. |
 | `/stop` | POST | Legt `stop.flag` an und stoppt laufende Agenten. |
 | `/restart` | POST | Entfernt `stop.flag` zum Neustart. |
 | `/export` | GET | Download von Logs und Konfigurationen als ZIP. |

--- a/controller/controller.py
+++ b/controller/controller.py
@@ -439,9 +439,12 @@ def add_task():
 @app.route("/agent/<name>/log")
 def agent_log(name: str):
     """Return the log content for the given agent."""
-    agent_name = name
+    log_path = agent_log_file(name)
+    if os.path.exists(log_path):
+        with open(log_path, "r", encoding="utf-8") as f:
+            return Response(f.read(), mimetype="text/plain")
     try:
-        upstream = _http_get(f"/agent/{agent_name}/log")
+        upstream = _http_get(f"/agent/{name}/log")
     except Exception:
         abort(502)
     if upstream.status_code == 404:

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -24,7 +24,7 @@ Dieses Dokument fasst die Gesamtarchitektur des Ananta-Dashboards zusammen und l
 | `/issues` | GET | Holt GitHub-Issues und reiht Aufgaben ein. |
 | `/set_theme` | POST | Speichert das Dashboard-Theme im Cookie. |
 | `/agent/<name>/toggle_active` | POST | Schaltet `controller_active` eines Agents um. |
-| `/agent/<name>/log` | GET | Liefert die Logdatei eines Agents. |
+| `/agent/<name>/log` | GET | Liefert die zeitgestempelte Logdatei eines Agents. |
 | `/stop`, `/restart` | POST | Legt `stop.flag` an bzw. entfernt ihn. |
 | `/export` | GET | Exportiert Logs und Konfigurationen als ZIP. |
 | `/ui`, `/ui/<pfad>` | GET | Serviert das gebaute Vue-Frontend. |

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -19,7 +19,7 @@ Das Dashboard nutzt folgende HTTP-Schnittstellen des Controllers:
 | `/config/api_endpoints` | POST | LLM-Endpunkte inklusive Modell-Liste aktualisieren. |
 | `/` | POST | Formularaktionen für Pipeline, Tasks oder Templates auslösen. |
 | `/agent/<name>/toggle_active` | POST | Aktiv-Status eines Agents ändern. |
-| `/agent/<name>/log` | GET | Logdatei eines Agents abrufen. |
+| `/agent/<name>/log` | GET | Zeitgestempelte Logdatei eines Agents abrufen. |
 | `/controller/status` | GET | Controller-Log abrufen. |
 | `/stop` | POST | Laufende Agenten stoppen. |
 | `/restart` | POST | `stop.flag` entfernen und Neustart veranlassen. |

--- a/tests/test_add_task_endpoint.py
+++ b/tests/test_add_task_endpoint.py
@@ -28,13 +28,9 @@ def test_add_task_and_next_config(tmp_path, monkeypatch):
 
 def test_agent_log_endpoint(tmp_path, monkeypatch):
     client, cfg_file = setup(tmp_path, monkeypatch)
+    log_file = tmp_path / "ai_log_default.json"
+    log_file.write_text("2024-01-01 00:00:00 INFO hello\n")
 
-    class DummyResp:
-        status_code = 200
-        content = b"hello"
-        headers = {"Content-Type": "text/plain"}
-
-    monkeypatch.setattr(cc, "_http_get", lambda url: DummyResp())
     resp = client.get("/agent/default/log")
     assert resp.status_code == 200
-    assert resp.data.decode() == "hello"
+    assert "hello" in resp.data.decode()


### PR DESCRIPTION
## Summary
- persist agent log entries with timestamps and store them on disk
- serve agent logs from controller directly from file with HTTP fallback
- document and test new timestamped log pipeline

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893dec06a4c8326b78dcaf13e6e3463