### PR TITLE
Add log deletion for agents and controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Ananta ist ein modulares Multi-Agenten-System mit einem Flask-basierten Controll
 | `/set_theme` | POST | Speichert Dashboard-Theme im Cookie. |
 | `/` | GET/POST | HTML-Dashboard für Pipeline- und Agentenverwaltung. |
 | `/agent/<name>/toggle_active` | POST | Schaltet `controller_active` eines Agents um. |
-| `/agent/<name>/log` | GET | Liefert Logeinträge eines Agents aus der Datenbank. |
+| `/agent/<name>/log` | GET/DELETE | Liefert oder löscht Logeinträge eines Agents aus der Datenbank. |
 | `/agent/add_task` | POST | Fügt eine Aufgabe zur globalen Liste hinzu. |
 | `/agent/<name>/tasks` | GET | Zeigt aktuelle und anstehende Aufgaben eines Agents. |
 | `/stop`, `/restart` | POST | Setzt Stop-Flags in der Datenbank. |
@@ -55,14 +55,14 @@ Ananta ist ein modulares Multi-Agenten-System mit einem Flask-basierten Controll
 | -------- | ------- | ------------ |
 | `/controller/next-task` | GET | Nächste nicht gesperrte Aufgabe. |
 | `/controller/blacklist` | GET/POST | Liest oder ergänzt die Blacklist. |
-| `/controller/status` | GET | Interner Log-Status des `ControllerAgent`. |
+| `/controller/status` | GET/DELETE | Interner Log-Status des `ControllerAgent` oder Leeren. |
 
 ### AI-Agent (`agent/ai_agent.py`)
 
 | Endpoint | Methode | Beschreibung |
 | -------- | ------- | ------------ |
 | `/agent/config` | GET/POST | Liest oder schreibt die Agent-Konfiguration aus/in PostgreSQL. |
-| `/agent/<name>/log` | GET | Gibt Logs eines Agents zurück. |
+| `/agent/<name>/log` | GET/DELETE | Gibt oder löscht Logs eines Agents. |
 
 ## Ablauf
 

--- a/agent/ai_agent.py
+++ b/agent/ai_agent.py
@@ -44,8 +44,17 @@ class ControllerAgent:
 AGENTS: dict[str, ControllerAgent] = {}
 
 
-@app.route("/agent/<name>/log")
+@app.route("/agent/<name>/log", methods=["GET", "DELETE"])
 def agent_log(name: str):
