### PR TITLE
Separate agent and controller config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+*.log
 
 # Frontend build artefacts
 /frontend/node_modules/

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Ananta ist ein modulares Multi-Agenten-System mit einem Flask-basierten Controll
 - Pollt den Controller, rendert Prompts aus Templates und führt bestätigte Kommandos aus.
 - Unterstützt mehrere LLM-Provider (Ollama, LM Studio, OpenAI) über konfigurierbare Endpunkte.
 - Nutzt `ModelPool`, um gleichzeitige Modellanfragen pro Provider/Modell zu begrenzen.
+- Verwaltet eigene Einstellungen in `agent_config.json`, zugreifbar über `/agent/config`.
 
 ### Frontend (`frontend/`)
 - Vue-Dashboard zur Anzeige von Logs und Steuerung der Agenten.
@@ -55,6 +56,12 @@ Ananta ist ein modulares Multi-Agenten-System mit einem Flask-basierten Controll
 | `/controller/next-task` | GET | Nächste nicht gesperrte Aufgabe. |
 | `/controller/blacklist` | GET/POST | Liest oder ergänzt die Blacklist. |
 | `/controller/status` | GET | Interner Log-Status des `ControllerAgent`. |
+
+### AI-Agent (`agent/ai_agent.py`)
+
+| Endpoint | Methode | Beschreibung |
+| -------- | ------- | ------------ |
+| `/agent/config` | GET/POST | Liest oder schreibt die Agent-Konfiguration. |
 
 ## Ablauf
 

--- a/architektur/README.md
+++ b/architektur/README.md
@@ -29,7 +29,7 @@ Ananta basiert auf einem modularen Ansatz, um flexibel verschiedene Agentenrolle
 
 ### Controller (Flask-Server)
 - **Aufgaben:**
-  - Verwaltung der Agenten-Konfiguration (z. B. `config.json`), Aufgabenliste, Blacklist sowie Log-Export.
+  - Verwaltung der Controller-Konfiguration (`config.json`), Aufgabenliste, Blacklist sowie Log-Export.
   - Bereitstellung zahlreicher HTTP-Endpunkte, die als Schnittstelle für Agenten, das Dashboard und das gebaute Frontend (Vue) dienen.
 - **Weitere Details:**
   - Verwendet Blueprint-Routen (siehe `/src/controller/routes.py`) für spezifische Operationen wie das Abrufen der nächsten Aufgabe oder die Blacklist-Verwaltung.
@@ -40,6 +40,7 @@ Ananta basiert auf einem modularen Ansatz, um flexibel verschiedene Agentenrolle
   - Periodisches Abfragen des Controllers (über `/next-config`) zur Ermittlung der Konfiguration und Aufgaben.
   - Erstellen und Rendern von Prompts über Vorlagen (PromptTemplates) zur Ansteuerung von LLMs.
   - Implementierung verschiedener LLM-Provider (Ollama, LM Studio, OpenAI) mit konfigurierbaren Endpunkten.
+  - Eigene Einstellungen werden separat in `agent_config.json` gespeichert und über `/agent/config` bereitgestellt.
 - **Wichtige Module:**
   - Nutzung der `ModelPool`-Klasse zur Limitierung paralleler Anfragen an LLM-Provider.
   - Logische Trennung der Agenten-Dateien zur protokollierten Ausführung der generierten Kommandos.
@@ -62,6 +63,8 @@ Das System bietet eine Vielzahl von HTTP-Endpunkten, die zentral sowohl für die
   Liefert die nächste Agenten-Konfiguration inkl. Aufgaben und Vorlagen.
 - **/config (GET):**
   Rückgabe der vollständigen Controller-Konfiguration als JSON.
+- **/agent/config (GET):**
+  Zugriff auf die Agent-Konfiguration.
 - **/approve (POST):**
   Validierung und Ausführung von Agentenvorschlägen.
 - **/issues (GET):**

--- a/controller/README.md
+++ b/controller/README.md
@@ -4,8 +4,9 @@ Dieses Verzeichnis bündelt den Flask-basierten Controller.
 
 ## Architektur
 
-- `controller.py` startet einen Flask-Server, lädt `config.json` aus dem Datenverzeichnis und registriert das Blueprint `src/controller/routes.py`.
+- `controller.py` startet einen Flask-Server, lädt die Controller-Konfiguration `config.json` aus dem Datenverzeichnis und registriert das Blueprint `src/controller/routes.py`.
 - Der Controller verwaltet Aufgaben, Agenten, Blacklist und bietet Log- sowie Exportfunktionen.
