### PR TITLE
docs: update architecture and testing documentation

### DIFF
--- a/README-TESTS.md
+++ b/README-TESTS.md
@@ -2,6 +2,10 @@
 
 Es gibt drei Möglichkeiten, die E2E-Tests auszuführen:
 
+## Testumgebung
+
+Die Playwright-Tests setzen eine funktionierende Node.js-Umgebung (>=18) voraus. Für reproduzierbare Ergebnisse empfiehlt sich die Nutzung der bereitgestellten Docker-Container.
+
 ## 1. Tests im Controller-Service ausführen
 
 Setze die Umgebungsvariable `RUN_TESTS=true` im Controller-Service in der docker-compose.yml:
@@ -49,3 +53,7 @@ Für die Fehlersuche bei den Tests kannst du:
 1. Die Logausgabe des Containers überprüfen
 2. Die Umgebungsvariable `DEBUG=pw:api` setzen, um detaillierte Playwright-Logs zu erhalten
 3. Bei lokaler Ausführung mit `PWDEBUG=1` den Playwright-Inspector nutzen
+
+## Docker-Hinweis
+
+Sowohl der Controller- als auch der Playwright-Service basieren auf dem offiziellen Playwright-Image und bringen alle benötigten Browser mit. Nach Abschluss der Tests können Container mit `docker-compose down` entfernt werden.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # Ananta
-# Ananta System
 
-Ein modulares Multi-Agent-System für AI-gestützte Entwicklung.
+Ein modulares Multi-Agent-System für AI-gestützte Entwicklung. Persistente Daten wie Konfigurationen, Aufgaben, Logs und Steuerflags werden in PostgreSQL gespeichert.
 
-## Komponenten
+## High-Level Objectives
 
-- **Controller**: Flask-basierter Server zur Verwaltung von Konfigurationen und Aufgaben
-- **AI-Agent**: Python-Agent zur Bearbeitung von Aufgaben mit LLM-Integration
-- **Frontend**: Vue 3-basiertes Dashboard
+- Document core architecture and establish coding conventions.
+- Deliver a usable dashboard with environment setup guidance.
+- Automate testing and deployment workflows.
+
+Weitere Details siehe [Product Roadmap](docs/roadmap.md).
 
 ## Quickstart
 
@@ -21,21 +22,11 @@ docker-compose logs -f
 
 ## Struktur
 
-- `agent/`: Enthält den AI-Agent-Code
-- `controller/`: Controller-Implementierung
-- `frontend/`: Vue-Frontend (wird im Docker-Build kompiliert)
-- `architektur/`: Dokumentation der Systemarchitektur
-
-## Fehlersuche
-
-Falls Fehler beim Starten der Container auftreten, überprüfen Sie:
-
-1. Sind alle benötigten Dateien vorhanden (insbesondere im Pfad `agent/ai_agent.py`)?
-2. Stimmen die Pfade im Dockerfile mit der tatsächlichen Projektstruktur überein?
-3. Sind die Umgebungsvariablen korrekt gesetzt?
-
-Siehe auch die README-Dateien in den jeweiligen Unterverzeichnissen für mehr Details.
-Ananta ist ein modulares Multi-Agenten-System mit einem Flask-basierten Controller, einem Python-Agenten und einem Vue-Dashboard. Persistente Daten wie Konfigurationen, Aufgaben, Logs und Steuerflags werden vollständig in einer PostgreSQL-Datenbank gespeichert.
+- `agent/` – AI-Agent-Code
+- `controller/` – Controller-Implementierung
+- `frontend/` – Vue-Frontend (wird im Docker-Build kompiliert)
+- `architektur/` – Dokumentation der Systemarchitektur
+- `src/` – Backend-Quellcode und Hilfsmodule
 
 ## Komponenten
 
@@ -126,8 +117,19 @@ Ananta ist ein modulares Multi-Agenten-System mit einem Flask-basierten Controll
 - Python-Tests: `python -m unittest`
 - Playwright-E2E-Tests: `npm test`
 
