### PR TITLE
Add Playwright E2E task test and compose service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,5 +52,21 @@ services:
     volumes:
       - db_data:/var/lib/postgresql/data
 
+  playwright:
+    image: mcr.microsoft.com/playwright:v1.45.0-jammy
+    depends_on:
+      - controller
+      - ai-agent
+      - db
+    environment:
+      - BACKEND_URL=http://controller:8081
+      - AGENT_URL=http://ai-agent:5000
+      - PLAYWRIGHT_BASE_URL=http://controller:8081
+      - PLAYWRIGHT_SKIP_WEBSERVER=1
+    working_dir: /app/frontend
+    volumes:
+      - ./:/app
+    entrypoint: sh -c "npm ci && npx playwright test"
+
 volumes:
   db_data:

--- a/frontend/e2e/tasks.spec.js
+++ b/frontend/e2e/tasks.spec.js
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+
+const backendUrl = process.env.BACKEND_URL || 'http://localhost:8081';
+const agentUrl = process.env.AGENT_URL || 'http://localhost:5000';
+
+test('task creation via UI persists to DB and is processed by ai-agent', async ({ page, request }) => {
+  const task = `e2e-task-${Date.now()}`;
+  const agent = 'Architect';
+
+  await page.goto('/ui/');
+  await page.waitForLoadState('networkidle');
+  await page.click('text=Tasks');
+  await page.fill('input[placeholder="Task"]', task);
+  await page.fill('input[placeholder="Agent (optional)"]', agent);
+  await page.click('text=Add');
+
+  const beforeResp = await request.get(`${backendUrl}/agent/${encodeURIComponent(agent)}/tasks`);
+  expect(beforeResp.ok()).toBeTruthy();
+  const beforeData = await beforeResp.json();
+  expect(beforeData.tasks.some(t => t.task === task)).toBe(true);
+
+  let found = false;
+  for (let i = 0; i < 20; i++) {
+    const logResp = await request.get(`${agentUrl}/agent/${encodeURIComponent(agent)}/log`);
+    if (logResp.ok()) {
+      const text = await logResp.text();
+      if (text.includes(task)) {
+        found = true;
+        break;
+      }
+    }
+    await new Promise(r => setTimeout(r, 1000));
+  }
+  expect(found).toBe(true);
+
+  const afterResp = await request.get(`${backendUrl}/agent/${encodeURIComponent(agent)}/tasks`);
+  expect(afterResp.ok()).toBeTruthy();
+  const afterData = await afterResp.json();
+  expect(afterData.tasks.some(t => t.task === task)).toBe(false);
+});

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -2,13 +2,15 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   testDir: './e2e',
-  webServer: {
-    command: 'npm run dev',
-    port: 5173,
-    reuseExistingServer: !process.env.CI,
-  },
+  webServer: process.env.PLAYWRIGHT_SKIP_WEBSERVER
+    ? undefined
+    : {
+        command: 'npm run dev',
+        port: 5173,
+        reuseExistingServer: !process.env.CI,
+      },
   use: {
-    baseURL: 'http://localhost:5173',
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:5173',
     headless: true,
   },
 });


### PR DESCRIPTION
## Summary
- run e2e tests in Docker Compose via new Playwright service
- allow Playwright config to use env-based base URL and skip dev server
- add task creation test verifying DB persistence and AI agent consumption

## Testing
- `cd frontend && PLAYWRIGHT_SKIP_WEBSERVER=1 PLAYWRIGHT_BASE_URL=http://localhost:8081 npx playwright test e2e/tasks.spec.js` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_6894e85a7a488326bc4ebd9aa1f9f968