+    if request.method == "DELETE":
+        conn = get_conn()
+        cur = conn.cursor()
+        cur.execute("DELETE FROM agent.logs WHERE agent=%s", (name,))
+        conn.commit()
+        cur.close()
+        conn.close()
+        return ("", 204)
+
     conn = get_conn()
     cur = conn.cursor()
     cur.execute(

--- a/architektur/README.md
+++ b/architektur/README.md
@@ -73,8 +73,8 @@ Das System bietet eine Vielzahl von HTTP-Endpunkten, die zentral sowohl für die
   Speicherung des Dashboard-Themes im Cookie.
 - **/agent/<name>/toggle_active (POST):**
   Umschalten des Aktiv-Status eines spezifischen Agents.
-- **/agent/<name>/log (GET):**
-  Bereitstellung der Protokolldatei eines Agenten.
+- **/agent/<name>/log (GET/DELETE):**
+  Bereitstellung oder Löschung der Protokolldatei eines Agenten.
 - **Weitere Endpunkte:**
   - `/stop`, `/restart` (Steuerung der Agenten-Läufe)
   - `/export` (Export der Logs und Konfigurationen)

--- a/controller/README.md
+++ b/controller/README.md
@@ -22,7 +22,7 @@ Dieses Verzeichnis bündelt den Flask-basierten Controller.
 | `/set_theme` | POST | Speichert das gewählte Dashboard-Theme im Cookie. |
 | `/` | GET/POST | HTML-Dashboard; POST verarbeitet Formaktionen wie Pipeline- oder Task-Updates. |
 | `/agent/<name>/toggle_active` | POST | Schaltet den `controller_active`-Status eines Agents um. |
-| `/agent/<name>/log` | GET | Liefert zeitgestempelte Logeinträge eines Agents aus der Datenbank. |
+| `/agent/<name>/log` | GET/DELETE | Liefert oder löscht zeitgestempelte Logeinträge eines Agents aus der Datenbank. |
 | `/agent/add_task` | POST | Fügt eine Aufgabe zur globalen Liste hinzu. |
 | `/agent/<name>/tasks` | GET | Zeigt aktuelle und anstehende Aufgaben eines Agents. |
 | `/stop` | POST | Setzt ein Stop-Flag in der Datenbank und stoppt laufende Agenten. |
@@ -37,4 +37,4 @@ Dieses Verzeichnis bündelt den Flask-basierten Controller.
 |----------|--------|--------------|
 | `/controller/next-task` | GET | Nächste nicht geblockte Aufgabe des Controller-Agenten. |
 | `/controller/blacklist` | GET/POST | Listet oder ergänzt Einträge der Blacklist. |
-| `/controller/status` | GET | Gibt den internen Log-Status des Controller-Agenten zurück. |
+| `/controller/status` | GET/DELETE | Gibt den internen Log-Status des Controller-Agenten zurück oder löscht ihn. |

--- a/controller/controller.py
+++ b/controller/controller.py
@@ -410,9 +410,19 @@ def add_task():
     return jsonify({"added": entry}), 201
 
 
-@app.route("/agent/<name>/log")
+@app.route("/agent/<name>/log", methods=["GET", "DELETE"])
 def agent_log(name: str):
-    """Return log entries for the given agent from PostgreSQL."""
+    """Return or clear log entries for the given agent."""
+
+    if request.method == "DELETE":
+        conn = get_conn()
+        cur = conn.cursor()
+        cur.execute("DELETE FROM agent.logs WHERE agent=%s", (name,))
+        conn.commit()
+        cur.close()
+        conn.close()
+        return ("", 204)
+
     conn = get_conn()
     cur = conn.cursor()
     cur.execute(

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -25,10 +25,11 @@ Dieses Dokument fasst die Gesamtarchitektur des Ananta-Dashboards zusammen und l
 | `/issues` | GET | Holt GitHub-Issues und reiht Aufgaben ein. |
 | `/set_theme` | POST | Speichert das Dashboard-Theme im Cookie. |
 | `/agent/<name>/toggle_active` | POST | Schaltet `controller_active` eines Agents um. |
-| `/agent/<name>/log` | GET | Liefert Logeinträge eines Agents aus der Datenbank. |
+| `/agent/<name>/log` | GET/DELETE | Liefert oder löscht Logeinträge eines Agents aus der Datenbank. |
 | `/stop`, `/restart` | POST | Setzt bzw. entfernt Stop-Flags in der Datenbank. |
 | `/export` | GET | Exportiert Logs und Konfigurationen als ZIP. |
 | `/ui`, `/ui/<pfad>` | GET | Serviert das gebaute Vue-Frontend. |
+| `/controller/status` | GET/DELETE | ControllerAgent-Log einsehen oder leeren. |
 | `/controller/models` | GET/POST | Übersicht und Registrierung von LLM-Modell-Limits. |
 
 Jeder Eintrag in `api_endpoints` enthält die Felder `type`, `url` und eine Liste `models` der verfügbaren LLM-Modelle.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -20,8 +20,8 @@ Das Dashboard nutzt folgende HTTP-Schnittstellen des Controllers sowie des AI-Ag
 | `/agent/config` | GET | Agent-Konfiguration laden. |
 | `/` | POST | Formularaktionen für Pipeline, Tasks oder Templates auslösen. |
 | `/agent/<name>/toggle_active` | POST | Aktiv-Status eines Agents ändern. |
-| `/agent/<name>/log` | GET | Logeinträge eines Agents abrufen. |
-| `/controller/status` | GET | Controller-Log abrufen. |
+| `/agent/<name>/log` | GET/DELETE | Logeinträge eines Agents abrufen oder löschen. |
+| `/controller/status` | GET/DELETE | Controller-Log abrufen oder löschen. |
 | `/stop` | POST | Laufende Agenten stoppen. |
 | `/restart` | POST | `stop.flag` entfernen und Neustart veranlassen. |
 | `/export` | GET | Logs und Konfigurationen als ZIP herunterladen. |

--- a/frontend/src/components/AgentLogViewer.vue
+++ b/frontend/src/components/AgentLogViewer.vue
@@ -8,6 +8,7 @@
           <option v-for="name in agentOptions" :key="name" :value="name">{{ name }}</option>
         </select>
       </label>
+      <button @click="clearLog" data-test="clear-log">Log löschen</button>
     </div>
     <div class="log-container">
       <div v-if="loading">Lade Logs...</div>
@@ -116,6 +117,14 @@ export default {
       } catch (e) {
         console.error('Fehler beim Abrufen der Tasks: ', e);
         this.taskInfo = { current: '', pending: [] };
+      }
+    },
+    async clearLog() {
+      try {
+        await fetch(`/agent/${encodeURIComponent(this.selectedAgent)}/log`, { method: 'DELETE' });
+        this.logs = [];
+      } catch (e) {
+        console.error('Fehler beim Löschen der Logs:', e);
       }
     }
   },

--- a/frontend/src/components/Settings.vue
+++ b/frontend/src/components/Settings.vue
@@ -12,6 +12,7 @@
     <div class="log-section">
       <h3>Logs</h3>
       <button @click="loadControllerLog" data-test="load-log">Load Controller Log</button>
+      <button @click="clearControllerLog" data-test="clear-log">Clear Controller Log</button>
       <pre v-if="controllerLog">{{ controllerLog }}</pre>
     </div>
 
@@ -76,6 +77,15 @@ const loadControllerLog = async () => {
     controllerLog.value = Array.isArray(data) ? data.join('\n') : JSON.stringify(data);
   } catch (err) {
     console.error('Failed to load controller log:', err);
+  }
+};
+
+const clearControllerLog = async () => {
+  try {
+    await fetch('/controller/status', { method: 'DELETE' });
+    controllerLog.value = '';
+  } catch (err) {
+    console.error('Failed to clear controller log:', err);
   }
 };
 