+- Der AI-Agent speichert eigene Einstellungen getrennt in `agent_config.json` und stellt sie über `/agent/config` bereit.
 - `DashboardManager` rendert das HTML-Dashboard; ein gebautes Vue-Frontend wird aus `/ui` ausgeliefert.
 - Standardpfade für Daten (`config.json`, `control_log.json`, `blacklist.txt`) können über die Umgebungsvariable `DATA_DIR` angepasst werden.
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -10,7 +10,7 @@ Dieses Dokument fasst die Gesamtarchitektur des Ananta-Dashboards zusammen und l
 
 1. Der AI-Agent fragt den Controller periodisch über `/next-config` nach neuer Konfiguration.
 2. Basierend auf dieser Konfiguration erstellt der Agent Prompts und sendet Ergebnisse über `/approve` zurück.
-3. Das Vue-Dashboard ruft Controller-Endpunkte wie `/config` oder `/agent/<name>/log` auf, um Statusinformationen anzuzeigen.
+3. Das Vue-Dashboard ruft Controller-Endpunkte wie `/config` oder `/agent/<name>/log` sowie den Agent-Endpunkt `/agent/config` auf, um Statusinformationen anzuzeigen.
 4. Der Controller stellt nach `npm run build` das gebaute Dashboard unter `/ui` bereit.
 
 ## Wichtige API-Endpunkte
@@ -20,6 +20,7 @@ Dieses Dokument fasst die Gesamtarchitektur des Ananta-Dashboards zusammen und l
 | `/next-config` | GET | Liefert die nächste Agenten-Konfiguration inkl. Aufgaben & Templates. |
 | `/config` | GET | Gibt die vollständige Controller-Konfiguration als JSON zurück. |
 | `/config/api_endpoints` | POST | Aktualisiert LLM-Endpunkte inklusive Modell-Liste. |
+| `/agent/config` | GET | Liefert die Agent-Konfiguration. |
 | `/approve` | POST | Validiert und führt Agenten-Vorschläge aus. |
 | `/issues` | GET | Holt GitHub-Issues und reiht Aufgaben ein. |
 | `/set_theme` | POST | Speichert das Dashboard-Theme im Cookie. |

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -11,12 +11,13 @@ Das Verzeichnis enthält ein Vue-3-Dashboard zur Steuerung und Überwachung der 
 
 ## API-Endpunkte
 
-Das Dashboard nutzt folgende HTTP-Schnittstellen des Controllers:
+Das Dashboard nutzt folgende HTTP-Schnittstellen des Controllers sowie des AI-Agenten:
 
 | Endpoint | Methode | Zweck |
 |----------|--------|------|
-| `/config` | GET | Aktuelle Konfiguration laden. |
+| `/config` | GET | Aktuelle Controller-Konfiguration laden. |
 | `/config/api_endpoints` | POST | LLM-Endpunkte inklusive Modell-Liste aktualisieren. |
+| `/agent/config` | GET | Agent-Konfiguration laden. |
 | `/` | POST | Formularaktionen für Pipeline, Tasks oder Templates auslösen. |
 | `/agent/<name>/toggle_active` | POST | Aktiv-Status eines Agents ändern. |
 | `/agent/<name>/log` | GET | Zeitgestempelte Logdatei eines Agents abrufen. |

--- a/frontend/src/components/Settings.vue
+++ b/frontend/src/components/Settings.vue
@@ -14,6 +14,11 @@
       <button @click="loadControllerLog" data-test="load-log">Load Controller Log</button>
       <pre v-if="controllerLog">{{ controllerLog }}</pre>
     </div>
+
+    <div class="agent-config" v-if="Object.keys(agentConfig).length">
+      <h3>Agent-Konfiguration</h3>
+      <pre>{{ agentConfig }}</pre>
+    </div>
   </div>
 </template>
 
@@ -24,6 +29,7 @@ const activeAgent = ref('');
 const agentOptions = ref([]);
 const controllerLog = ref('');
 const error = ref('');