+## Fehlersuche
+
+Falls Fehler beim Starten der Container auftreten, überprüfen Sie:
+
+1. Sind alle benötigten Dateien vorhanden (insbesondere im Pfad `agent/ai_agent.py`)?
+2. Stimmen die Pfade im Dockerfile mit der tatsächlichen Projektstruktur überein?
+3. Sind die Umgebungsvariablen korrekt gesetzt?
+
+Siehe auch die README-Dateien in den jeweiligen Unterverzeichnissen für mehr Details.
+
 ## Weitere Dokumentation
 
 - [src/README.md](src/README.md) – Übersicht über den Backend-Code.
 - [frontend/README.md](frontend/README.md) – Nutzung des Vue-Dashboards.
 - [docs/dashboard.md](docs/dashboard.md) – Architektur und zentrale API-Endpunkte des Dashboards.
+- [docs/roadmap.md](docs/roadmap.md) – Produkt-Roadmap und Ziele.

--- a/architektur/README.md
+++ b/architektur/README.md
@@ -125,16 +125,11 @@ Das System bietet eine Vielzahl von HTTP-Endpunkten, die zentral sowohl für die
 
 ## UML-Diagramme und weitere Beschreibungen
 
-Für eine grafische Darstellung der Systemarchitektur wird empfohlen, ergänzend UML-Diagramme zu erstellen. Vorschläge:
+Zur besseren Veranschaulichung sind die UML-Diagramme unter `architektur/uml/` abgelegt. Aktuell vorhanden:
 
-- **Komponentendiagramm:**
-  Visualisiert die Hauptmodule (Controller, AI-Agent, Frontend) und deren Interaktionen.
-- **Sequenzdiagramm:**
-  Zeigt den Ablauf von Konfigurationsabfragen, Prompt-Generierung, LLM-Kommunikation und Auftragserfüllung.
-- **Klassendiagramm:**
-  Beschreibt die Beziehungen innerhalb der Python-Module wie `ModelPool`, `PromptTemplates` und Agenten-spezifischen Klassen.
+- [Systemübersicht](uml/system-overview.mmd) – zeigt die Interaktionen zwischen Controller, AI-Agent und Vue-Dashboard.
 
-Diese Diagramme können in einem Unterordner, beispielsweise `architektur/uml/`, abgelegt werden. Für eine bessere Übersicht sollten jeweils auch kurze Beschreibungen zu den Diagrammen in diesem Readme aufgeführt werden.
+Weitere Diagramme, wie Sequenz- oder Klassendiagramme, können hier ergänzt werden. Eine kurze Beschreibung pro Diagramm hilft bei der Einordnung.
 
 ---
 

--- a/architektur/uml/system-overview.mmd
+++ b/architektur/uml/system-overview.mmd
@@ -1,0 +1,11 @@
+```mermaid
+graph TD
+    Controller[Controller]
+    Agent[AI-Agent]
+    Frontend[Vue-Dashboard]
+
+    Agent -->|polls tasks| Controller
+    Controller -->|serves API| Frontend
+    Frontend -->|sends commands| Controller
+    Controller -->|delivers config| Agent
+```

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -34,6 +34,28 @@ Dieses Dokument fasst die Gesamtarchitektur des Ananta-Dashboards zusammen und l
 
 Jeder Eintrag in `api_endpoints` enthält die Felder `type`, `url` und eine Liste `models` der verfügbaren LLM-Modelle.
 