--- a/frontend/tests/AgentLogViewer.spec.js
+++ b/frontend/tests/AgentLogViewer.spec.js
@@ -5,12 +5,15 @@ import AgentLogViewer from '../src/components/AgentLogViewer.vue';
 describe('AgentLogViewer.vue', () => {
   it('lädt Agenten und Logs', async () => {
     vi.useFakeTimers();
-    const fetchMock = vi.fn((url) => {
+    const fetchMock = vi.fn((url, opts) => {
       if (url === '/config') {
         return Promise.resolve({ ok: true, json: () => Promise.resolve({ agents: { default: {}, other: {} } }) });
       }
-      if (url === '/agent/default/log') {
+      if (url === '/agent/default/log' && (!opts || opts.method !== 'DELETE')) {
         return Promise.resolve({ ok: true, text: () => Promise.resolve('2024 INFO test') });
+      }
+      if (url === '/agent/default/log' && opts && opts.method === 'DELETE') {
+        return Promise.resolve({ ok: true });
       }
       if (url === '/agent/default/tasks') {
          return Promise.resolve({ ok: true, json: () => Promise.resolve({ current_task: 'c', tasks: [{ task: 'p' }] }) });
@@ -28,6 +31,11 @@ describe('AgentLogViewer.vue', () => {
     expect(fetchMock).toHaveBeenCalledWith('/agent/default/tasks');
     expect(wrapper.find('.log-entry').text()).toContain('test');
     expect(wrapper.text()).toContain('Aktueller Task: c');
+
+    await wrapper.find('[data-test="clear-log"]').trigger('click');
+    await flushPromises();
+    expect(fetchMock).toHaveBeenCalledWith('/agent/default/log', { method: 'DELETE' });
+    expect(wrapper.findAll('.log-entry').length).toBe(0);
 
     wrapper.unmount();
     global.fetch = originalFetch;

--- a/src/controller/agent.py
+++ b/src/controller/agent.py
@@ -40,3 +40,8 @@ class ControllerAgent(Agent):
         """Return a copy of the internal log."""
 
         return list(self._log)
+
+    def clear_log(self) -> None:
+        """Remove all log entries."""
+
+        self._log.clear()

--- a/src/controller/routes.py
+++ b/src/controller/routes.py
@@ -40,10 +40,13 @@ def blacklist() -> object:
     return jsonify(sorted(controller_agent.blacklist))
 
 
-@bp.route("/status", methods=["GET"])
+@bp.route("/status", methods=["GET", "DELETE"])
 def status() -> object:
-    """Return the controller agent log."""
+    """Return or clear the controller agent log."""
 
+    if request.method == "DELETE":
+        controller_agent.clear_log()
+        return ("", 204)
     return jsonify(controller_agent.log_status())
 
 

--- a/tests/test_controller_agent.py
+++ b/tests/test_controller_agent.py
@@ -21,3 +21,6 @@ def test_assign_task_skips_blacklisted():
     log_copy = agent.log_status()
     log_copy.append("changed")
     assert "changed" not in agent.log_status()
+
+    agent.clear_log()
+    assert agent.log_status() == []

--- a/tests/test_controller_agent_log_endpoint.py
+++ b/tests/test_controller_agent_log_endpoint.py
@@ -1,0 +1,29 @@
+import importlib
+
+from src.db import get_conn
+
+
+def test_delete_agent_log_controller(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://postgres@localhost:5432/ananta")
+    import controller.controller as cc
+    importlib.reload(cc)
+    client = cc.app.test_client()
+    conn = get_conn()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO agent.logs (agent, level, message) VALUES (%s, %s, %s)",
+        ("test", "INFO", "hi"),
+    )
+    conn.commit()
+    cur.close()
+    conn.close()
+
+    resp = client.delete("/agent/test/log")
+    assert resp.status_code == 204
+
+    conn = get_conn()
+    cur = conn.cursor()
+    cur.execute("SELECT * FROM agent.logs WHERE agent='test'")
+    assert cur.fetchall() == []
+    cur.close()
+    conn.close()

--- a/tests/test_controller_routes.py
+++ b/tests/test_controller_routes.py
@@ -36,6 +36,10 @@ def test_next_task_and_blacklist():
     assert "assigned:one" in data
     assert "blacklisted:two" in data
 
+    resp = client.delete("/controller/status")
+    assert resp.status_code == 204
+    assert routes.controller_agent.log_status() == []
+
 
 def test_model_routes():
     app = setup_app()


### PR DESCRIPTION
## Summary
- Allow clearing controller logs via new `DELETE /controller/status` endpoint and `clear_log` method.
- Support deleting agent logs from both controller and AI agent through `DELETE /agent/<name>/log`.
- Add Vue UI controls and tests to load and purge logs for agents and the controller.

## Testing
- `pytest`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894da6a2eac83268d00292c075e8dd3