### PR TITLE
Centralize database URL configuration

### DIFF
--- a/agent/wait-for-db.py
+++ b/agent/wait-for-db.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 
 import psycopg2
-import os
 import time
 import sys
 import logging
+from pathlib import Path
 
-DATABASE_URL = os.environ.get('DATABASE_URL', 'postgresql://postgres:postgres@db:5432/postgres')
+# Ensure the shared database configuration is importable
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+from db_config import DATABASE_URL
 MAX_RETRIES = 30
 DELAY = 2
 

--- a/src/db.py
+++ b/src/db.py
@@ -1,9 +1,11 @@
-import os
 import json
 import psycopg2
 from psycopg2.extras import Json
 
-DATABASE_URL = os.environ.get("DATABASE_URL", "postgresql://postgres:postgres@db:5432/ananta")
+try:  # Prefer shared configuration if available
+    from .db_config import DATABASE_URL
+except ImportError:  # pragma: no cover - fallback when run as a script
+    from db_config import DATABASE_URL
 
 
 def get_conn():

--- a/src/db_config.py
+++ b/src/db_config.py
@@ -1,0 +1,4 @@
+import os
+
+# Central configuration for database connections
+DATABASE_URL = os.environ.get("DATABASE_URL", "postgresql://postgres:postgres@db:5432/ananta")

--- a/src/db_setup.py
+++ b/src/db_setup.py
@@ -4,11 +4,13 @@
 # Datenbankeinrichtungsskript für das Ananta-System
 
 import psycopg2
-import os
 import time
 import logging
 
-DATABASE_URL = os.environ.get('DATABASE_URL', 'postgresql://postgres:postgres@db:5432/postgres')
+try:  # Use shared configuration so all modules reference the same database
+    from .db_config import DATABASE_URL
+except ImportError:  # pragma: no cover - fallback when executed directly
+    from db_config import DATABASE_URL
 logger = logging.getLogger(__name__)
 
 def wait_for_db(max_retries=30, delay=2):


### PR DESCRIPTION
## Summary
- Move common database URL into `src/db_config.py` for reuse.
- Update `db_setup.py`, `db.py`, and `agent/wait-for-db.py` to import the shared configuration.

## Testing
- `pytest` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689569618dd48326bd4bb6d5482cac71