+const agentConfig = ref({});
 
 const fetchSettings = async () => {
   try {
@@ -36,6 +42,15 @@ const fetchSettings = async () => {
     activeAgent.value = cfg.active_agent || '';
     agentOptions.value = Object.keys(cfg.agents || {});
     error.value = '';
+
+    try {
+      const agentResp = await fetch('/agent/config');
+      if (agentResp.ok) {
+        agentConfig.value = await agentResp.json();
+      }
+    } catch (e) {
+      console.error('Failed to load agent config:', e);
+    }
   } catch (err) {
     console.error('Failed to load settings:', err);
     error.value = 'Fehler beim Laden der Konfiguration';

--- a/frontend/tests/Settings.spec.js
+++ b/frontend/tests/Settings.spec.js
@@ -6,8 +6,11 @@ describe('Settings.vue', () => {
   it('loads and saves active agent', async () => {
     const mockConfig = { active_agent: 'Bob', agents: { Bob: {}, Alice: {} } };
     const fetchMock = vi.fn((url, opts) => {
-      if (!opts) {
+      if (!opts && url === '/config') {
         return Promise.resolve({ json: () => Promise.resolve(mockConfig) });
+      }
+      if (!opts && url === '/agent/config') {
+        return Promise.resolve({ json: () => Promise.resolve({}) });
       }
       return Promise.resolve({});
     });
@@ -18,12 +21,13 @@ describe('Settings.vue', () => {
     await flushPromises();
 
     expect(fetchMock).toHaveBeenCalledWith('/config');
+    expect(fetchMock).toHaveBeenCalledWith('/agent/config');
     expect(wrapper.find('select').element.value).toBe('Bob');
 
     await wrapper.find('select').setValue('Alice');
     await wrapper.find('[data-test="save"]').trigger('click');
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    const body = JSON.parse(fetchMock.mock.calls[1][1].body);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const body = JSON.parse(fetchMock.mock.calls[2][1].body);
     expect(body).toEqual({ active_agent: 'Alice' });
 
     global.fetch = originalFetch;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,20 +1,22 @@
 import json
+import logging
 import pytest
 import controller.controller as cc
 
+
 @pytest.fixture(autouse=True)
-def stub_ai_agent(monkeypatch, tmp_path):
-    """Stub ai-agent HTTP calls to use local config file."""
+def controller_config(tmp_path, monkeypatch):
     cfg = tmp_path / "config.json"
     cfg.write_text(json.dumps({}))
     monkeypatch.setattr(cc, "CONFIG_FILE", str(cfg))
-
-    def fake_http_get(url, retries=1, delay=0):
-        if url.endswith("/config"):
-            with open(cc.CONFIG_FILE, "r", encoding="utf-8") as fh:
-                return json.load(fh)
-        raise RuntimeError("unexpected url")
-
-    monkeypatch.setattr(cc, "_http_get", fake_http_get)
+    log_file = tmp_path / "controller.log"
+    monkeypatch.setattr(cc, "LOG_FILE", str(log_file))
+    for h in list(logging.getLogger().handlers):
+        if isinstance(h, logging.FileHandler):
+            logging.getLogger().removeHandler(h)
+    fh = logging.FileHandler(log_file)
+    fh.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
+    logging.getLogger().addHandler(fh)
     cc.config_provider = cc.FileConfig(cc.read_config, cc.write_config)
     yield
+

--- a/tests/test_agent_config_endpoint.py
+++ b/tests/test_agent_config_endpoint.py
@@ -1,0 +1,23 @@
+import json
+import importlib
+
+
+def test_agent_config_endpoint(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    ai = importlib.reload(importlib.import_module("agent.ai_agent"))
+    client = ai.app.test_client()
+
+    resp = client.get("/agent/config")
+    assert resp.status_code == 200
+    assert resp.get_json() == {}
+
+    payload = {"example": 1}
+    post = client.post("/agent/config", json=payload)
+    assert post.status_code == 200
+    assert post.get_json()["status"] == "ok"
+    stored = json.loads((tmp_path / "agent_config.json").read_text())
+    assert stored == payload
+
+    resp2 = client.get("/agent/config")
+    assert resp2.get_json() == payload
+


### PR DESCRIPTION
## Summary
- add dedicated `/agent/config` endpoint with agent-specific file storage and file-based logging
- keep controller configuration local with own log file
- expose agent config in Vue settings and document new API

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68948d02c5cc8326b6423bb2fe721f1b