### PR TITLE
Avoid legacy controller import side effects

### DIFF
--- a/src/controller/__init__.py
+++ b/src/controller/__init__.py
@@ -1,31 +1,21 @@
-"""Task controller package and compatibility layer for the legacy controller.
+"""Light‑weight controller package.
 
-The repository contains a ``controller/controller.py`` module used by
-various tests. To avoid import conflicts, this package mirrors the public
-attributes of that module so ``import controller`` continues to work
-whether the legacy module or this package is picked up first on
-``sys.path``.
+This package previously attempted to mirror the public attributes of the
+legacy :mod:`controller.controller` module by importing it on package
+initialisation.  Importing the legacy module, however, triggers database
+initialisation which makes unit tests that simply need the bundled
+blueprints fail when a database isn't available.  The eager import also
+introduced a circular import when ``controller.controller`` itself tried to
+import :mod:`src.controller.routes`.
+
+To keep imports side‑effect free, the compatibility layer has been removed
+and only the ``ControllerAgent`` is exported here.  The legacy module can
+still be imported directly as ``controller.controller`` where required.
 """
 
 from __future__ import annotations
-
-from pathlib import Path
-import importlib.util
-from types import ModuleType
 
 from .agent import ControllerAgent
 
 __all__ = ["ControllerAgent"]
 
-# Expose symbols from the legacy controller if it exists
-# Path to the legacy module at repository root
-_root = Path(__file__).resolve().parents[2] / "controller" / "controller.py"
-if _root.exists():
-    spec = importlib.util.spec_from_file_location("_legacy_controller", _root)
-    module = importlib.util.module_from_spec(spec)
-    assert spec.loader is not None
-    spec.loader.exec_module(module)  # type: ignore[attr-defined]
-    for name in dir(module):
-        if not name.startswith("_"):
-            globals()[name] = getattr(module, name)
-            __all__.append(name)


### PR DESCRIPTION
## Summary
- streamline `src.controller` package by removing eager import of legacy module
- prevent database initialisation/circular import during package import

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894e0cbebd88326b7bd3e687ffee9bf