### PR TITLE
Add documentation TODO list

### DIFF
--- a/todo.json
+++ b/todo.json
@@ -1,0 +1,28 @@
+{
+  "todos": [
+    {
+      "task": "Create UML diagrams and add them under architektur/uml/ with references in architektur/README.md",
+      "role": "architect"
+    },
+    {
+      "task": "Add backend overview by creating src/README.md and updating root README link",
+      "role": "back-end developer"
+    },
+    {
+      "task": "Extend dashboard documentation with environment setup details and API examples",
+      "role": "front-end developer"
+    },
+    {
+      "task": "Review and standardize documentation; remove duplicate sections in root README",
+      "role": "fullstack reviewer"
+    },
+    {
+      "task": "Document test environment and Docker instructions for Playwright tests including RUN_TESTS variable",
+      "role": "devop"
+    },
+    {
+      "task": "Draft a product roadmap and include high-level objectives in root documentation",
+      "role": "product owner"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- evaluate documentation and add repo-wide TODO list for Scrum roles

## Testing
- `python -m unittest` *(fails: No module named 'psycopg2')*
- `npm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_689774975e048326a3cc0c4da7a3b8a9