+## Environment Setup
+
+```bash
+# install dependencies
+npm install
+
+# set environment variables
+cp .env.example .env   # adjust API URL if needed
+```
+
+Der Entwicklungsserver läuft auf `http://localhost:5173` und erwartet, dass der Controller unter `http://localhost:8081` erreichbar ist.
+
+## API Examples
+
+```bash
+# fetch controller config
+curl http://localhost:8081/config
+
+# toggle an agent
+curl -X POST http://localhost:8081/agent/Architect/toggle_active
+```
+
 ## Entwicklungsbefehle
 
 ```bash

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,14 @@
+# Product Roadmap
+
+## Vision
+Provide a modular multi-agent framework that streamlines software development tasks through clear role separation.
+
+## High-Level Objectives
+- Document core architecture and establish coding conventions.
+- Deliver a usable dashboard with environment setup guidance.
+- Automate testing and deployment workflows.
+
+## Milestones
+1. **v0.1** – Baseline architecture and documentation.
+2. **v0.2** – Enhanced dashboard features and backend docs.
+3. **v0.3** – Continuous integration with automated Playwright tests.

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,22 @@
+# Backend Overview
+
+This directory contains the backend components of Ananta.
+
+## Structure
+
+- `agents/` – dataclasses and prompt template utilities.
+- `controller/` – Flask controller agent and HTTP routes.
+- `models/` – model pool and related abstractions.
+- `db/` – database migrations and helpers.
+
+## Getting Started
+
+```bash
+# install dependencies
+pip install -r requirements.txt
+
+# run controller for development
+python -m src.controller.controller
+```
+
+See the root README for overarching project details.

--- a/tasks_history/architect_20250809163406.json
+++ b/tasks_history/architect_20250809163406.json
@@ -1,0 +1,6 @@
+{
+  "role": "architect",
+  "tasks": [
+    "Create UML diagrams and add them under architektur/uml/ with references in architektur/README.md"
+  ]
+}

--- a/tasks_history/back-end_developer_20250809163406.json
+++ b/tasks_history/back-end_developer_20250809163406.json
@@ -1,0 +1,6 @@
+{
+  "role": "back-end developer",
+  "tasks": [
+    "Add backend overview by creating src/README.md and updating root README link"
+  ]
+}

--- a/tasks_history/devop_20250809163406.json
+++ b/tasks_history/devop_20250809163406.json
@@ -1,0 +1,6 @@
+{
+  "role": "devop",
+  "tasks": [
+    "Document test environment and Docker instructions for Playwright tests including RUN_TESTS variable"
+  ]
+}

--- a/tasks_history/front-end_developer_20250809163406.json
+++ b/tasks_history/front-end_developer_20250809163406.json
@@ -1,0 +1,6 @@
+{
+  "role": "front-end developer",
+  "tasks": [
+    "Extend dashboard documentation with environment setup details and API examples"
+  ]
+}

--- a/tasks_history/fullstack_reviewer_20250809163406.json
+++ b/tasks_history/fullstack_reviewer_20250809163406.json
@@ -1,0 +1,6 @@
+{
+  "role": "fullstack reviewer",
+  "tasks": [
+    "Review and standardize documentation; remove duplicate sections in root README"
+  ]
+}

--- a/tasks_history/product_owner_20250809163406.json
+++ b/tasks_history/product_owner_20250809163406.json
@@ -1,0 +1,6 @@
+{
+  "role": "product owner",
+  "tasks": [
+    "Draft a product roadmap and include high-level objectives in root documentation"
+  ]
+}

--- a/todo_next.json
+++ b/todo_next.json
@@ -1,0 +1,32 @@
+{
+  "todos": [
+    {
+      "task": "Refine UML diagrams with sequence details for key workflows",
+      "role": "architect"
+    },
+    {
+      "task": "Document database schema and add ER diagram to architektur/uml/",
+      "role": "back-end developer"
+    },
+    {
+      "task": "Create usage examples for dashboard components, including screenshots",
+      "role": "front-end developer"
+    },
+    {
+      "task": "Cross-check UML diagrams and docs for consistency with codebase",
+      "role": "fullstack reviewer"
+    },
+    {
+      "task": "Develop end-to-end test cases for dashboard features using Playwright",
+      "role": "qa/test engineer"
+    },
+    {
+      "task": "Automate Playwright test setup in CI pipeline",
+      "role": "devop"
+    },
+    {
+      "task": "Break down roadmap objectives into user stories for the next sprint",
+      "role": "product owner"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add UML system overview and reference in architecture docs
- provide backend overview and extend dashboard and testing guides
- introduce product roadmap and create follow-up task lists with history

## Testing
- `pytest` *(fails: module 'agent.ai_agent' has no attribute 'create_app')*
- `npm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_689777ebcfc08326bcd0584568cbfe17