### PR TITLE
refactor: centralize database schema initialization

### DIFF
--- a/init-db.sql
+++ b/init-db.sql
@@ -7,19 +7,16 @@ CREATE SCHEMA IF NOT EXISTS agent;
 -- Controller Tabellen
 CREATE TABLE IF NOT EXISTS controller.config (
     id SERIAL PRIMARY KEY,
-    data JSONB NOT NULL,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    data JSONB
 );
 
 CREATE TABLE IF NOT EXISTS controller.blacklist (
-    id SERIAL PRIMARY KEY,
-    cmd TEXT UNIQUE NOT NULL,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    cmd TEXT PRIMARY KEY
 );
 
 CREATE TABLE IF NOT EXISTS controller.control_log (
     id SERIAL PRIMARY KEY,
-    received TEXT NOT NULL,
+    received TEXT,
     summary TEXT,
     approved TEXT,
     timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP
@@ -27,31 +24,27 @@ CREATE TABLE IF NOT EXISTS controller.control_log (
 
 CREATE TABLE IF NOT EXISTS controller.tasks (
     id SERIAL PRIMARY KEY,
-    task TEXT NOT NULL,
+    task TEXT,
     agent TEXT,
     template TEXT,
-    status TEXT DEFAULT 'pending',
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    completed_at TIMESTAMP
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
 -- Agent Tabellen
 CREATE TABLE IF NOT EXISTS agent.logs (
     id SERIAL PRIMARY KEY,
-    agent TEXT NOT NULL,
-    level INTEGER NOT NULL,
-    message TEXT NOT NULL,
+    agent TEXT,
+    level TEXT,
+    message TEXT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE TABLE IF NOT EXISTS agent.config (
     id SERIAL PRIMARY KEY,
-    data JSONB NOT NULL,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    data JSONB
 );
 
 CREATE TABLE IF NOT EXISTS agent.flags (
     name TEXT PRIMARY KEY,
-    value TEXT NOT NULL,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    value TEXT
 );

--- a/src/config/manager.py
+++ b/src/config/manager.py
@@ -38,8 +38,7 @@ class ConfigManager:
                     cur.execute("""
                     CREATE TABLE IF NOT EXISTS controller.config (
                         id SERIAL PRIMARY KEY,
-                        data JSONB NOT NULL,
-                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                        data JSONB
                     )
                     """)
                     conn.commit()
@@ -78,8 +77,7 @@ class ConfigManager:
                 cur.execute("""
                 CREATE TABLE IF NOT EXISTS controller.config (
                     id SERIAL PRIMARY KEY,
-                    data JSONB NOT NULL,
-                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                    data JSONB
                 )
                 """)
                 conn.commit()

--- a/src/db.py
+++ b/src/db.py
@@ -1,6 +1,4 @@
-import json
 import psycopg2
-from psycopg2.extras import Json
 
 try:  # Prefer shared configuration if available
     from .db_config import DATABASE_URL
@@ -12,89 +10,78 @@ def get_conn():
     return psycopg2.connect(DATABASE_URL)
 
 
+SCHEMA_STATEMENTS = [
+    "CREATE SCHEMA IF NOT EXISTS controller",
+    "CREATE SCHEMA IF NOT EXISTS agent",
+]
+
+TABLE_STATEMENTS = [
+    """
+    CREATE TABLE IF NOT EXISTS controller.config (
+        id SERIAL PRIMARY KEY,
+        data JSONB
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS controller.tasks (
+        id SERIAL PRIMARY KEY,
+        task TEXT,
+        agent TEXT,
+        template TEXT,
+        created_at TIMESTAMP DEFAULT now()
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS controller.logs (
+        id SERIAL PRIMARY KEY,
+        agent TEXT,
+        level TEXT,
+        message TEXT,
+        created_at TIMESTAMP DEFAULT now()
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS controller.blacklist (
+        cmd TEXT PRIMARY KEY
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS controller.control_log (
+        id SERIAL PRIMARY KEY,
+        received TEXT,
+        summary TEXT,
+        approved TEXT,
+        timestamp TIMESTAMP DEFAULT now()
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS agent.logs (
+        id SERIAL PRIMARY KEY,
+        agent TEXT,
+        level TEXT,
+        message TEXT,
+        created_at TIMESTAMP DEFAULT now()
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS agent.config (
+        id SERIAL PRIMARY KEY,
+        data JSONB
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS agent.flags (
+        name TEXT PRIMARY KEY,
+        value TEXT
+    )
+    """,
+]
+
+
 def init_db():
-    conn = get_conn()
-    cur = conn.cursor()
-    # create schemas
-    cur.execute("CREATE SCHEMA IF NOT EXISTS controller")
-    cur.execute("CREATE SCHEMA IF NOT EXISTS agent")
-    # controller tables
-    cur.execute(
-        """
-        CREATE TABLE IF NOT EXISTS controller.config (
-            id SERIAL PRIMARY KEY,
-            data JSONB
-        )
-        """
-    )
-    cur.execute(
-        """
-        CREATE TABLE IF NOT EXISTS controller.tasks (
-            id SERIAL PRIMARY KEY,
-            task TEXT,
-            agent TEXT,
-            template TEXT,
-            created_at TIMESTAMP DEFAULT now()
-        )
-        """
-    )
-    cur.execute(
-        """
-        CREATE TABLE IF NOT EXISTS controller.logs (
-            id SERIAL PRIMARY KEY,
-            agent TEXT,
-            level TEXT,
-            message TEXT,
-            created_at TIMESTAMP DEFAULT now()
-        )
-        """
-    )
-    cur.execute(
-        """
-        CREATE TABLE IF NOT EXISTS controller.blacklist (
-            cmd TEXT PRIMARY KEY
-        )
-        """
-    )
-    cur.execute(
-        """
-        CREATE TABLE IF NOT EXISTS controller.control_log (
-            id SERIAL PRIMARY KEY,
-            received TEXT,
-            summary TEXT,
-            approved TEXT,
-            timestamp TIMESTAMP DEFAULT now()
-        )
-        """
-    )
-    # agent tables
-    cur.execute(
-        """
-        CREATE TABLE IF NOT EXISTS agent.logs (
-            id SERIAL PRIMARY KEY,
-            agent TEXT,
-            level TEXT,
-            message TEXT,
-            created_at TIMESTAMP DEFAULT now()
-        )
-        """
-    )
-    cur.execute(
-        """
-        CREATE TABLE IF NOT EXISTS agent.config (
-            id SERIAL PRIMARY KEY,
-            data JSONB
-        )
-        """
-    )
-    cur.execute(
-        """
-        CREATE TABLE IF NOT EXISTS agent.flags (
-            name TEXT PRIMARY KEY,
-            value TEXT
-        )
-        """
-    )
-    conn.commit()
-    cur.close()
-    conn.close()
+    """Create required schemas and tables for controller and agent."""
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            for stmt in SCHEMA_STATEMENTS + TABLE_STATEMENTS:
+                cur.execute(stmt)
+        conn.commit()


### PR DESCRIPTION
## Summary
- consolidate schema creation into `init_db` with shared statements
- simplify db setup script to wait for DB and call `init_db`
- align SQL bootstrap and config manager with unified table definitions

## Testing
- `PGPASSWORD=postgres pytest` *(fails: tests/test_add_task_endpoint.py::test_add_task_and_next - TypeError: 'NoneType' object is not subscriptable, tests/test_agent_config_endpoint.py::test_agent_config_endpoint - assert 404 == 200, tests/test_ai_agent_log_endpoint.py::test_log_endpoint_serves_buffer - urllib.error.HTTPError: HTTP Error 404: NOT FOUND, tests/test_ai_agent_log_endpoint.py::test_delete_log_endpoint - urllib.error.HTTPError: HTTP Error 404: NOT FOUND, tests/test_approve_endpoint.py::test_approve_writes_log_and_blacklist - assert 404 == 200, tests/test_update_active_agent.py::test_update_active_agent - assert 404 == 200, tests/test_update_api_endpoints.py::test_update_api_endpoints - assert 404 == 200)`

------
https://chatgpt.com/codex/tasks/task_e_68956a8d3758832697a64c90748945b0