### PR TITLE
feat: robust task detection and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,10 +140,13 @@ Für CI-Pipelines empfehlen wir:
   Response: {"active": false}
 
 - GET /agent/<name>/tasks
-  Response: {"tasks": ["t1", "t2"]}
+  Response: {"tasks": [{"id": 1, "task": "t1", "agent": "alice", "template": null}]}
+
+- GET /tasks/next?agent=<name>
+  Response: {"task": "t1"} oder {"task": null}
 
 - GET /next-config
-  Response: {"tasks": ["t1"], "templates": {}}
+  Response: {"agent": null, "api_endpoints": [], "prompt_templates": {}}
 
 Sicherheit:
 - Eingaben werden validiert (Typen, Längenbeschränkungen, Paginierung).

--- a/frontend/e2e/tasks.spec.js
+++ b/frontend/e2e/tasks.spec.js
@@ -68,8 +68,12 @@ async function isTaskPresentForAgent(request, agent, task) {
 
     if (!list) return false;
 
-    const byAgent = list.filter((t) => !t.agent || t.agent === agent);
+    const byAgent = list.filter((t) => {
+      if (typeof t === 'string') return true;
+      return !t.agent || t.agent === agent;
+    });
     return byAgent.some((t) => {
+      if (typeof t === 'string') return t === task;
       const candidates = [t.task, t.description, t.name].filter(Boolean);
       return candidates.includes(task);
     });

--- a/tests/test_controller_tasks.py
+++ b/tests/test_controller_tasks.py
@@ -21,14 +21,14 @@ class ControllerTasksTests(unittest.TestCase):
         # List tasks
         res = self.app.get("/agent/default/tasks")
         self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.get_json()["tasks"], ["t1"])  # controller stores plain strings
+        tasks = res.get_json()["tasks"]
+        self.assertEqual(len(tasks), 1)
+        self.assertEqual(tasks[0]["task"], "t1")
 
-        # next-config should pop the task
-        nc = self.app.get("/next-config")
-        self.assertEqual(nc.status_code, 200)
-        data = nc.get_json()
-        self.assertIn("tasks", data)
-        self.assertEqual(data["tasks"], ["t1"])  # returned then removed
+        # Pop the task via /tasks/next
+        nxt = self.app.get("/tasks/next?agent=default")
+        self.assertEqual(nxt.status_code, 200)
+        self.assertEqual(nxt.get_json()["task"], "t1")
 
         # After pop, list should be empty again
         res2 = self.app.get("/agent/default/tasks")


### PR DESCRIPTION
## Summary
- handle plain-string task lists in Playwright e2e helper
- clarify /tasks API responses and next-config behavior in README
- align controller unit test with object-based task format

## Testing
- `npm --prefix frontend test` *(fails: AgentLogViewer spec fetch error and missing Pinia context)*
- `python3 -m pytest tests/test_controller_tasks.py -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68af4898af10832682ce13dae60b16d3