### PR TITLE
docs: describe per-role task history format

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ docker-compose logs -f
 - `frontend/` – Vue-Frontend (wird im Docker-Build kompiliert)
 - `architektur/` – Dokumentation der Systemarchitektur
 - `src/` – Backend-Quellcode und Hilfsmodule
+- `tasks_history/` – Aufgabenhistorie pro Rolle
 
 ## Komponenten
 
@@ -40,6 +41,7 @@ docker-compose logs -f
 - Stellt eigene Routen (`/health`, `/logs`, `/tasks`, `/stop`, `/restart`) bereit.
 - Nutzt `ModelPool`, um gleichzeitige Modellanfragen pro Provider/Modell zu begrenzen.
 - Schreibt eigene Einstellungen und Laufzeit-Logs in das Schema `agent` der Datenbank.
+- Speichert Aufgabenverläufe in `tasks_history/<rolle>.json` (JSON-Array mit `task` und `date`).
 
 ### Frontend (`frontend/`)
 - Vue-Dashboard zur Anzeige von Logs und Steuerung der Agenten.

--- a/agent/README.md
+++ b/agent/README.md
@@ -20,6 +20,12 @@ Der Python-basierte Agent pollt den Controller periodisch und führt erhaltene A
 | `/stop`   | POST    | setzt ein Stop-Flag in der Datenbank           |
 | `/restart`| POST    | entfernt das Stop-Flag                         |
 
+## Aufgabenhistorie
+
+Für jede Agentenrolle führt der AI-Agent eine Datei unter `tasks_history/<rolle>.json`.
+Die Datei besteht aus einem JSON-Array, dessen Einträge jeweils `task` und `date` enthalten.
+Bei neuen Aufgaben fügt der Agent einen Eintrag mit aktuellem Zeitstempel hinzu.
+
 ## Umgebungsvariablen
 
 Alle Werte sind Platzhalter und müssen an die eigene Umgebung angepasst werden:

--- a/tasks_history/README.md
+++ b/tasks_history/README.md
@@ -1,0 +1,13 @@
+# Task History
+
+Each file in this directory is named after the corresponding agent role (e.g., `architect.json`).
+
+Files contain a JSON array where each element records a single task:
+
+```json
+[
+  { "task": "Description of work", "date": "2025-08-09T16:34:06Z" }
+]
+```
+
+The AI agent appends new entries with the current timestamp to track completed tasks per role.

--- a/tasks_history/architect.json
+++ b/tasks_history/architect.json
@@ -1,0 +1,6 @@
+[
+  {
+    "task": "Create UML diagrams and add them under architektur/uml/ with references in architektur/README.md",
+    "date": "2025-08-09T16:34:06Z"
+  }
+]

--- a/tasks_history/architect_20250809163406.json
+++ b/tasks_history/architect_20250809163406.json
@@ -1,6 +1,0 @@
-{
-  "role": "architect",
-  "tasks": [
-    "Create UML diagrams and add them under architektur/uml/ with references in architektur/README.md"
-  ]
-}

--- a/tasks_history/back-end_developer.json
+++ b/tasks_history/back-end_developer.json
@@ -1,0 +1,6 @@
+[
+  {
+    "task": "Add backend overview by creating src/README.md and updating root README link",
+    "date": "2025-08-09T16:34:06Z"
+  }
+]

--- a/tasks_history/back-end_developer_20250809163406.json
+++ b/tasks_history/back-end_developer_20250809163406.json
@@ -1,6 +1,0 @@
-{
-  "role": "back-end developer",
-  "tasks": [
-    "Add backend overview by creating src/README.md and updating root README link"
-  ]
-}

--- a/tasks_history/devop.json
+++ b/tasks_history/devop.json
@@ -1,0 +1,6 @@
+[
+  {
+    "task": "Document test environment and Docker instructions for Playwright tests including RUN_TESTS variable",
+    "date": "2025-08-09T16:34:06Z"
+  }
+]

--- a/tasks_history/devop_20250809163406.json
+++ b/tasks_history/devop_20250809163406.json
@@ -1,6 +1,0 @@
-{
-  "role": "devop",
-  "tasks": [
-    "Document test environment and Docker instructions for Playwright tests including RUN_TESTS variable"
-  ]
-}

--- a/tasks_history/front-end_developer.json
+++ b/tasks_history/front-end_developer.json
@@ -1,0 +1,6 @@
+[
+  {
+    "task": "Extend dashboard documentation with environment setup details and API examples",
+    "date": "2025-08-09T16:34:06Z"
+  }
+]

--- a/tasks_history/front-end_developer_20250809163406.json
+++ b/tasks_history/front-end_developer_20250809163406.json
@@ -1,6 +1,0 @@
-{
-  "role": "front-end developer",
-  "tasks": [
-    "Extend dashboard documentation with environment setup details and API examples"
-  ]
-}

--- a/tasks_history/fullstack_reviewer.json
+++ b/tasks_history/fullstack_reviewer.json
@@ -1,0 +1,6 @@
+[
+  {
+    "task": "Review and standardize documentation; remove duplicate sections in root README",
+    "date": "2025-08-09T16:34:06Z"
+  }
+]

--- a/tasks_history/fullstack_reviewer_20250809163406.json
+++ b/tasks_history/fullstack_reviewer_20250809163406.json
@@ -1,6 +1,0 @@
-{
-  "role": "fullstack reviewer",
-  "tasks": [
-    "Review and standardize documentation; remove duplicate sections in root README"
-  ]
-}

--- a/tasks_history/product_owner.json
+++ b/tasks_history/product_owner.json
@@ -1,0 +1,6 @@
+[
+  {
+    "task": "Draft a product roadmap and include high-level objectives in root documentation",
+    "date": "2025-08-09T16:34:06Z"
+  }
+]

--- a/tasks_history/product_owner_20250809163406.json
+++ b/tasks_history/product_owner_20250809163406.json
@@ -1,6 +1,0 @@
-{
-  "role": "product owner",
-  "tasks": [
-    "Draft a product roadmap and include high-level objectives in root documentation"
-  ]
-}


### PR DESCRIPTION
## Summary
- rename task history files to per-role JSON arrays and add README for format
- document per-role task storage in top-level README and agent/README

## Testing
- `python -m unittest`
- `npm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68977c3716bc83268cb9153ed753b9ad