### PR TITLE
Align controller and agent APIs with docs

### DIFF
--- a/frontend/src/components/Endpoints.vue
+++ b/frontend/src/components/Endpoints.vue
@@ -132,13 +132,19 @@ const deleteEndpoint = async (index) => {
 
 const persistEndpoints = async () => {
   try {
-    await fetch('/config/api_endpoints', {
+    const resp = await fetch('/config/api_endpoints', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ api_endpoints: endpoints.value })
     });
-  } catch (error) {
-    console.error('Failed to save endpoints:', error);
+    if (!resp.ok) {
+      const text = typeof resp.text === 'function' ? await resp.text() : '';
+      throw new Error(text);
+    }
+    error.value = '';
+  } catch (err) {
+    console.error('Failed to save endpoints:', err);
+    error.value = 'Fehler beim Speichern';
   }
 };
 

--- a/src/controller/routes.py
+++ b/src/controller/routes.py
@@ -1,4 +1,11 @@
-"""HTTP routes exposing controller functionality."""
+"""Additional controller routes and ControllerAgent hooks.
+
+This module defines the blueprint used by ``controller/controller.py``.  The
+implementation was previously cluttered with duplicate blueprint definitions and
+test endpoints that were not part of the documented API.  The rewritten module
+exposes only the routes described in the documentation: ``next-task``,
+``blacklist``, ``status`` and ``models``.
+"""
 
 from __future__ import annotations
 
@@ -7,15 +14,15 @@ from flask import Blueprint, jsonify, request
 from .agent import ControllerAgent
 from ..models import ModelPool
 
+# ControllerAgent instance managing internal tasks/blacklist/logs
 controller_agent = ControllerAgent(
-    name="controller",
-    model="none",
-    prompt_template="",
-    config_path="",
+    name="controller", model="none", prompt_template="", config_path=""
 )
 
+# Blueprint registered by ``controller/controller.py``
 bp = Blueprint("controller", __name__, url_prefix="/controller")
 
+# ModelPool used to track concurrency limits for provider/model combinations
 model_pool = ModelPool()
 
 
@@ -30,25 +37,7 @@ def next_task() -> object:
 @bp.route("/blacklist", methods=["GET", "POST"])
 def blacklist() -> object:
     """Get or update the blacklist."""
-import logging
-from flask import Blueprint, request, jsonify
 
-bp = Blueprint('controller', __name__, url_prefix='/controller')
-logger = logging.getLogger(__name__)
-
-@bp.route('/hello')
-def hello():
-    """Einfacher Test-Endpunkt."""
-    return jsonify({"message": "Hello from controller blueprint!"})
-
-@bp.route('/status')
-def get_status():
-    """Gibt den aktuellen Status des Controllers zurück."""
-    return jsonify({
-        "status": "running",
-        "version": "1.0.0",
-        "timestamp": "2025-08-08T06:30:00"
-    })
     if request.method == "POST":
         data = request.get_json(silent=True) or {}
         entry = data.get("task")
@@ -82,3 +71,7 @@ def models() -> object:
             return ("", 204)
         return ("", 400)
     return jsonify(model_pool.status())
+
+
+__all__ = ["bp"]
+


### PR DESCRIPTION
## Summary
- Clean controller blueprint by removing duplicate routes and exposing only documented endpoints
- Provide a `create_app` helper in the AI agent with health, task, log and control routes
- Improve Vue endpoint editor to surface save errors

## Testing
- `python -m pytest` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895d081cc40832691c5c00b8419bad7