### PR TITLE
Fix task addition via UI

### DIFF
--- a/controller/controller.py
+++ b/controller/controller.py
@@ -430,6 +430,7 @@ def toggle_agent_active(name: str):
 def add_task():
     """Add a task to the global configuration."""
     data = request.get_json(silent=True) or request.form.to_dict()
+    logger.debug("/agent/add_task payload: %s", data)
     task = (data.get("task") or "").strip()
     if not task:
         logger.error("/agent/add_task called without task")

--- a/frontend/src/components/Tasks.vue
+++ b/frontend/src/components/Tasks.vue
@@ -87,16 +87,34 @@ async function saveTask(idx) {
 }
 
 async function addTask() {
-  const form = new FormData();
-  form.append('add_task', '1');
-  form.append('task_text', taskText.value);
-  form.append('task_agent', taskAgent.value);
-  form.append('task_template', taskTemplate.value);
-  await fetch(base + '/', { method: 'POST', body: form });
-  await loadConfig();
-  taskText.value = '';
-  taskAgent.value = '';
-  taskTemplate.value = '';
+  const task = taskText.value.trim()
+  if (!task) {
+    error.value = 'Task darf nicht leer sein'
+    return
+  }
+  const payload = { task }
+  const agent = taskAgent.value.trim()
+  const template = taskTemplate.value.trim()
+  if (agent) payload.agent = agent
+  if (template) payload.template = template
+  try {
+    const res = await fetch('/agent/add_task', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    })
+    if (!res.ok) {
+      const text = typeof res.text === 'function' ? await res.text() : ''
+      throw new Error(text)
+    }
+    await loadConfig()
+    taskText.value = ''
+    taskAgent.value = ''
+    taskTemplate.value = ''
+    error.value = ''
+  } catch (e) {
+    error.value = 'Fehler beim Hinzufügen der Aufgabe'
+  }
 }
 
 async function taskAction(idx, action) {

--- a/frontend/tests/Tasks.spec.js
+++ b/frontend/tests/Tasks.spec.js
@@ -3,46 +3,50 @@ import { describe, it, expect, vi } from 'vitest';
 import Tasks from '../src/components/Tasks.vue';
 
 describe('Tasks.vue', () => {
-  it('adds a task and persists it', async () => {
-    const mockConfig = { tasks: [] };
-    const fetchMock = vi.fn(async (url, opts) => {
-      if (!opts) {
-        return Promise.resolve({ json: () => Promise.resolve({ ...mockConfig, tasks: [...mockConfig.tasks] }) });
-      }
-      const body = Object.fromEntries(opts.body.entries());
-      if (body.add_task) {
-        mockConfig.tasks.push({
-          task: body.task_text,
-          agent: body.task_agent,
-          template: body.task_template
-        });
-      }
-      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    it('adds a task and persists it', async () => {
+      const mockConfig = { tasks: [] };
+      const fetchMock = vi.fn(async (url, opts) => {
+        if (!opts) {
+          return Promise.resolve({ json: () => Promise.resolve({ ...mockConfig, tasks: [...mockConfig.tasks] }) });
+        }
+        let body = {};
+        if (opts.headers && opts.headers['Content-Type'] === 'application/json') {
+          body = JSON.parse(opts.body);
+        } else if (opts.body && typeof opts.body.entries === 'function') {
+          body = Object.fromEntries(opts.body.entries());
+        }
+        if (body.task) {
+          mockConfig.tasks.push({
+            task: body.task,
+            agent: body.agent,
+            template: body.template
+          });
+        }
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+      });
+      const originalFetch = global.fetch;
+      global.fetch = fetchMock;
+
+      const wrapper = mount(Tasks);
+      await flushPromises();
+
+      await wrapper.get('.task-form input[placeholder="Task"]').setValue('t2');
+      await wrapper.get('.task-form input[placeholder="Agent (optional)"]').setValue('Bob');
+      await wrapper.get('.task-form input[placeholder="Template (optional)"]').setValue('tpl1');
+      await wrapper.get('.task-form button').trigger('click');
+      await flushPromises();
+
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      const bodyEntries = JSON.parse(fetchMock.mock.calls[1][1].body);
+      expect(bodyEntries).toMatchObject({
+        task: 't2',
+        agent: 'Bob',
+        template: 'tpl1'
+      });
+      expect(wrapper.text()).toContain('t2');
+
+      global.fetch = originalFetch;
     });
-    const originalFetch = global.fetch;
-    global.fetch = fetchMock;
-
-    const wrapper = mount(Tasks);
-    await flushPromises();
-
-    await wrapper.get('.task-form input[placeholder="Task"]').setValue('t2');
-    await wrapper.get('.task-form input[placeholder="Agent (optional)"]').setValue('Bob');
-    await wrapper.get('.task-form input[placeholder="Template (optional)"]').setValue('tpl1');
-    await wrapper.get('.task-form button').trigger('click');
-    await flushPromises();
-
-    expect(fetchMock).toHaveBeenCalledTimes(3);
-    const bodyEntries = Object.fromEntries(fetchMock.mock.calls[1][1].body.entries());
-    expect(bodyEntries).toMatchObject({
-      add_task: '1',
-      task_text: 't2',
-      task_agent: 'Bob',
-      task_template: 'tpl1'
-    });
-    expect(wrapper.text()).toContain('t2');
-
-    global.fetch = originalFetch;
-  });
 
   it('removes a task when skipped', async () => {
     const mockConfig = { tasks: [{ task: 't1', agent: 'Alice' }] };

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -19,10 +19,22 @@ export default defineConfig({
         target: backendUrl,
         changeOrigin: true
       },
-      '/agent': backendUrl,
-      '/stop': backendUrl,
-      '/restart': backendUrl,
-      '/export': backendUrl
+      '/agent': {
+        target: backendUrl,
+        changeOrigin: true
+      },
+      '/stop': {
+        target: backendUrl,
+        changeOrigin: true
+      },
+      '/restart': {
+        target: backendUrl,
+        changeOrigin: true
+      },
+      '/export': {
+        target: backendUrl,
+        changeOrigin: true
+      }
     }
   },
   base: '/ui/',


### PR DESCRIPTION
## Summary
- send tasks as JSON with Content-Type from Tasks.vue
- add debug logging and validation to `/agent/add_task`
- proxy `/agent` and related routes correctly to backend

## Testing
- `pytest`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68948102d41c8326a249af07b79660a8