### PR TITLE
Add www.ananta.de static website deployment

### DIFF
--- a/.github/workflows/pages-www.yml
+++ b/.github/workflows/pages-www.yml
@@ -1,0 +1,41 @@
+name: Deploy www.ananta.de
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "web/www/**"
+      - ".github/workflows/pages-www.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload static site
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: web/www
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/web/www/README.md
+++ b/web/www/README.md
@@ -1,0 +1,25 @@
+# www.ananta.de
+
+Dieses Verzeichnis enthält die statischen Dateien für die öffentliche Ananta-Webseite.
+
+Deployment:
+
+- Quelle: `web/www/`
+- Workflow: `.github/workflows/pages-www.yml`
+- Ziel: GitHub Pages
+- Gewünschte Domain: `www.ananta.de`
+
+Nach dem Merge muss in GitHub einmalig eingestellt werden:
+
+1. Repository `Settings` → `Pages`
+2. `Build and deployment` → `Source` = `GitHub Actions`
+3. `Custom domain` = `www.ananta.de`
+4. Nach erfolgreicher DNS-Prüfung `Enforce HTTPS` aktivieren
+
+DNS beim Domainanbieter:
+
+```text
+www   CNAME   ananta888.github.io
+```
+
+Bestehende DynDNS-Subdomains bleiben davon unabhängig.

--- a/web/www/assets/site.css
+++ b/web/www/assets/site.css
@@ -1,0 +1,126 @@
+:root {
+  color-scheme: dark;
+  --bg: #070a12;
+  --panel: #101827;
+  --text: #e7edf7;
+  --muted: #9da9bb;
+  --accent: #70e1c8;
+  --accent-2: #8ab4ff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at 20% 20%, rgba(112, 225, 200, 0.18), transparent 30rem),
+    radial-gradient(circle at 80% 10%, rgba(138, 180, 255, 0.16), transparent 28rem),
+    var(--bg);
+  color: var(--text);
+}
+
+.page {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 72px 0;
+}
+
+.hero {
+  padding: 64px;
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: 32px;
+  background: rgba(16, 24, 39, 0.76);
+  box-shadow: 0 24px 90px rgba(0, 0, 0, 0.38);
+}
+
+.eyebrow {
+  margin: 0 0 12px;
+  color: var(--accent);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(3.2rem, 12vw, 8rem);
+  line-height: 0.9;
+}
+
+.claim {
+  max-width: 780px;
+  margin: 28px 0 0;
+  font-size: clamp(1.45rem, 3vw, 2.5rem);
+  line-height: 1.12;
+}
+
+.intro {
+  max-width: 760px;
+  color: var(--muted);
+  font-size: 1.12rem;
+  line-height: 1.65;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  margin-top: 32px;
+}
+
+.actions a {
+  color: var(--bg);
+  background: var(--accent);
+  text-decoration: none;
+  padding: 12px 18px;
+  border-radius: 999px;
+  font-weight: 700;
+}
+
+.actions a + a {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+  margin-top: 18px;
+}
+
+.grid article {
+  padding: 28px;
+  border-radius: 24px;
+  background: rgba(16, 24, 39, 0.72);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.grid h2 {
+  margin: 0 0 12px;
+}
+
+.grid p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+@media (max-width: 760px) {
+  .page {
+    padding: 24px 0;
+  }
+
+  .hero {
+    padding: 32px 24px;
+  }
+
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/web/www/index.html
+++ b/web/www/index.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Ananta</title>
+  <meta name="description" content="Ananta ist ein AI Agent Management System für kontrollierte, nachvollziehbare Softwareentwicklung mit lokalen und externen Workern.">
+  <link rel="stylesheet" href="./assets/site.css">
+</head>
+<body>
+  <main class="page">
+    <section class="hero">
+      <p class="eyebrow">ananta.de</p>
+      <h1>Ananta</h1>
+      <p class="claim">AI Agent Management System für Softwareentwicklung.</p>
+      <p class="intro">
+        Ananta soll KI-gestützte Entwicklung kontrollierbarer machen: mit Hub, Workern,
+        klaren Policies, nachvollziehbaren Tasks und begrenztem Zugriff auf Projektwissen.
+      </p>
+      <div class="actions">
+        <a href="https://github.com/ananta888/ananta">GitHub ansehen</a>
+        <a href="#features">Was es zeigen soll</a>
+      </div>
+    </section>
+
+    <section id="features" class="grid" aria-label="Ananta Features">
+      <article>
+        <h2>Agenten-Steuerung</h2>
+        <p>Zentrale Verwaltung von Workern, Rollen, Laufumgebungen und Ausführungsmodi.</p>
+      </article>
+      <article>
+        <h2>Kontrollierter Kontext</h2>
+        <p>Projektwissen soll gezielt an passende Worker gegeben werden, nicht blind alles an jedes Modell.</p>
+      </article>
+      <article>
+        <h2>Nachvollziehbare Tasks</h2>
+        <p>Planung, Ausführung, Artefakte, Tests und Review sollen sichtbar und prüfbar bleiben.</p>
+      </article>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Zweck

Legt einen eigenen Webspace im Repository an, der später direkt über `www.ananta.de` per GitHub Pages erreichbar sein soll.

## Änderungen

- Neues Verzeichnis `web/www/` für die statischen Webseiten-Dateien
- Erste einfache Landingpage unter `web/www/index.html`
- Styling unter `web/www/assets/site.css`
- GitHub-Pages-Deployment per GitHub Actions über `.github/workflows/pages-www.yml`
- Dokumentation unter `web/www/README.md`

## Nach dem Merge einmalig manuell nötig

1. Repository `Settings` → `Pages`
2. `Build and deployment` → `Source` = `GitHub Actions`
3. `Custom domain` = `www.ananta.de`
4. DNS beim Domainanbieter setzen:

```text
www   CNAME   ananta888.github.io
```

5. Nach erfolgreicher Prüfung `Enforce HTTPS` aktivieren

Hinweis: Die `CNAME`-Datei konnte über den Connector nicht angelegt werden, daher Custom Domain bitte einmalig in GitHub Pages setzen.