### PR TITLE
feat(pair-media): enable secure public audio and video

### DIFF
--- a/docker/nginx/conf.d/default.conf
+++ b/docker/nginx/conf.d/default.conf
@@ -31,7 +31,7 @@ server {
     # This production edge deliberately supports the public Ananta issuer.
     # A deployment with another profile issuer must provide its own explicit
     # connect-src allowlist instead of widening this policy to arbitrary HTTPS.
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://keycloak.ananta.de ws: wss:;" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://keycloak.ananta.de https://webrtc.ananta.de ws: wss:;" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
     location / {

--- a/docs/ops/public-ananta-test-rendezvous.md
+++ b/docs/ops/public-ananta-test-rendezvous.md
@@ -12,10 +12,13 @@ The public test profile supports early Angular Pair-Dev collaboration tests:
 
 This infrastructure is provided as a limited free test service by Peter Stuiber/ananta.de. It is not a production service, has no SLA, may be reset, rate-limited or disabled, and must not be used for confidential production workloads.
 
-The current strict public adapter enables E2E-encrypted DataChannel payloads
-only. Public audio/video publication stays disabled until the established Pair
-key is connected to browser insertable-stream transforms; DTLS-SRTP alone is
-not represented as application-level E2EE.
+The strict public adapter always protects supported DataChannel payloads with
+Pair E2EE. Public audio/video is an additive v1 extension for newly created v2
+sessions: both browsers must advertise the exact standard transform capability,
+verify the separately signed media contract and complete bilateral consent
+before DROP-first encoded-media transforms receive keys. Old, asymmetric or
+unsupported clients remain data-only. DTLS-SRTP alone is never represented as
+application-level E2EE.
 
 ## Security warning
 
@@ -118,7 +121,7 @@ The rendezvous service (`public-rendezvous/rendezvous/`) is a standalone Flask/G
 | `POST /rendezvous/sessions/join` | Beitreten per Invite-Code ohne bekannte Session-ID |
 | `POST /rendezvous/sessions/<id>/join` | Beitreten per Invite-Code |
 | `GET /rendezvous/sessions/<id>/participants` | Presence für berechtigte Teilnehmer |
-| `GET /rendezvous/sessions/<id>/security/key-packages` | Adressiertes, kurzlebiges Peer-Key-Paket und strikter E2EE-Vertrag |
+| `GET /rendezvous/sessions/<id>/security/key-packages` | Adressiertes, kurzlebiges Peer-Key-Paket, strikter Basisvertrag und gegebenenfalls separat signierter Media-v1-Vertrag |
 | `GET/POST /rendezvous/sessions/<id>/security/key-confirmations` | Undurchsichtige bilaterale Schlüsselbestätigung |
 | `PATCH /rendezvous/sessions/<id>/permissions` | Fail-closed mit HTTP 409 `permission_update_rekey_required` |
 | `DELETE /rendezvous/sessions/<id>` | Session widerrufen (Owner) |
@@ -150,10 +153,13 @@ nonce is not accepted as a replacement for the required bearer token. Angular
 uses OIDC-authenticated HTTP polling at the public `/webrtc/sessions/<id>/signal`
 boundary. Only SDP/ICE metadata passes through that boundary. Chat, view deltas
 and artifacts use the peer-to-peer encrypted DataChannel path. Ordinary video
-and audio publication is deliberately disabled for public Pair sessions until
-the confirmed Pair key is wired into browser Insertable-Streams transforms;
-DTLS-SRTP alone does not satisfy the advertised application-E2EE contract. If
-direct ICE is impossible, the browser may use coturn with short-lived
+and audio use fixed Opus/VP8 slots only when both v2 memberships negotiated the
+separately authority-signed `public_media_security_contract_v1`, both peers
+confirmed it over the Pair-encrypted DataChannel, and standard
+`RTCRtpScriptTransform` workers are installed DROP-first. Missing support,
+one-sided advertisement or any pre-key topology failure leaves the base Pair
+data-only; failures after possible key release close the connection. If direct
+ICE is impossible, the browser may use coturn with short-lived
 credentials; coturn relays encrypted packets and does not receive application
 plaintext. Public sessions never fall back to the local Hub relay.
 

--- a/docs/user/pair-dev-audio-video.md
+++ b/docs/user/pair-dev-audio-video.md
@@ -1,44 +1,80 @@
 # Pair Dev: Audio und Video
 
-Pair Dev verwendet fuer normale Zwei-Personen-Gespraeche den bestehenden
-WebRTC-Pfad. Der Hub bleibt dabei die zentrale Autoritaet fuer Netzwerkprofil,
-Session, Mitgliedschaft und Feature-Freigabe. Audio- und Videodaten werden
-nicht als Worker-Tasks verarbeitet.
+Pair Dev verwendet fuer normale Zwei-Personen-Gespraeche den direkten
+WebRTC-Pfad. Eine private Session wird vom Hub autorisiert. Bei einer
+oeffentlichen v2-Session autorisiert die bestaetigte Public-Pair-Bindung den
+Medienpfad; ein lokaler Hub ist dafuer nicht erforderlich. Audio- und
+Videodaten werden nicht als Worker-Tasks verarbeitet.
 
 ## Voraussetzungen
 
-- Beide Browser sind im Pair-Dev-Bereich mit Keycloak angemeldet. Sie duerfen
-  denselben Keycloak-Account verwenden, muessen dann aber unterschiedliche
+- Beide Browser sind im Pair-Dev-Bereich angemeldet. Bei Public Pair duerfen
+  sie denselben Keycloak-Account verwenden, muessen dann aber unterschiedliche
   lokale P-256-Geraeteschluessel besitzen und eine neu erstellte v2-Session
   verwenden.
 - Beide Browser sind derselben aktiven, nicht widerrufenen Share-Session
   beigetreten.
 - Das aktive Netzwerkprofil verwendet den Transport `webrtc`; ein
   `hub_relay`-Fallback uebertraegt keine Audio- oder Videospuren.
-- Der Hub wurde mit
-  `ANANTA_ORDINARY_MEDIA_PUBLICATION_ENABLED=true` gestartet.
 - Keycloak, Signaling sowie die konfigurierten STUN-/TURN-Dienste sind vom
   jeweiligen Browser erreichbar.
 - Die Seite laeuft ueber HTTPS oder auf `localhost`, damit der Browser
   Mikrofon und Kamera freigeben darf.
 
-Die weitergehenden Flags fuer semantische Bildaufnahme, Speech-Runtime und SFU
+Zusaetzlich gilt fuer **Public Pair**:
+
+- Die Sicherheitsanzeige muss die gegenseitige Geraete- und
+  Schluesselbestaetigung abgeschlossen haben.
+- Beide Browser muessen den von Ananta verwendeten WebRTC-Encoded-Transform
+  unterstuetzen. Fehlt diese Browserfunktion, bleibt Capture geschlossen.
+- Der separate signierte `public_media_security_contract_v1` muss die
+  Medien-Grants, Publikations-Slots und den E2EE-Transform fuer beide Peers
+  bestaetigen. Der bestehende Public-Pair-Basisvertrag bleibt unveraendert auf
+  `bulk`, `control` und `semantic` begrenzt. Die Anwendung akzeptiert keine
+  lokale oder ungesicherte Ersatzfreigabe.
+- Bereits vor dieser Medienversion erstellte Public-Pair-Sessions bleiben
+  absichtlich reine Daten-Sessions. Nach dem Client-Update eine neue Session
+  erstellen und mit dem aktualisierten zweiten Browser erneut beitreten.
+- Das Hub-Flag `ANANTA_ORDINARY_MEDIA_PUBLICATION_ENABLED` wird fuer Public
+  Pair weder benoetigt noch als Autoritaet ausgewertet.
+
+Fuer eine **private Hub-Session** muss der Hub dagegen mit
+`ANANTA_ORDINARY_MEDIA_PUBLICATION_ENABLED=true` gestartet sein. Die
+weitergehenden Flags fuer semantische Bildaufnahme, Speech-Runtime und SFU
 sind fuer einen direkten Zweier-Call nicht erforderlich und bleiben
 standardmaessig deaktiviert.
+
+## Medienverschluesselung bei Public Pair
+
+Vor dem ersten Browser-Capture richtet Ananta fuer die konkrete Session und
+den bestaetigten Gegenueber-Schluessel einen Medien-E2EE-Pfad ein. Audio- und
+Video-Frames werden im sendenden Browser verschluesselt und erst im
+empfangenden Browser wieder entschluesselt. Rendezvous, STUN und TURN erhalten
+keinen Medien-Inhaltsschluessel. Kann der Pfad nicht vollstaendig eingerichtet
+werden oder geht die Sicherheitsbindung verloren, bleiben neue Freigaben
+gesperrt und laufende Public-Pair-Medien werden beendet.
 
 ## Ablauf in der Oberflaeche
 
 1. Im AI-Snake-Fenster `Pair Dev` oeffnen und mit Keycloak anmelden.
 2. Eine Share-Session erstellen oder ihr beitreten und warten, bis die
    WebRTC-Verbindung steht.
-3. Im Medienbereich `Ordinary Audio/Video` aktivieren. Erst die bestaetigte
-   Hub-/Pair-Projektion schaltet die Capture-Schaltflaechen frei.
+3. Im Medienbereich **auf beiden Rechnern bzw. Browsern** `Ordinary
+   Audio/Video` aktivieren. Bei Public Pair bestaetigen beide Seiten damit den
+   schluesselgebundenen Medien-E2EE-Pfad; bei einer privaten Session wird die
+   Hub-Freigabe geprueft. Solange nur eine Seite aktiviert hat, bleibt der
+   Status erwartungsgemaess bei `awaiting-peer`.
 4. `Mikrofon freigeben`, `Kamera freigeben` oder `Bildschirm freigeben`
    bewusst anklicken und die Browserabfrage bestaetigen.
 5. Empfangene Audiospuren erscheinen im Remote-Audio-Player. Empfangene
    Kameras und Bildschirmfreigaben werden als eigene Remote-Videos angezeigt.
 
-Das Oeffnen des Pair-Dev-Bereichs fordert nie selbststaendig Browserrechte an.
+`Bildschirm freigeben` uebertraegt aktuell nur das Bild. Fuer Ton parallel
+`Mikrofon freigeben` verwenden; Browser- oder Systemton der Bildschirmquelle
+wird noch nicht mitgesendet.
+
+Das Oeffnen oder Aktivieren des Pair-Dev-Medienbereichs fordert noch keine
+Browserrechte an.
 Stummschalten, Stoppen und Wechseln einer lokalen Quelle bleiben explizite
 Benutzeraktionen. Das Verlassen bzw. Widerrufen der Session beendet die
 sessiongebundenen lokalen Publikationen.
@@ -52,10 +88,30 @@ sessiongebundenen lokalen Publikationen.
 | `ordinary_media_publication_disabled` | Das Hub-Feature-Flag ist nicht aktiv. Hub mit dem obigen Flag neu erstellen. |
 | `ordinary_media_webrtc_transport_required` | Die Session verwendet keinen direkten WebRTC-Medienpfad. Signaling/STUN/TURN pruefen. |
 | `ordinary_media_session_missing` | Es besteht keine aktive Share-Session. |
+| `public_ordinary_media_e2ee_not_ready` | Die bestaetigte Pair-Sicherheitsbindung oder der Medien-E2EE-Pfad ist noch nicht bereit. |
+| `public_ordinary_media_e2ee_awaiting_security` | Die gegenseitige Pair-Schluesselbestaetigung ist noch nicht abgeschlossen. |
+| `public_ordinary_media_e2ee_awaiting_peer` | Das Gegenueber muss `Ordinary Audio/Video` ebenfalls aktivieren. |
+| `public_ordinary_media_e2ee_negotiating` | Beide Browser haben zugestimmt und richten die Transforms gerade ein. |
+| `public_ordinary_media_e2ee_unavailable` | Der sichere Public-Medienpfad ist in diesem Browser nicht verfuegbar. |
+| `media_e2ee_transform_unsupported` | Der Browser stellt keinen unterstuetzten WebRTC-Encoded-Transform bereit. |
+| `public_media_runtime_unsupported` | Der Browser unterstuetzt den standardisierten `RTCRtpScriptTransform`-Pfad nicht vollstaendig. |
+| `public_media_contract_not_ready` | Der separate signierte Medienvertrag fehlt noch; Sicherheitsbestaetigung abwarten oder mit zwei aktualisierten Browsern eine neue Session erstellen. |
+| `public_media_contract_missing` | Fuer diese Session wurde kein separater signierter Medienvertrag ausgehandelt; mit zwei aktualisierten Browsern eine neue Session erstellen. |
+| `public_media_contract_expired` | Der Public-Medienvertrag ist abgelaufen; eine neue Pair-Session erstellen. |
+| `public_media_transform_not_prepared` | Der WebRTC-Pfad bzw. seine festen E2EE-Medienslots sind noch nicht vorbereitet. |
+| `public_media_peer_consent_pending` | Das Gegenueber muss `Ordinary Audio/Video` ebenfalls aktivieren. |
+| `public_media_peer_activation_pending` | Das Gegenueber muss `Ordinary Audio/Video` ebenfalls aktivieren. |
+| `public_media_transport_closed` | Die direkte WebRTC-Verbindung wurde geschlossen. Fuer Public-Medien eine neue Pair-Session erstellen und auf beiden Seiten erneut aktivieren. |
+| `public_media_fresh_connection_required` | Ein ICE-/Netzwerk-Neustart darf die alten Medienschluessel nicht wiederverwenden. Eine neue Pair-Session erstellen. |
+| `media_e2ee_transform_install_failed` | Der schluesselgebundene Sender- oder Empfaenger-Transform konnte nicht installiert werden. |
+| `media_e2ee_authentication_failed` | Ein empfangener Frame war fuer die aktive Session bzw. Epoche nicht authentisch; der Pfad schliesst fehlersicher. |
 | `microphone_permission_denied` | Die Mikrofonfreigabe wurde im Browser abgelehnt. |
 | `publication_permission_denied` | Kamera- oder Bildschirmfreigabe wurde abgelehnt. |
 | `webrtc_session_not_open` | Die Medienfreigabe wurde vor dem Aufbau der Peer-Verbindung gestartet. |
 
-Die Standardwerte in den Compose-Dateien bleiben absichtlich `false`. Eine
-Aktivierung wird nur an den Hub durchgereicht, niemals an Worker; dadurch
-bleibt die Hub-Worker-Grenze erhalten.
+Die Hub-Feature-Flags in den Compose-Dateien bleiben absichtlich `false`.
+Public Pair schaltet diese Hub-Flags nicht um, sondern verwendet ausschliesslich
+den separaten signierten Medienvertrag und die bestaetigte
+Browser-zu-Browser-Bindung.
+Worker erhalten weiterhin weder die Medienfreigabe noch Audio-/Videodaten;
+dadurch bleibt die Hub-Worker-Grenze erhalten.

--- a/frontend-angular/src/app/features/pair-view/webrtc-media-panel.component.spec.ts
+++ b/frontend-angular/src/app/features/pair-view/webrtc-media-panel.component.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { WebrtcMediaPanelComponent } from './webrtc-media-panel.component';
+
+describe('WebrtcMediaPanelComponent Public Pair reasons', () => {
+  it.each([
+    ['public_ordinary_media_e2ee_not_ready', 'noch nicht bereit'],
+    ['public_ordinary_media_e2ee_awaiting_peer', 'ebenfalls aktivieren'],
+    ['media_e2ee_transform_unsupported', 'unterstützt den benötigten Medien-E2EE-Pfad nicht'],
+    ['public_media_runtime_unsupported', 'standardisierten Public-Medien-E2EE-Pfad'],
+    ['public_media_fresh_connection_required', 'neuen Pair-Session'],
+    ['media_e2ee_authentication_failed', 'konnte nicht authentifiziert werden'],
+    ['ordinary_media_public_authority_offline', 'Public-Pair-Autorität ist nicht erreichbar'],
+  ])('maps %s to an actionable label', (reasonCode, expected) => {
+    expect(new WebrtcMediaPanelComponent().reasonLabel(reasonCode)).toContain(expected);
+  });
+
+  it('keeps unknown codes visible under a Pair-authority fallback label', () => {
+    expect(new WebrtcMediaPanelComponent().reasonLabel('media_e2ee_future_failure'))
+      .toBe('Medienstatus der Pair-Autorität oder des Browsers:');
+  });
+});

--- a/frontend-angular/src/app/features/pair-view/webrtc-media-panel.component.ts
+++ b/frontend-angular/src/app/features/pair-view/webrtc-media-panel.component.ts
@@ -13,6 +13,15 @@ import { WebrtcRemoteVideoComponent } from './webrtc-remote-video.component';
       <p class="notice" role="note">
         Kamera und Mikrofon benötigen HTTPS oder localhost sowie die Browserfreigabe für diese Website.
       </p>
+      @if (publicPair && e2eeProtected) {
+        <p class="notice" role="status" data-testid="public-media-e2ee-ready">
+          Public-Pair-Medien werden vor dem WebRTC-Transport mit sitzungs- und verbindungsgebundenen Schlüsseln verschlüsselt.
+        </p>
+      } @else if (publicPair) {
+        <p class="notice" role="status" data-testid="public-media-e2ee-pending">
+          Public-Pair-Capture bleibt gesperrt, bis beide Browser den Medien-E2EE-Pfad bestätigt haben.
+        </p>
+      }
       @if (!captureEnabled || !videoCaptureEnabled) {
         <p role="note">{{ reasonLabel(captureReason) }} <code>{{ captureReason }}</code></p>
       }
@@ -84,6 +93,8 @@ import { WebrtcRemoteVideoComponent } from './webrtc-remote-video.component';
 export class WebrtcMediaPanelComponent {
   @Input() captureEnabled = false;
   @Input() videoCaptureEnabled = false;
+  @Input() publicPair = false;
+  @Input() e2eeProtected = false;
   @Input() captureReason = 'ordinary_media_capture_not_authorized';
   @Input() audioState: OrdinaryAudioState = {
     status: 'idle', trackId: null, deviceLabelVisible: false, reasonCode: null,
@@ -125,18 +136,47 @@ export class WebrtcMediaPanelComponent {
 
   reasonLabel(reasonCode: string): string {
     return ({
-      ordinary_media_activation_required: 'Audio/Video muss zuerst beim Hub aktiviert werden.',
-      ordinary_media_capture_not_authorized: 'Der Hub hat die Medienaufnahme nicht freigegeben.',
+      ordinary_media_activation_required: 'Audio/Video muss zuerst bei der Pair-Autorität aktiviert werden.',
+      ordinary_media_capture_not_authorized: 'Die Pair-Autorität hat die Medienaufnahme nicht freigegeben.',
       ordinary_media_publication_disabled: 'Ordinary Media ist in diesem Netzwerkprofil deaktiviert.',
       ordinary_media_webrtc_transport_required: 'Die direkte WebRTC-Verbindung ist noch nicht verfügbar.',
       ordinary_media_session_missing: 'Es ist noch keine aktive Pair-Session ausgewählt.',
       ordinary_media_hub_offline: 'Der Hub ist nicht erreichbar; neue Medienfreigaben sind gesperrt.',
+      ordinary_media_public_authority_offline: 'Die Public-Pair-Autorität ist nicht erreichbar.',
+      ordinary_media_activation_stale: 'Die Pair-Session hat sich während der Medienaktivierung geändert.',
+      public_ordinary_media_e2ee_not_ready: 'Die bestätigte Medienverschlüsselung ist noch nicht bereit.',
+      public_ordinary_media_e2ee_awaiting_security: 'Die Pair-Sicherheitsbindung wird noch bestätigt.',
+      public_ordinary_media_e2ee_awaiting_peer: 'Das Gegenüber muss Ordinary Audio/Video ebenfalls aktivieren.',
+      public_ordinary_media_e2ee_negotiating: 'Beide Browser richten den Medien-E2EE-Pfad ein.',
+      public_ordinary_media_e2ee_unavailable: 'Sichere Public-Pair-Medien sind in diesem Browser nicht verfügbar.',
+      public_ordinary_media_e2ee_context_mismatch: 'Der Medien-E2EE-Status gehört nicht zur aktiven Pair-Session.',
+      media_e2ee_transform_unsupported: 'Dieser Browser unterstützt den benötigten Medien-E2EE-Pfad nicht.',
+      media_e2ee_transform_install_failed: 'Der Medien-E2EE-Pfad konnte nicht eingerichtet werden.',
+      public_media_runtime_unsupported: 'Dieser Browser stellt den standardisierten Public-Medien-E2EE-Pfad nicht bereit.',
+      public_media_contract_not_ready: 'Der separate signierte Public-Medienvertrag ist noch nicht verfügbar.',
+      public_media_contract_missing: 'Der separate signierte Public-Medienvertrag fehlt.',
+      public_media_contract_expired: 'Der Public-Medienvertrag ist abgelaufen; eine neue Pair-Session ist erforderlich.',
+      public_media_transform_not_prepared: 'Die WebRTC-Medientransforms sind noch nicht vorbereitet.',
+      public_media_peer_consent_pending: 'Das Gegenüber muss Ordinary Audio/Video ebenfalls aktivieren.',
+      public_media_peer_activation_pending: 'Das Gegenüber muss Ordinary Audio/Video ebenfalls aktivieren.',
+      public_media_transport_closed: 'Die direkte WebRTC-Verbindung wurde geschlossen; für Public-Medien ist eine neue Pair-Session erforderlich.',
+      public_media_fresh_connection_required: 'Die Verbindung muss mit frischen Medienschlüsseln in einer neuen Pair-Session aufgebaut werden.',
+      public_media_security_context_changed: 'Die Pair-Sicherheitsbindung hat sich geändert; Medien wurden beendet.',
+      public_media_opus_unsupported: 'Dieser Browser bietet den ausgehandelten Opus-Audiocodec nicht an.',
+      public_media_vp8_unsupported: 'Dieser Browser bietet den ausgehandelten VP8-Videocodec nicht an.',
+      public_media_topology_invalid: 'Der ausgehandelte Medienpfad stimmt nicht mit den freigegebenen Slots überein.',
+      media_e2ee_worker_failed: 'Der isolierte Medien-E2EE-Prozess ist fehlgeschlagen.',
+      media_e2ee_worker_ack_timeout: 'Der Medien-E2EE-Prozess hat die Einrichtung nicht rechtzeitig bestätigt.',
+      media_e2ee_security_not_ready: 'Die Pair-Sicherheitsbindung ist noch nicht bestätigt.',
+      media_e2ee_peer_binding_missing: 'Der bestätigte Schlüssel des Gegenübers fehlt noch.',
+      media_e2ee_negotiating: 'Der Medien-E2EE-Pfad wird gerade eingerichtet.',
+      media_e2ee_authentication_failed: 'Ein empfangener Medien-Frame konnte nicht authentifiziert werden.',
       microphone_permission_denied: 'Der Browser hat den Mikrofonzugriff abgelehnt.',
       publication_permission_denied: 'Der Browser hat den Kamera- oder Bildschirmzugriff abgelehnt.',
       browser_media_devices_unavailable: 'Dieses Browserfenster kann nicht auf Mediengeräte zugreifen.',
       browser_display_capture_unavailable: 'Dieser Browser unterstützt keine Bildschirmfreigabe.',
-      publication_authorization_expired: 'Die Freigabe des Hubs ist abgelaufen.',
+      publication_authorization_expired: 'Die Medienfreigabe ist abgelaufen.',
       remote_track_unavailable: 'Der entfernte Video-Track ist nicht mehr verfügbar.',
-    } as Record<string, string>)[reasonCode] ?? 'Medienstatus des Hubs oder Browsers:';
+    } as Record<string, string>)[reasonCode] ?? 'Medienstatus der Pair-Autorität oder des Browsers:';
   }
 }

--- a/frontend-angular/src/app/features/voice/semantic-media-program-host.component.spec.ts
+++ b/frontend-angular/src/app/features/voice/semantic-media-program-host.component.spec.ts
@@ -95,6 +95,8 @@ function hostView(): SemanticMediaProgramHostView {
     }],
     online: true,
     hubUrl: 'http://hub.test',
+    ordinaryMediaAuthority: 'hub',
+    ordinaryMediaActivationEnabled: true,
     computeVisible: false,
     compute: {
       contract: { contractId: '', revision: 0, status: 'absent', profile: 'off', delayMs: 5000, roles: {} },

--- a/frontend-angular/src/app/features/voice/semantic-media-program-host.component.ts
+++ b/frontend-angular/src/app/features/voice/semantic-media-program-host.component.ts
@@ -47,6 +47,8 @@ import { WebrtcMediaPublicationService } from '../../services/webrtc-media-publi
         [capabilities]="view.capabilities"
         [online]="view.online"
         [hubUrl]="view.hubUrl"
+        [ordinaryMediaAuthority]="view.ordinaryMediaAuthority"
+        [ordinaryMediaActivationEnabled]="view.ordinaryMediaActivationEnabled"
         [computeVisible]="view.computeVisible"
         [computeContract]="view.compute.contract"
         [computeLocalMeasurement]="view.compute.localMeasurement"

--- a/frontend-angular/src/app/features/voice/semantic-media-program-shell.component.html
+++ b/frontend-angular/src/app/features/voice/semantic-media-program-shell.component.html
@@ -1,6 +1,14 @@
 <section aria-labelledby="semantic-program-title" [attr.data-display-mode]="displayMode">
   <h2 id="semantic-program-title">{{ heading() }}</h2>
-  <p role="status" aria-live="polite">{{ online ? 'Hub erreichbar' : 'Offline – neue Freigaben gesperrt' }}</p>
+  @if (displayMode === 'pair_media' && ordinaryMediaAuthority === 'public') {
+    <p role="status" aria-live="polite">
+      {{ ordinaryMediaActivationEnabled
+        ? 'Public-Pair-Medien können sicher aktiviert werden'
+        : 'Public-Pair-Medien sind noch nicht freigabebereit' }}
+    </p>
+  } @else {
+    <p role="status" aria-live="polite">{{ online ? 'Hub erreichbar' : 'Offline – neue Freigaben gesperrt' }}</p>
+  }
 
   @if (displayMode === 'full') {
     <dl aria-label="Freigabeumfang">
@@ -13,10 +21,18 @@
       <dt>Ordinary-Fallback</dt><dd>{{ scope.ordinaryFallback }}</dd>
     </dl>
   } @else {
-    <p role="note">
-      Der Hub prüft die aktive Pair-Session und die Ordinary-Media-Freigabe. Erst danach fragt der Browser
-      gezielt nach Mikrofon, Kamera oder Bildschirm.
-    </p>
+    @if (ordinaryMediaAuthority === 'public') {
+      <p role="note">
+        Public Pair prüft die bestätigte Gerätebindung und richtet vor der Freigabe den
+        sitzungsgebundenen Medien-E2EE-Pfad ein. Erst danach fragt der Browser gezielt nach
+        Mikrofon, Kamera oder Bildschirm.
+      </p>
+    } @else {
+      <p role="note">
+        Der Hub prüft die aktive Pair-Session und die Ordinary-Media-Freigabe. Erst danach fragt der Browser
+        gezielt nach Mikrofon, Kamera oder Bildschirm.
+      </p>
+    }
   }
 
   <div class="program-grid">
@@ -62,7 +78,7 @@
         }
         <button
           type="button"
-          [disabled]="pending(row) || !online || adapterActivationUnavailable(row.capability)"
+          [disabled]="pending(row) || !activationAvailable(row) || adapterActivationUnavailable(row.capability)"
           (click)="request(row.capability, 'activate')"
           [attr.aria-describedby]="'scope-' + row.capability">
           {{ isSensitive(row.capability) ? 'Einzeln freigeben' : 'Aktivieren' }}
@@ -81,6 +97,8 @@
     <app-webrtc-media-panel
       [captureEnabled]="ordinaryMediaCaptureEnabled"
       [videoCaptureEnabled]="ordinaryMediaVideoCaptureEnabled"
+      [publicPair]="ordinaryMediaAuthority === 'public'"
+      [e2eeProtected]="ordinaryMediaAuthority === 'public' && ordinaryMediaCaptureEnabled && ordinaryMediaVideoCaptureEnabled"
       [captureReason]="ordinaryMediaReason"
       [audioState]="ordinaryAudioState"
       [publications]="ordinaryMediaPublications"

--- a/frontend-angular/src/app/features/voice/semantic-media-program-shell.component.spec.ts
+++ b/frontend-angular/src/app/features/voice/semantic-media-program-shell.component.spec.ts
@@ -162,6 +162,51 @@ describe("SemanticMediaProgramShellComponent", () => {
     ).toContain("Offline");
   });
 
+  it("routes Public Pair ordinary-media activation without treating Hub offline as authority loss", () => {
+    const emitted: any[] = [];
+    fixture.componentInstance.intent.subscribe(value => emitted.push(value));
+    fixture.componentRef.setInput("displayMode", "pair_media");
+    fixture.componentRef.setInput("online", false);
+    fixture.componentRef.setInput("ordinaryMediaAuthority", "public");
+    fixture.componentRef.setInput("ordinaryMediaActivationEnabled", true);
+    fixture.componentRef.setInput("capabilities", [{
+      capability: "ordinary_media", label: "Ordinary Audio/Video", sensitive: false,
+      state: "revoked", requestId: null,
+    }]);
+    fixture.detectChanges();
+
+    const activate = fixture.nativeElement.querySelector('[data-capability="ordinary_media"] button') as HTMLButtonElement;
+    expect(activate.disabled).toBe(false);
+    activate.click();
+    expect(emitted).toEqual([expect.objectContaining({
+      capability: "ordinary_media", desired: "activate",
+    })]);
+    expect(fixture.componentInstance.capabilities[0].state).toBe("sent_to_authority");
+    expect(fixture.nativeElement.textContent).toContain("Public-Pair-Medien können sicher aktiviert werden");
+
+    fixture.componentRef.setInput("capabilities", [{
+      capability: "ordinary_media", label: "Ordinary Audio/Video", sensitive: false,
+      state: "degraded", requestId: null,
+      reasonCode: "public_ordinary_media_e2ee_awaiting_peer",
+    }]);
+    fixture.componentRef.setInput("ordinaryMediaCaptureEnabled", false);
+    fixture.componentRef.setInput("ordinaryMediaVideoCaptureEnabled", false);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain("Capture bleibt gesperrt");
+
+    fixture.componentRef.setInput("capabilities", [{
+      capability: "ordinary_media", label: "Ordinary Audio/Video", sensitive: false,
+      state: "authoritatively_active", requestId: null,
+    }]);
+    fixture.componentRef.setInput("ordinaryMediaCaptureEnabled", true);
+    fixture.componentRef.setInput("ordinaryMediaVideoCaptureEnabled", true);
+    fixture.detectChanges();
+    const panel = fixture.debugElement.query(By.directive(WebrtcMediaPanelComponent));
+    expect((panel.componentInstance as WebrtcMediaPanelComponent).publicPair).toBe(true);
+    expect((panel.componentInstance as WebrtcMediaPanelComponent).e2eeProtected).toBe(true);
+    expect(panel.nativeElement.textContent).toContain("sitzungs- und verbindungsgebundenen Schlüsseln");
+  });
+
   it("mounts reconciliation only after the Hub capability becomes authoritative", () => {
     capabilities.push({
       capability: "speech_reconciliation",

--- a/frontend-angular/src/app/features/voice/semantic-media-program-shell.component.ts
+++ b/frontend-angular/src/app/features/voice/semantic-media-program-shell.component.ts
@@ -43,6 +43,7 @@ import { WebrtcMediaPanelComponent } from '../pair-view/webrtc-media-panel.compo
 export type SemanticProgramState =
   | 'locally_desired'
   | 'sent_to_hub'
+  | 'sent_to_authority'
   | 'authoritatively_active'
   | 'pausing'
   | 'revoked'
@@ -51,6 +52,7 @@ export type SemanticProgramState =
   | 'failed';
 
 export type SemanticMediaProgramDisplayMode = 'full' | 'pair_media';
+export type OrdinaryMediaAuthorityKind = 'hub' | 'public' | 'unbound';
 
 export type SemanticProgramCapability =
   | 'ordinary_media'
@@ -146,6 +148,8 @@ export class SemanticMediaProgramShellComponent {
   @Input({ required: true }) scope!: SemanticProgramScopeView;
   @Input() online = true;
   @Input() hubUrl = '';
+  @Input() ordinaryMediaAuthority: OrdinaryMediaAuthorityKind = 'unbound';
+  @Input() ordinaryMediaActivationEnabled = false;
   @Input() computeVisible = false;
   @Input() computeContract: ComputeContractView = {
     contractId: '', revision: 0, status: 'absent', profile: 'off', delayMs: 5_000, roles: {},
@@ -252,11 +256,15 @@ export class SemanticMediaProgramShellComponent {
 
   request(capability: SemanticProgramCapability, desired: SemanticProgramIntent['desired']): void {
     const row = this.capabilityRows.find(item => item.capability === capability);
-    if (!row || row.requestId || (!this.online && desired === 'activate')) return;
+    if (!row || row.requestId || (!this.activationAvailable(row) && desired === 'activate')) return;
     const requestId = `semantic-program-request-${++this.serial}`;
     row.state = desired === 'activate' ? 'locally_desired' : 'pausing';
     row.requestId = requestId;
-    if (this.online) row.state = 'sent_to_hub';
+    if (this.activationAvailable(row)) {
+      row.state = capability === 'ordinary_media' && this.ordinaryMediaAuthority === 'public'
+        ? 'sent_to_authority'
+        : 'sent_to_hub';
+    }
     else row.state = 'failed';
     const selected = capability === 'adapter_activation'
       ? this.adapterRows.find(value => this.adapterKey(value) === this.selectedAdapterKey)
@@ -278,7 +286,7 @@ export class SemanticMediaProgramShellComponent {
   applyHubState(
     capability: SemanticProgramCapability,
     requestId: string,
-    state: Exclude<SemanticProgramState, 'locally_desired' | 'sent_to_hub'>,
+    state: Exclude<SemanticProgramState, 'locally_desired' | 'sent_to_hub' | 'sent_to_authority'>,
   ): boolean {
     const row = this.capabilityRows.find(item => item.capability === capability);
     if (!row || row.requestId !== requestId) return false;
@@ -293,6 +301,10 @@ export class SemanticMediaProgramShellComponent {
 
   pending(row: SemanticProgramCapabilityView): boolean {
     return row.requestId !== null;
+  }
+
+  activationAvailable(row: Pick<SemanticProgramCapabilityView, 'capability'>): boolean {
+    return row.capability === 'ordinary_media' ? this.ordinaryMediaActivationEnabled : this.online;
   }
 
   adapterActivationUnavailable(capability: SemanticProgramCapability): boolean {

--- a/frontend-angular/src/app/features/voice/semantic-media-program.facade.spec.ts
+++ b/frontend-angular/src/app/features/voice/semantic-media-program.facade.spec.ts
@@ -26,6 +26,8 @@ import { WebrtcMediaSessionService } from '../../services/webrtc-media-session.s
 import { WebrtcMediaPublicationService } from '../../services/webrtc-media-publication.service';
 import { WebrtcTransportService } from '../../services/webrtc-transport.service';
 import { PairOrdinaryMediaPolicy } from '../../services/pair-ordinary-media.policy';
+import { PairMediaE2eeCoordinatorService } from '../../services/pair-media-e2ee-coordinator.service';
+import { PairSessionControlPlaneService } from '../../services/pair-session-control-plane.service';
 import { SemanticComputeIntentFacade } from '../pair-view/semantic-compute-intent.facade';
 import { SemanticMediaProgramFacade } from './semantic-media-program.facade';
 import { PeerEvidenceSyncFacade } from './peer-evidence-sync.facade';
@@ -136,8 +138,28 @@ describe('SemanticMediaProgramFacade', () => {
     stopAudio: vi.fn(), setMuted: vi.fn(),
   };
   const ordinaryMediaPolicy = {
+    canActivate: vi.fn(() => true),
+    assertActivationAllowed: vi.fn(),
     allows: vi.fn(() => true),
     assertAllowed: vi.fn(),
+  };
+  const pairMediaE2eeStatus$ = new BehaviorSubject<any>({
+    sessionId: 'session-a', state: 'ready', contractDigest: 'a'.repeat(64),
+  });
+  const pairMediaE2ee = {
+    status$: pairMediaE2eeStatus$,
+    statusFor: vi.fn(() => pairMediaE2eeStatus$.value),
+    canActivate: vi.fn(() => true),
+    activate: vi.fn(async () => pairMediaE2eeStatus$.value),
+    deactivate: vi.fn(),
+  };
+  const pairControlPlane = {
+    authorityKindForSession: vi.fn<(sessionId: string) => 'hub' | 'public'>(() => 'hub'),
+  };
+  const directory = {
+    list: vi.fn<() => Array<{ role: string; name: string; url: string }>>(
+      () => [{ role: 'hub', name: 'hub', url: 'http://hub.test' }],
+    ),
   };
   const mediaPublications$ = new BehaviorSubject<readonly any[]>([]);
   const mediaPublications = {
@@ -167,12 +189,26 @@ describe('SemanticMediaProgramFacade', () => {
     shareState$.next({ ...shareState$.value, session });
     profile$.next(profile);
     mode$.next('webrtc');
+    sfuState$.next({ status: 'connected' });
     runtimeOnline$.next(true);
     audioState$.next({ status: 'active' });
     mediaPublications$.next([]);
     ordinaryMediaPolicy.allows.mockReset();
     ordinaryMediaPolicy.allows.mockReturnValue(true);
+    ordinaryMediaPolicy.canActivate.mockReset();
+    ordinaryMediaPolicy.canActivate.mockReturnValue(true);
+    ordinaryMediaPolicy.assertActivationAllowed.mockReset();
     ordinaryMediaPolicy.assertAllowed.mockReset();
+    pairControlPlane.authorityKindForSession.mockReset();
+    pairControlPlane.authorityKindForSession.mockReturnValue('hub');
+    directory.list.mockReset();
+    directory.list.mockReturnValue([{ role: 'hub', name: 'hub', url: 'http://hub.test' }]);
+    pairMediaE2eeStatus$.next({
+      sessionId: 'session-a', state: 'ready', contractDigest: 'a'.repeat(64),
+    });
+    pairMediaE2ee.activate.mockReset();
+    pairMediaE2ee.activate.mockImplementation(async () => pairMediaE2eeStatus$.value);
+    pairMediaE2ee.deactivate.mockReset();
     speechRuntime.settings$.next(DEFAULT_SEMANTIC_SPEECH_SETTINGS);
     qualityState$.next({
       mode: 'semantic_reconstruction', reasonCode: 'quality_healthy', transitioned: false,
@@ -183,7 +219,7 @@ describe('SemanticMediaProgramFacade', () => {
     TestBed.configureTestingModule({ providers: [
       SemanticMediaProgramFacade,
       SemanticReceiverPathService,
-      { provide: AgentDirectoryService, useValue: { list: () => [{ role: 'hub', name: 'hub', url: 'http://hub.test' }] } },
+      { provide: AgentDirectoryService, useValue: directory },
       { provide: NetworkProfileService, useValue: { current: profile, profile$, load: vi.fn(async () => undefined) } },
       { provide: ShareSessionService, useValue: { state$: shareState$, currentUserId: 'alice' } },
       { provide: WebrtcTransportService, useValue: { mode$ } },
@@ -209,6 +245,8 @@ describe('SemanticMediaProgramFacade', () => {
       { provide: WebrtcMediaSessionService, useValue: media },
       { provide: WebrtcMediaPublicationService, useValue: mediaPublications },
       { provide: PairOrdinaryMediaPolicy, useValue: ordinaryMediaPolicy },
+      { provide: PairMediaE2eeCoordinatorService, useValue: pairMediaE2ee },
+      { provide: PairSessionControlPlaneService, useValue: pairControlPlane },
       { provide: SpeechReconciliationApiService, useValue: reconciliationApi },
       { provide: SpeechAdapterRegistryApiService, useValue: adapterApi },
     ] });
@@ -287,10 +325,163 @@ describe('SemanticMediaProgramFacade', () => {
     expect(media.stopAudio).toHaveBeenCalledWith('microphone_user_stop');
   });
 
-  it('ignores a malicious media feature flag for a public Pair session', async () => {
+  it('activates key-bound Public Pair media without a Hub URL or Hub feature flag', async () => {
+    directory.list.mockReturnValue([]);
+    pairControlPlane.authorityKindForSession.mockReturnValue('public');
+    runtimeOnline$.next(false);
+    audioState$.next({ status: 'idle', trackId: null, deviceLabelVisible: false, reasonCode: null });
+    sfuState$.next({ status: 'disconnected' });
+    profile$.next({
+      ...profile,
+      profile_id: 'public-ananta',
+      public_rendezvous: true,
+      semantic_media_feature_flags: { ...flags, ordinary_media_publication: false },
+    });
+
+    await facade.handleProgramIntent({
+      capability: 'ordinary_media', desired: 'activate', requestId: 'public-media-ready',
+    });
+
+    expect(pairMediaE2ee.activate).toHaveBeenCalledWith('session-a');
+    expect(facade.view$.value.online).toBe(false);
+    expect(facade.view$.value.ordinaryMediaAuthority).toBe('public');
+    expect(facade.view$.value.ordinaryMediaActivationEnabled).toBe(true);
+    expect(facade.view$.value.ordinaryMediaCaptureEnabled).toBe(true);
+    expect(facade.view$.value.ordinaryMediaVideoCaptureEnabled).toBe(true);
+    expect(facade.view$.value.capabilities.find(row => row.capability === 'ordinary_media')?.state)
+      .toBe('authoritatively_active');
+
+    await facade.startOrdinaryVideo('camera');
+    expect(media.requestMicrophone).not.toHaveBeenCalled();
+    expect(mediaPublications.startLocal).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: 'session-a', source: 'camera', permitted: true }),
+      expect.anything(),
+    );
+    expect(facade.view$.value.capabilities.find(row => row.capability === 'ordinary_media')?.state)
+      .toBe('authoritatively_active');
+
+    await facade.startOrdinaryMicrophone();
+    expect(media.requestMicrophone).toHaveBeenCalled();
+
+    await facade.handleProgramIntent({
+      capability: 'ordinary_media', desired: 'revoke', requestId: 'public-media-revoke',
+    });
+    expect(pairMediaE2ee.deactivate)
+      .toHaveBeenCalledWith('session-a', 'ordinary_media_capability_revoked');
+  });
+
+  it('keeps bilateral Public media activation pending until the peer consents', async () => {
+    directory.list.mockReturnValue([]);
+    pairControlPlane.authorityKindForSession.mockReturnValue('public');
+    profile$.next({
+      ...profile,
+      profile_id: 'public-ananta',
+      public_rendezvous: true,
+      semantic_media_feature_flags: { ...flags, ordinary_media_publication: false },
+    });
+    pairMediaE2eeStatus$.next({ sessionId: 'session-a', state: 'inactive' });
     ordinaryMediaPolicy.allows.mockReturnValue(false);
     ordinaryMediaPolicy.assertAllowed.mockImplementation(() => {
-      throw new Error('public_ordinary_media_e2ee_unavailable');
+      throw new Error('public_ordinary_media_e2ee_awaiting_peer');
+    });
+    pairMediaE2ee.activate.mockImplementation(async () => {
+      const awaitingPeer = { sessionId: 'session-a', state: 'awaiting-peer' };
+      pairMediaE2eeStatus$.next(awaitingPeer);
+      return awaitingPeer;
+    });
+
+    await facade.handleProgramIntent({
+      capability: 'ordinary_media', desired: 'activate', requestId: 'public-media-await-peer',
+    });
+
+    expect(facade.view$.value.capabilities.find(row => row.capability === 'ordinary_media'))
+      .toMatchObject({ state: 'degraded', reasonCode: 'public_ordinary_media_e2ee_awaiting_peer' });
+    expect(facade.view$.value.ordinaryMediaCaptureEnabled).toBe(false);
+
+    ordinaryMediaPolicy.allows.mockReturnValue(true);
+    ordinaryMediaPolicy.assertAllowed.mockReset();
+    pairMediaE2eeStatus$.next({
+      sessionId: 'session-a', state: 'ready', contractDigest: 'a'.repeat(64),
+    });
+
+    expect(facade.view$.value.capabilities.find(row => row.capability === 'ordinary_media')?.state)
+      .toBe('authoritatively_active');
+    expect(facade.view$.value.ordinaryMediaCaptureEnabled).toBe(true);
+  });
+
+  it('does not let a superseded Public activation overwrite an explicit revoke', async () => {
+    directory.list.mockReturnValue([]);
+    pairControlPlane.authorityKindForSession.mockReturnValue('public');
+    profile$.next({
+      ...profile,
+      profile_id: 'public-ananta',
+      public_rendezvous: true,
+      semantic_media_feature_flags: { ...flags, ordinary_media_publication: false },
+    });
+    let resolveActivation!: (state: any) => void;
+    pairMediaE2ee.activate.mockReturnValueOnce(new Promise(resolve => { resolveActivation = resolve; }));
+    const activation = facade.handleProgramIntent({
+      capability: 'ordinary_media', desired: 'activate', requestId: 'public-media-cancelled',
+    });
+    await Promise.resolve();
+
+    await facade.handleProgramIntent({
+      capability: 'ordinary_media', desired: 'revoke', requestId: 'public-media-cancelled',
+    });
+    resolveActivation({ sessionId: 'session-a', state: 'ready', contractDigest: 'a'.repeat(64) });
+    await activation;
+
+    expect(facade.view$.value.capabilities.find(row => row.capability === 'ordinary_media')?.state)
+      .toBe('revoked');
+    expect(pairMediaE2ee.deactivate)
+      .toHaveBeenCalledWith('session-a', 'ordinary_media_capability_revoked');
+  });
+
+  it.each([
+    ['awaiting-security', 'public_ordinary_media_e2ee_awaiting_security', 'degraded'],
+    ['awaiting-peer', 'public_ordinary_media_e2ee_awaiting_peer', 'degraded'],
+    ['negotiating', 'public_ordinary_media_e2ee_negotiating', 'degraded'],
+    ['failed', 'media_e2ee_worker_failed', 'failed'],
+    ['inactive', 'public_ordinary_media_e2ee_not_ready', 'failed'],
+  ])('cleans Public captures exactly once when ready becomes %s', async (state, reasonCode, expectedState) => {
+    directory.list.mockReturnValue([]);
+    pairControlPlane.authorityKindForSession.mockReturnValue('public');
+    profile$.next({
+      ...profile,
+      profile_id: 'public-ananta',
+      public_rendezvous: true,
+      semantic_media_feature_flags: { ...flags, ordinary_media_publication: false },
+    });
+    await facade.handleProgramIntent({
+      capability: 'ordinary_media', desired: 'activate', requestId: 'public-media-before-failure',
+    });
+    media.stopAudio.mockClear();
+    mediaPublications.stopAll.mockClear();
+    ordinaryMediaPolicy.allows.mockReturnValue(false);
+    ordinaryMediaPolicy.assertAllowed.mockImplementation(() => {
+      throw new Error(reasonCode);
+    });
+
+    const unavailable = { sessionId: 'session-a', state, reasonCode };
+    pairMediaE2eeStatus$.next(unavailable);
+    pairMediaE2eeStatus$.next(unavailable);
+
+    expect(media.stopAudio).toHaveBeenCalledTimes(1);
+    expect(media.stopAudio).toHaveBeenCalledWith(reasonCode);
+    expect(mediaPublications.stopAll).toHaveBeenCalledTimes(1);
+    expect(mediaPublications.stopAll).toHaveBeenCalledWith(reasonCode, true);
+    expect(facade.view$.value.capabilities.find(row => row.capability === 'ordinary_media'))
+      .toMatchObject({ state: expectedState, reasonCode });
+  });
+
+  it('fails Public Pair capture closed when the E2EE coordinator is unavailable', async () => {
+    pairControlPlane.authorityKindForSession.mockReturnValue('public');
+    ordinaryMediaPolicy.allows.mockReturnValue(false);
+    ordinaryMediaPolicy.assertActivationAllowed.mockImplementation(() => {
+      throw new Error('media_e2ee_transform_unsupported');
+    });
+    ordinaryMediaPolicy.assertAllowed.mockImplementation(() => {
+      throw new Error('media_e2ee_transform_unsupported');
     });
 
     await facade.handleProgramIntent({
@@ -302,7 +493,8 @@ describe('SemanticMediaProgramFacade', () => {
     expect(facade.view$.value.ordinaryMediaCaptureEnabled).toBe(false);
     expect(facade.view$.value.ordinaryMediaVideoCaptureEnabled).toBe(false);
     expect(facade.view$.value.ordinaryMediaReason)
-      .toBe('public_ordinary_media_e2ee_unavailable');
+      .toBe('media_e2ee_transform_unsupported');
+    expect(pairMediaE2ee.activate).not.toHaveBeenCalled();
     expect(media.requestMicrophone).not.toHaveBeenCalled();
     expect(mediaPublications.startLocal).not.toHaveBeenCalled();
   });
@@ -316,9 +508,11 @@ describe('SemanticMediaProgramFacade', () => {
     });
     expect(mediaPublications.stopAll).toHaveBeenCalledWith('ordinary_media_capability_revoked');
     expect(media.stopAudio).toHaveBeenCalledWith('ordinary_media_capability_revoked');
+    expect(pairMediaE2ee.deactivate).not.toHaveBeenCalled();
 
     shareState$.next({ ...shareState$.value, session: { ...session, id: 'session-b' } });
     expect(mediaPublications.stopAll).toHaveBeenCalledWith('ordinary_media_session_ended', true);
+    expect(pairMediaE2ee.deactivate).not.toHaveBeenCalled();
   });
 
   it('applies pause and ordinary override to transport and ordinary media, not only the panel label', async () => {

--- a/frontend-angular/src/app/features/voice/semantic-media-program.facade.ts
+++ b/frontend-angular/src/app/features/voice/semantic-media-program.facade.ts
@@ -28,6 +28,7 @@ import {
 } from '../../services/semantic-speech-quality-controller.service';
 import { SemanticSfuPathCoordinatorService } from '../../services/semantic-sfu-path-coordinator.service';
 import { ShareSession, ShareSessionService, ActiveShareState } from '../../services/share-session.service';
+import { PairSessionControlPlaneService } from '../../services/pair-session-control-plane.service';
 import {
   SpeechEvidenceConsentDocument,
   SpeechEvidenceConsentReadModel,
@@ -46,6 +47,10 @@ import {
   PUBLIC_ORDINARY_MEDIA_E2EE_UNAVAILABLE,
   PairOrdinaryMediaPolicy,
 } from '../../services/pair-ordinary-media.policy';
+import {
+  PairMediaE2eeCoordinatorService,
+  type PublicPairMediaE2eeState,
+} from '../../services/pair-media-e2ee-coordinator.service';
 import { WebrtcTransportService } from '../../services/webrtc-transport.service';
 import {
   ComputeContractIntent,
@@ -67,6 +72,7 @@ import {
   SemanticProgramCapability,
   SemanticProgramCapabilityView,
   SemanticProgramIntent,
+  OrdinaryMediaAuthorityKind,
   SemanticProgramScopeView,
   SemanticProgramState,
   SpeechAdapterActivationOption,
@@ -82,6 +88,8 @@ export interface SemanticMediaProgramHostView {
   readonly capabilities: readonly SemanticProgramCapabilityView[];
   readonly online: boolean;
   readonly hubUrl: string;
+  readonly ordinaryMediaAuthority: OrdinaryMediaAuthorityKind;
+  readonly ordinaryMediaActivationEnabled: boolean;
   readonly computeVisible: boolean;
   readonly compute: SemanticComputePanelState;
   readonly receiverPaths: readonly SemanticReceiverPathView[];
@@ -135,6 +143,7 @@ export class SemanticMediaProgramFacade implements OnDestroy {
   private readonly directory = inject(AgentDirectoryService);
   private readonly profiles = inject(NetworkProfileService);
   private readonly shares = inject(ShareSessionService);
+  private readonly pairControlPlane = inject(PairSessionControlPlaneService);
   private readonly transport = inject(WebrtcTransportService);
   private readonly peerKeys = inject(WebrtcPeerKeyService);
   private readonly speech = inject(SemanticSpeechTransportService);
@@ -149,6 +158,7 @@ export class SemanticMediaProgramFacade implements OnDestroy {
   private readonly media = inject(WebrtcMediaSessionService);
   private readonly mediaPublications = inject(WebrtcMediaPublicationService);
   private readonly ordinaryMediaPolicy = inject(PairOrdinaryMediaPolicy);
+  private readonly pairMediaE2ee = inject(PairMediaE2eeCoordinatorService);
   private readonly mobileRuntime = inject(MobileRuntimeService);
   private readonly evidenceFlow = inject(PeerEvidenceSyncFacade);
   private readonly consent = inject(SpeechEvidenceConsentFacade);
@@ -182,14 +192,19 @@ export class SemanticMediaProgramFacade implements OnDestroy {
   private speechAdapterGeneration = 0;
   private activeSpeechAdapter: SpeechAdapterMetadata | null = null;
   private speechAdapterValidationTimer: ReturnType<typeof setTimeout> | null = null;
+  private publicMediaReadySessionId = '';
+  private publicMediaFailureCleanupSessionId = '';
 
   readonly view$ = new BehaviorSubject<SemanticMediaProgramHostView>(this.buildView());
 
   constructor() {
     this.subscriptions.add(this.shares.state$.subscribe(state => {
       const previousSessionId = this.shareState.session?.id ?? '';
+      const previousAuthority = this.ordinaryMediaAuthority();
       this.shareState = state;
-      if (previousSessionId && previousSessionId !== (state.session?.id ?? '')) this.stopSessionScopedState();
+      if (previousSessionId && previousSessionId !== (state.session?.id ?? '')) {
+        this.stopSessionScopedState(previousSessionId, previousAuthority === 'public');
+      }
       this.syncContext();
       this.emit();
     }));
@@ -214,6 +229,9 @@ export class SemanticMediaProgramFacade implements OnDestroy {
       const latestReason = [...publications].reverse().find(value => value.local && value.reasonCode)?.reasonCode;
       if (latestReason) this.ordinaryMediaOperationReason = latestReason;
       this.emit();
+    }));
+    this.subscriptions.add(this.pairMediaE2ee.status$.subscribe(status => {
+      this.reconcilePublicMediaStatus(status);
     }));
     this.subscriptions.add(this.speechRuntime.settings$.subscribe(settings => {
       this.speechSettings = settings;
@@ -282,13 +300,32 @@ export class SemanticMediaProgramFacade implements OnDestroy {
   }
 
   async handleProgramIntent(intent: SemanticProgramIntent): Promise<void> {
+    const intentSessionId = this.shareState.session?.id ?? '';
     const current = this.capability(intent.capability);
     if (current.requestId && current.requestId !== intent.requestId) return;
-    if (intent.desired === 'activate' && !this.hubOnline()) {
-      this.setCapability(intent.capability, 'failed', null);
+    const activationAvailable = intent.capability === 'ordinary_media'
+      ? this.ordinaryMediaActivationAvailable()
+      : this.hubOnline();
+    if (intent.desired === 'activate' && !activationAvailable) {
+      this.setCapability(
+        intent.capability,
+        'failed',
+        null,
+        intent.capability === 'ordinary_media'
+          ? this.ordinaryCaptureReason()
+          : 'semantic_program_hub_offline',
+      );
       return;
     }
-    this.setCapability(intent.capability, intent.desired === 'activate' ? 'sent_to_hub' : 'pausing', intent.requestId);
+    this.setCapability(
+      intent.capability,
+      intent.desired === 'activate'
+        ? intent.capability === 'ordinary_media' && this.ordinaryMediaAuthority() === 'public'
+          ? 'sent_to_authority'
+          : 'sent_to_hub'
+        : 'pausing',
+      intent.requestId,
+    );
     if (intent.desired !== 'activate') {
       this.deactivate(intent.capability, intent.desired === 'revoke' ? 'revoked' : 'pausing');
       this.setCapability(intent.capability, intent.desired === 'revoke' ? 'revoked' : 'revoked', null);
@@ -296,8 +333,23 @@ export class SemanticMediaProgramFacade implements OnDestroy {
     }
     try {
       const activatedState = await this.activate(intent);
-      this.setCapability(intent.capability, activatedState, null);
+      if (
+        (this.shareState.session?.id ?? '') !== intentSessionId
+        || this.capability(intent.capability).requestId !== intent.requestId
+      ) return;
+      this.setCapability(
+        intent.capability,
+        activatedState,
+        null,
+        intent.capability === 'ordinary_media' && activatedState === 'degraded'
+          ? this.ordinaryCaptureReason()
+          : null,
+      );
     } catch (error) {
+      if (
+        (this.shareState.session?.id ?? '') !== intentSessionId
+        || this.capability(intent.capability).requestId !== intent.requestId
+      ) return;
       const reasonCode = reason(error, 'semantic_program_activation_failed');
       if (intent.capability === 'adapter_activation') {
         this.clearSpeechAdapterActivation(reasonCode);
@@ -486,7 +538,10 @@ export class SemanticMediaProgramFacade implements OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.stopSessionScopedState();
+    this.stopSessionScopedState(
+      this.shareState.session?.id ?? '',
+      this.ordinaryMediaAuthority() === 'public',
+    );
     this.subscriptions.unsubscribe();
     this.view$.complete();
   }
@@ -497,13 +552,40 @@ export class SemanticMediaProgramFacade implements OnDestroy {
     const capability = intent.capability;
     const session = this.requireSession();
     const flags = this.profile.semantic_media_feature_flags;
-    if (!this.hubUrl()) throw new Error('semantic_program_hub_missing');
     if (capability === 'ordinary_media') {
-      this.ordinaryMediaPolicy.assertAllowed(session.id);
       if (this.transport.mode$.value !== 'webrtc') throw new Error('ordinary_media_webrtc_transport_required');
-      if (!flags.ordinary_media_publication) throw new Error('ordinary_media_publication_disabled');
+      const authority = this.ordinaryMediaAuthority();
+      if (authority === 'unbound') throw new Error('ordinary_media_session_binding_missing');
+      if (authority === 'hub' && !flags.ordinary_media_publication) {
+        throw new Error('ordinary_media_publication_disabled');
+      }
+      if (authority === 'public') {
+        this.ordinaryMediaPolicy.assertActivationAllowed(session.id);
+        const status = await this.pairMediaE2ee.activate(session.id);
+        if (this.shareState.session?.id !== session.id || this.ordinaryMediaAuthority() !== 'public') {
+          this.pairMediaE2ee.deactivate(session.id, 'ordinary_media_activation_stale');
+          throw new Error('ordinary_media_activation_stale');
+        }
+        if (status.sessionId !== session.id) {
+          this.pairMediaE2ee.deactivate(session.id, 'public_ordinary_media_e2ee_context_mismatch');
+          throw new Error('public_ordinary_media_e2ee_context_mismatch');
+        }
+        if (status.state === 'awaiting-peer' || status.state === 'negotiating') {
+          this.ordinaryMediaOperationReason = this.ordinaryMediaPolicyReason(session.id)
+            || PUBLIC_ORDINARY_MEDIA_E2EE_UNAVAILABLE;
+          return 'degraded';
+        }
+        if (status.state !== 'ready') {
+          throw new Error(status.reasonCode || this.ordinaryMediaPolicyReason(session.id)
+            || PUBLIC_ORDINARY_MEDIA_E2EE_UNAVAILABLE);
+        }
+        this.publicMediaReadySessionId = session.id;
+        this.publicMediaFailureCleanupSessionId = '';
+      }
+      this.ordinaryMediaPolicy.assertAllowed(session.id);
       return 'authoritatively_active';
     }
+    if (!this.hubUrl()) throw new Error('semantic_program_hub_missing');
     if (capability === 'live_speech') {
       if (!flags.semantic_speech_runtime) throw new Error('semantic_speech_disabled');
       await this.startSpeech();
@@ -579,6 +661,12 @@ export class SemanticMediaProgramFacade implements OnDestroy {
 
   private deactivate(capability: SemanticProgramCapability, _state: SemanticProgramState): void {
     if (capability === 'ordinary_media') {
+      const sessionId = this.shareState.session?.id ?? '';
+      if (sessionId && this.ordinaryMediaAuthority() === 'public') {
+        this.publicMediaReadySessionId = '';
+        this.publicMediaFailureCleanupSessionId = '';
+        this.pairMediaE2ee.deactivate(sessionId, 'ordinary_media_capability_revoked');
+      }
       this.media.stopAudio('ordinary_media_capability_revoked');
       this.mediaPublications.stopAll('ordinary_media_capability_revoked');
       void this.sfuCoordinator.stop('sfu_ordinary_media_revoked');
@@ -649,7 +737,12 @@ export class SemanticMediaProgramFacade implements OnDestroy {
     });
   }
 
-  private stopSessionScopedState(): void {
+  private stopSessionScopedState(sessionId = '', deactivatePublicMedia = false): void {
+    if (sessionId && deactivatePublicMedia) {
+      this.publicMediaReadySessionId = '';
+      this.publicMediaFailureCleanupSessionId = '';
+      this.pairMediaE2ee.deactivate(sessionId, 'ordinary_media_session_ended');
+    }
     this.stopSpeech('semantic_speech_session_ended');
     this.speech.stop();
     this.evidenceFlow.clear();
@@ -724,7 +817,19 @@ export class SemanticMediaProgramFacade implements OnDestroy {
     const state: SemanticProgramState = capability === 'ordinary_media'
       && session
       && this.ordinaryMediaActive() ? 'authoritatively_active' : 'revoked';
-    return Object.freeze({ capability, label: LABELS[capability], sensitive: SENSITIVE.has(capability), state, requestId: null });
+    const activationReason = capability === 'ordinary_media'
+      && this.ordinaryMediaAuthority() === 'public'
+      && !this.ordinaryMediaActivationAvailable()
+      ? this.ordinaryMediaActivationReason()
+      : null;
+    return Object.freeze({
+      capability,
+      label: LABELS[capability],
+      sensitive: SENSITIVE.has(capability),
+      state,
+      requestId: null,
+      ...(activationReason ? { reasonCode: activationReason } : {}),
+    });
   }
 
   private buildView(): SemanticMediaProgramHostView {
@@ -734,6 +839,8 @@ export class SemanticMediaProgramFacade implements OnDestroy {
       capabilities: Object.freeze((Object.keys(LABELS) as SemanticProgramCapability[]).map(value => this.capability(value))),
       online: this.hubOnline(),
       hubUrl: this.hubUrl(),
+      ordinaryMediaAuthority: this.ordinaryMediaAuthority(),
+      ordinaryMediaActivationEnabled: this.ordinaryMediaActivationAvailable(),
       computeVisible: Boolean(session && this.shares.currentUserId && (session.security_epoch ?? 0) > 0),
       compute: this.computeState,
       receiverPaths: this.receiverRows,
@@ -765,6 +872,96 @@ export class SemanticMediaProgramFacade implements OnDestroy {
   private emit(): void { this.view$.next(this.buildView()); }
 
   private hubOnline(): boolean { return Boolean(this.hubUrl()) && this.runtimeOnline; }
+
+  private ordinaryMediaAuthority(): OrdinaryMediaAuthorityKind {
+    const sessionId = this.shareState.session?.id ?? '';
+    if (!sessionId) return 'unbound';
+    try { return this.pairControlPlane.authorityKindForSession(sessionId); } catch { return 'unbound'; }
+  }
+
+  private ordinaryMediaActivationAvailable(): boolean {
+    const session = this.shareState.session;
+    if (
+      !session
+      || session.revoked_at !== null
+      || (session.expires_at ?? Number.MAX_SAFE_INTEGER) * 1_000 <= Date.now()
+    ) return false;
+    const authority = this.ordinaryMediaAuthority();
+    return authority === 'public'
+      ? this.ordinaryMediaPolicy.canActivate(session.id)
+      : authority === 'hub' && this.hubOnline();
+  }
+
+  private ordinaryMediaActivationReason(): string {
+    const session = this.shareState.session;
+    if (
+      !session
+      || session.revoked_at !== null
+      || (session.expires_at ?? Number.MAX_SAFE_INTEGER) * 1_000 <= Date.now()
+    ) return 'ordinary_media_session_missing';
+    try {
+      this.ordinaryMediaPolicy.assertActivationAllowed(session.id);
+      return 'ordinary_media_activation_required';
+    } catch (error) {
+      return reason(error, PUBLIC_ORDINARY_MEDIA_E2EE_UNAVAILABLE);
+    }
+  }
+
+  private reconcilePublicMediaStatus(status: PublicPairMediaE2eeState): void {
+    const sessionId = this.shareState.session?.id ?? '';
+    const current = this.capabilityStates.get('ordinary_media');
+    if (!sessionId || status.sessionId !== sessionId || this.ordinaryMediaAuthority() !== 'public') {
+      this.emit();
+      return;
+    }
+    if (status.state === 'ready') {
+      this.publicMediaReadySessionId = sessionId;
+      this.publicMediaFailureCleanupSessionId = '';
+      if (
+        !current
+        || current.state === 'sent_to_authority'
+        || current.state === 'degraded'
+        || current.state === 'authoritatively_active'
+      ) {
+        this.setCapability('ordinary_media', 'authoritatively_active', null);
+        return;
+      }
+    }
+    if (
+      status.state !== 'ready'
+      && this.publicMediaReadySessionId === sessionId
+      && current?.state !== 'revoked'
+    ) {
+      const failureReason = status.reasonCode || this.ordinaryMediaPolicyReason(sessionId)
+        || PUBLIC_ORDINARY_MEDIA_E2EE_UNAVAILABLE;
+      if (this.publicMediaFailureCleanupSessionId !== sessionId) {
+        this.publicMediaFailureCleanupSessionId = sessionId;
+        this.media.stopAudio(failureReason);
+        this.mediaPublications.stopAll(failureReason, true);
+      }
+      this.publicMediaReadySessionId = '';
+      this.setCapability(
+        'ordinary_media',
+        status.state === 'failed' || status.state === 'inactive' ? 'failed' : 'degraded',
+        null,
+        failureReason,
+      );
+      return;
+    }
+    if (
+      (status.state === 'awaiting-peer' || status.state === 'negotiating' || status.state === 'awaiting-security')
+      && (current?.state === 'sent_to_authority' || current?.state === 'authoritatively_active')
+    ) {
+      this.setCapability(
+        'ordinary_media',
+        'degraded',
+        null,
+        status.reasonCode || this.ordinaryMediaPolicyReason(sessionId),
+      );
+      return;
+    }
+    this.emit();
+  }
 
   private reconciliationContextKey(): string {
     const session = this.shareState.session;
@@ -982,19 +1179,23 @@ export class SemanticMediaProgramFacade implements OnDestroy {
     const sessionId = this.shareState.session?.id ?? '';
     return this.ordinaryMediaPolicy.allows(sessionId)
       && this.transport.mode$.value === 'webrtc'
-      && (['active', 'muted'].includes(this.media.audioState$.value.status)
+      && (this.ordinaryMediaAuthority() === 'public'
+        || ['active', 'muted'].includes(this.media.audioState$.value.status)
         || sfuState?.status === 'connected');
   }
 
   private ordinaryCaptureAllowed(video: boolean): boolean {
     const session = this.shareState.session;
     const state = this.capabilityStates.get('ordinary_media')?.state;
+    const authority = this.ordinaryMediaAuthority();
+    const profileEnabled = authority === 'public'
+      || this.profile.semantic_media_feature_flags.ordinary_media_publication;
     return Boolean(
-      session && session.revoked_at === null && this.hubOnline()
+      session && session.revoked_at === null && this.ordinaryMediaActivationAvailable()
       && this.ordinaryMediaPolicy.allows(session.id)
       && this.transport.mode$.value === 'webrtc'
-      && this.profile.semantic_media_feature_flags.ordinary_media_publication
-      && (!video || this.profile.semantic_media_feature_flags.ordinary_media_publication)
+      && profileEnabled
+      && (!video || profileEnabled)
       && (state === 'authoritatively_active' || state === 'degraded'),
     );
   }
@@ -1005,18 +1206,35 @@ export class SemanticMediaProgramFacade implements OnDestroy {
 
   private ordinaryCaptureReason(): string {
     const session = this.shareState.session;
-    if (!session || session.revoked_at !== null) return 'ordinary_media_session_missing';
-    if (!this.ordinaryMediaPolicy.allows(session.id)) {
-      return PUBLIC_ORDINARY_MEDIA_E2EE_UNAVAILABLE;
-    }
-    if (!this.profile.semantic_media_feature_flags.ordinary_media_publication) {
+    if (
+      !session
+      || session.revoked_at !== null
+      || (session.expires_at ?? Number.MAX_SAFE_INTEGER) * 1_000 <= Date.now()
+    ) return 'ordinary_media_session_missing';
+    const policyReason = this.ordinaryMediaPolicyReason(session.id);
+    if (policyReason) return policyReason;
+    const authority = this.ordinaryMediaAuthority();
+    if (authority === 'hub' && !this.profile.semantic_media_feature_flags.ordinary_media_publication) {
       return 'ordinary_media_publication_disabled';
     }
     if (this.transport.mode$.value !== 'webrtc') return 'ordinary_media_webrtc_transport_required';
-    if (!this.hubOnline()) return 'ordinary_media_hub_offline';
+    if (!this.ordinaryMediaActivationAvailable()) {
+      return authority === 'public'
+        ? this.ordinaryMediaActivationReason()
+        : 'ordinary_media_hub_offline';
+    }
     const state = this.capabilityStates.get('ordinary_media')?.state;
     if (state !== 'authoritatively_active' && state !== 'degraded') return 'ordinary_media_activation_required';
     return this.ordinaryMediaOperationReason;
+  }
+
+  private ordinaryMediaPolicyReason(sessionId: string): string | null {
+    try {
+      this.ordinaryMediaPolicy.assertAllowed(sessionId);
+      return null;
+    } catch (error) {
+      return reason(error, PUBLIC_ORDINARY_MEDIA_E2EE_UNAVAILABLE);
+    }
   }
 
   private mediaPublicationAuthorization(source: 'camera' | 'screen'): MediaPublicationAuthorization {

--- a/frontend-angular/src/app/features/voice/voice-console.component.spec.ts
+++ b/frontend-angular/src/app/features/voice/voice-console.component.spec.ts
@@ -164,7 +164,8 @@ describe('VoiceConsoleComponent', () => {
           direction: 'bidirectional', dataClass: 'Transcript', purpose: 'Test', retentionLabel: 'keine',
           trainerLocation: 'lokal', e2eeMode: 'strict_e2ee', ordinaryFallback: 'aktiv',
         },
-        capabilities: [], online: true, hubUrl: 'http://hub.test', computeVisible: false,
+        capabilities: [], online: true, hubUrl: 'http://hub.test',
+        ordinaryMediaAuthority: 'hub', ordinaryMediaActivationEnabled: true, computeVisible: false,
         compute: {
           contract: { contractId: '', revision: 0, status: 'absent', profile: 'off', delayMs: 5_000, roles: {} },
           leases: [], pending: false, errorCode: null,

--- a/frontend-angular/src/app/services/pair-media-e2ee-coordinator.service.spec.ts
+++ b/frontend-angular/src/app/services/pair-media-e2ee-coordinator.service.spec.ts
@@ -1,0 +1,346 @@
+import { Injector, runInInjectionContext } from '@angular/core';
+
+import { E2eEncryptionService } from './e2e-encryption.service';
+import {
+  PairMediaE2eeCoordinatorService,
+  PairMediaE2eeTransportPort,
+} from './pair-media-e2ee-coordinator.service';
+import { PairMediaE2eeTransformAdapter, PublicPairMediaSlotKeySet } from './pair-media-e2ee-transform.adapter';
+import { PairSecureSequenceService } from './pair-secure-sequence.service';
+import { PairViewSecurityBootstrapService } from './pair-view-security-bootstrap.service';
+import {
+  PUBLIC_PAIR_MEDIA_SLOTS,
+  PublicPairMediaSecurityContractV1,
+} from './public-pair-media-security-contract';
+import { SemanticDataChannelMessage } from './webrtc-datachannel.service';
+import { VerifiedPeerBinding, WebrtcPeerKeyService } from './webrtc-peer-key.service';
+import { decodeB64, encodeB64 } from './webrtc-secure-envelope';
+
+interface CoordinatorNode {
+  readonly coordinator: PairMediaE2eeCoordinatorService;
+  readonly transforms: CoordinatorTransforms;
+  readonly crypto: TransparentEncryption;
+  readonly binding: VerifiedPeerBinding;
+  readonly disabled: ReturnType<typeof vi.fn>;
+  readonly closed: ReturnType<typeof vi.fn>;
+  readonly outbound: SemanticDataChannelMessage[];
+  readonly sent: SemanticDataChannelMessage[];
+}
+
+describe('PairMediaE2eeCoordinatorService', () => {
+  const activeNodes: CoordinatorNode[] = [];
+
+  afterEach(() => {
+    for (const node of activeNodes.splice(0)) {
+      node.coordinator.deactivate('session-a', 'test_cleanup');
+    }
+    vi.useRealTimers();
+  });
+
+  it('completes bilateral owner/guest consent and derives inverse keys for all fixed slots', async () => {
+    const owner = node('peer:owner', 'peer:guest');
+    const guest = node('peer:guest', 'peer:owner');
+    connect(owner, guest);
+    prepareNegotiation(owner);
+    prepareNegotiation(guest);
+
+    const ownerActivation = owner.coordinator.activate('session-a');
+    const guestActivation = guest.coordinator.activate('session-a');
+    await pump(owner, guest);
+
+    await expect(ownerActivation).resolves.toMatchObject({ state: 'ready' });
+    await expect(guestActivation).resolves.toMatchObject({ state: 'ready' });
+    const ownerKeys = owner.transforms.installed[0];
+    const guestKeys = guest.transforms.installed[0];
+    expect(ownerKeys.map(value => value.slot)).toEqual(PUBLIC_PAIR_MEDIA_SLOTS.map(value => value.slot));
+    expect(guestKeys.map(value => value.slot)).toEqual(PUBLIC_PAIR_MEDIA_SLOTS.map(value => value.slot));
+    for (const definition of PUBLIC_PAIR_MEDIA_SLOTS) {
+      const ownerSlot = ownerKeys.find(value => value.slot === definition.slot)!;
+      const guestSlot = guestKeys.find(value => value.slot === definition.slot)!;
+      expect(ownerSlot.sendContext).toMatchObject({
+        senderId: 'peer:owner', recipientId: 'peer:guest', slot: definition.slot,
+        kind: definition.kind, codec: definition.codec,
+      });
+      expect(ownerSlot.receiveContext).toEqual(guestSlot.sendContext);
+      expect(ownerSlot.sendContext).toEqual(guestSlot.receiveContext);
+      expect(ownerSlot.sendContext.connectionId).toBe(ownerSlot.receiveContext.connectionId);
+    }
+  });
+
+  it('returns genuine failure immediately but resolves deactivate as inactive', async () => {
+    const failing = node('peer:owner', 'peer:guest');
+    bindSink(failing);
+    prepareNegotiation(failing);
+    const failedActivation = failing.coordinator.activate('session-a');
+    failing.coordinator.fail('session-a', 'public_media_control_invalid');
+    await expect(failedActivation).resolves.toMatchObject({
+      state: 'failed', reasonCode: 'public_media_control_invalid',
+    });
+
+    const cancelled = node('peer:owner', 'peer:guest');
+    bindSink(cancelled);
+    prepareNegotiation(cancelled);
+    const cancelledActivation = cancelled.coordinator.activate('session-a');
+    cancelled.coordinator.deactivate('session-a', 'ordinary_media_capability_revoked');
+    await expect(cancelledActivation).resolves.toMatchObject({
+      state: 'inactive', reasonCode: 'ordinary_media_capability_revoked',
+    });
+  });
+
+  it('refreshes expired pre-key hellos when the second peer consents after the control TTL', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+    const owner = node('peer:owner', 'peer:guest', 2_000_000);
+    const guest = node('peer:guest', 'peer:owner', 2_000_000);
+    connect(owner, guest);
+    prepareNegotiation(owner);
+    prepareNegotiation(guest);
+    void owner.coordinator.activate('session-a');
+    await pump(owner, guest);
+    expect(countControl(owner, 'hello')).toBe(1);
+    expect(owner.coordinator.statusFor('session-a').state).not.toBe('ready');
+
+    await vi.advanceTimersByTimeAsync(31_000);
+    const guestActivation = guest.coordinator.activate('session-a');
+    await pump(owner, guest);
+
+    await expect(guestActivation).resolves.toMatchObject({ state: 'ready' });
+    expect(owner.coordinator.statusFor('session-a').state).toBe('ready');
+    expect(countControl(owner, 'hello')).toBe(2);
+  });
+
+  it('treats media failure after local ACK release as transport-fatal', async () => {
+    const owner = node('peer:owner', 'peer:guest');
+    const guest = node('peer:guest', 'peer:owner');
+    connect(owner, guest);
+    prepareNegotiation(owner);
+    prepareNegotiation(guest);
+    // Hold the guest ACK in the queue. Owner sends its ACK first, so the peer
+    // may already be deriving even though owner has not installed locally.
+    void owner.coordinator.activate('session-a');
+    void guest.coordinator.activate('session-a');
+    await settle(6);
+    await deliverOne(owner, guest); // owner hello
+    await deliverOne(guest, owner); // guest hello
+    await settle(8);
+    expect(countControl(owner, 'hello_ack')).toBe(1);
+
+    owner.coordinator.failMediaExtension('session-a', 'media_e2ee_worker_failed');
+
+    expect(owner.closed).toHaveBeenCalledWith('media_e2ee_worker_failed');
+    expect(owner.disabled).not.toHaveBeenCalled();
+  });
+
+  it('downgrades a provably pre-ACK asymmetric topology to data-only', () => {
+    const owner = node('peer:owner', 'peer:guest');
+    bindSink(owner);
+    owner.transforms.topologyError = new Error('public_media_topology_invalid');
+
+    owner.coordinator.markTopologyNegotiated('session-a');
+
+    expect(owner.disabled).toHaveBeenCalledWith('public_media_topology_invalid');
+    expect(owner.closed).not.toHaveBeenCalled();
+    expect(owner.coordinator.statusFor('session-a')).toMatchObject({
+      state: 'failed', reasonCode: 'public_media_topology_invalid',
+    });
+  });
+
+  it('fences a delayed worker ACK from a new adapter/runtime generation of the same session', async () => {
+    const owner = node('peer:owner', 'peer:guest');
+    const guest = node('peer:guest', 'peer:owner');
+    const installGate = deferred<void>();
+    const installEntered = deferred<void>();
+    owner.transforms.installGate = installGate.promise;
+    owner.transforms.installEntered = installEntered;
+    connect(owner, guest);
+    prepareNegotiation(owner);
+    prepareNegotiation(guest);
+    void owner.coordinator.activate('session-a');
+    void guest.coordinator.activate('session-a');
+    const oldHandshake = pump(owner, guest);
+    await installEntered.promise;
+
+    owner.coordinator.unbindTransport('session-a', 'test_reconnect');
+    owner.transforms.generation = 2;
+    owner.transforms.prepared = true;
+    owner.closed.mockClear();
+    bindSink(owner);
+    installGate.resolve(undefined);
+    await oldHandshake;
+    await settle(5);
+
+    expect(owner.transforms.installed).toEqual([]);
+    expect(owner.closed).not.toHaveBeenCalled();
+    expect(owner.coordinator.statusFor('session-a').state).toBe('inactive');
+  });
+});
+
+function node(localPeerId: string, remotePeerId: string, expiresAtMs = 2_000_000_000_000): CoordinatorNode {
+  const mediaContract = contract(expiresAtMs);
+  const binding = {
+    scopeKind: 'session', scopeId: 'session-a', localPeerId, remotePeerId,
+    peerPublicKeySpkiB64: 'unused', epoch: 7, keyId: 'pair-key-7', contractDigest: 'b'.repeat(64),
+    packageId: 'c'.repeat(64), tenantId: 'tenant', deviceId: 'device', membershipId: localPeerId,
+    membershipVersion: 1, peerFingerprint: 'd'.repeat(64), confirmed: true,
+    fingerprintChanged: false, transcriptDigest: 'e'.repeat(64), authorityKeyId: 'authority',
+  } as VerifiedPeerBinding;
+  const transforms = new CoordinatorTransforms();
+  const encryption = new TransparentEncryption();
+  const sequence = new Sequence();
+  const injector = Injector.create({ providers: [
+    { provide: PairViewSecurityBootstrapService, useValue: { mediaContractFor: () => mediaContract } },
+    { provide: WebrtcPeerKeyService, useValue: { requireBinding: () => binding } },
+    { provide: E2eEncryptionService, useValue: encryption },
+    { provide: PairSecureSequenceService, useValue: sequence },
+    { provide: PairMediaE2eeTransformAdapter, useValue: transforms },
+  ] });
+  const coordinator = runInInjectionContext(injector, () => new PairMediaE2eeCoordinatorService());
+  const value: CoordinatorNode = {
+    coordinator, transforms, crypto: encryption, binding,
+    disabled: vi.fn(), closed: vi.fn(), outbound: [], sent: [],
+  };
+  activeNode(value);
+  return value;
+}
+
+const registeredNodes: CoordinatorNode[] = [];
+function activeNode(value: CoordinatorNode): void {
+  // The describe-local cleanup array is not accessible from helpers; release
+  // long expiry timers through an afterEach registry instead.
+  registeredNodes.push(value);
+}
+
+afterEach(() => {
+  for (const value of registeredNodes.splice(0)) {
+    value.coordinator.deactivate('session-a', 'test_cleanup');
+  }
+});
+
+function connect(left: CoordinatorNode, right: CoordinatorNode): void {
+  left.coordinator.bindTransport('session-a', port(left));
+  right.coordinator.bindTransport('session-a', port(right));
+}
+
+function bindSink(value: CoordinatorNode): void {
+  value.coordinator.bindTransport('session-a', port(value));
+}
+
+function port(value: CoordinatorNode): PairMediaE2eeTransportPort {
+  return {
+    send: async message => { value.outbound.push(message); value.sent.push(message); },
+    disableMedia: value.disabled,
+    failClosed: value.closed,
+  };
+}
+
+function prepareNegotiation(value: CoordinatorNode): void {
+  value.coordinator.markDataChannelOpen('session-a');
+  value.coordinator.markTopologyNegotiated('session-a');
+}
+
+async function pump(left: CoordinatorNode, right: CoordinatorNode): Promise<void> {
+  for (let pass = 0; pass < 30; pass += 1) {
+    await settle(3);
+    let delivered = false;
+    while (left.outbound.length) {
+      delivered = true;
+      await right.coordinator.acceptSemantic(left.outbound.shift()!);
+    }
+    while (right.outbound.length) {
+      delivered = true;
+      await left.coordinator.acceptSemantic(right.outbound.shift()!);
+    }
+    if (
+      left.coordinator.statusFor('session-a').state === 'ready'
+      && right.coordinator.statusFor('session-a').state === 'ready'
+    ) return;
+    if (!delivered) await settle(3);
+  }
+}
+
+async function deliverOne(source: CoordinatorNode, recipient: CoordinatorNode): Promise<void> {
+  await settle(3);
+  const message = source.outbound.shift();
+  if (!message) throw new Error('test_control_message_missing');
+  await recipient.coordinator.acceptSemantic(message);
+}
+
+class CoordinatorTransforms {
+  generation = 1;
+  prepared = true;
+  readonly installed: Array<readonly PublicPairMediaSlotKeySet[]> = [];
+  topologyError: Error | null = null;
+  installGate: Promise<void> | null = null;
+  installEntered: { resolve(value: void): void } | null = null;
+  isPrepared(_session: string, _epoch?: number, _digest?: string, generation?: number): boolean {
+    return this.prepared && (generation === undefined || generation === this.generation);
+  }
+  generationForSession(): number | null { return this.prepared ? this.generation : null; }
+  validateFinalTopology(): void { if (this.topologyError) throw this.topologyError; }
+  async installKeys(_session: string, keys: readonly PublicPairMediaSlotKeySet[], generation: number): Promise<void> {
+    this.installEntered?.resolve(undefined);
+    if (this.installGate) await this.installGate;
+    if (!this.isPrepared('session-a', undefined, undefined, generation)) throw new Error('stale_adapter');
+    this.installed.push(keys);
+  }
+  releaseSession(_session?: string, generation?: number): void {
+    if (generation === undefined || generation === this.generation) this.prepared = false;
+  }
+}
+
+class Sequence {
+  private value = 0;
+  async next(): Promise<number> { return ++this.value; }
+}
+
+class TransparentEncryption {
+  readonly derived: string[] = [];
+  async seal(binding: VerifiedPeerBinding, plaintext: Uint8Array, options: any): Promise<any> {
+    return {
+      version: 1,
+      scope: { kind: 'session', id: binding.scopeId },
+      sender_id: binding.localPeerId,
+      recipient: { kind: 'peer', id: binding.remotePeerId },
+      epoch: binding.epoch,
+      sequence: options.sequence,
+      key_id: binding.keyId,
+      payload_type: options.payloadType,
+      expires_at_ms: options.expiresAtMs,
+      nonce_b64: encodeB64(new Uint8Array(12)),
+      aad: { traffic_class: options.trafficClass, content_encoding: 'binary', contract_digest: binding.contractDigest },
+      ciphertext_b64: encodeB64(plaintext),
+    };
+  }
+  async open(_binding: VerifiedPeerBinding, envelope: any): Promise<any> {
+    return { envelope, plaintext: decodeB64(envelope.ciphertext_b64) };
+  }
+  async derivePurposeAesKey(_binding: VerifiedPeerBinding, _purpose: string, bindingId: string): Promise<CryptoKey> {
+    this.derived.push(bindingId);
+    return crypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, false, ['encrypt', 'decrypt']);
+  }
+}
+
+function contract(expiresAtMs: number): PublicPairMediaSecurityContractV1 {
+  return {
+    session_id: 'session-a', epoch: 7, digest: 'a'.repeat(64), expires_at_ms: expiresAtMs,
+    transform: 'RTCRtpScriptTransform',
+  } as PublicPairMediaSecurityContractV1;
+}
+
+function countControl(value: CoordinatorNode, kind: 'hello' | 'hello_ack'): number {
+  return value.sent.filter(message => message.message_id.includes(`pair-media-${kind}-`)).length;
+}
+
+async function settle(turns = 3): Promise<void> {
+  for (let index = 0; index < turns; index += 1) {
+    // Native WebCrypto completion is not guaranteed to run within a chain of
+    // Promise.resolve() microtasks in Node.
+    await crypto.subtle.digest('SHA-256', new Uint8Array(0));
+  }
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve(value: T): void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(accept => { resolve = accept; });
+  return { promise, resolve };
+}

--- a/frontend-angular/src/app/services/pair-media-e2ee-coordinator.service.ts
+++ b/frontend-angular/src/app/services/pair-media-e2ee-coordinator.service.ts
@@ -1,0 +1,943 @@
+import { Injectable, inject } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+
+import { E2eEncryptionService } from './e2e-encryption.service';
+import { PairMediaE2eeTransformAdapter, PublicPairMediaSlotKeySet } from './pair-media-e2ee-transform.adapter';
+import { PairSecureSequenceService } from './pair-secure-sequence.service';
+import { PairViewSecurityBootstrapService } from './pair-view-security-bootstrap.service';
+import {
+  PUBLIC_PAIR_MEDIA_GRANTS,
+  PUBLIC_PAIR_MEDIA_SLOTS,
+  PublicPairMediaSecurityContractV1,
+} from './public-pair-media-security-contract';
+import {
+  SEMANTIC_DC_VERSION,
+  SemanticDataChannelMessage,
+  validateSemanticDcMessage,
+} from './webrtc-datachannel.service';
+import { VerifiedPeerBinding, WebrtcPeerKeyService } from './webrtc-peer-key.service';
+import {
+  canonicalSecurityJson,
+  decodeB64,
+  encodeB64,
+} from './webrtc-secure-envelope';
+
+export type PublicPairMediaE2eeStateName =
+  | 'inactive'
+  | 'awaiting-security'
+  | 'awaiting-peer'
+  | 'negotiating'
+  | 'ready'
+  | 'failed';
+
+export interface PublicPairMediaE2eeState {
+  readonly sessionId: string;
+  readonly state: PublicPairMediaE2eeStateName;
+  readonly reasonCode?: string;
+  readonly contractDigest?: string;
+}
+
+/** Lower-level port registered by WebrtcSessionService; no reverse DI edge. */
+export interface PairMediaE2eeTransportPort {
+  send(message: SemanticDataChannelMessage): Promise<void>;
+  disableMedia(reasonCode: string): void;
+  failClosed(reasonCode: string): void;
+}
+
+interface MediaHelloV1 {
+  readonly schema: 'ananta.public-pair.media-hello.v1';
+  readonly kind: 'hello';
+  readonly session_id: string;
+  readonly epoch: number;
+  readonly sender_id: string;
+  readonly recipient_id: string;
+  readonly media_contract_digest: string;
+  readonly connection_salt_b64: string;
+  readonly slots: typeof PUBLIC_PAIR_MEDIA_GRANTS;
+  readonly expires_at_ms: number;
+}
+
+interface MediaHelloAckV1 {
+  readonly schema: 'ananta.public-pair.media-hello-ack.v1';
+  readonly kind: 'hello_ack';
+  readonly session_id: string;
+  readonly epoch: number;
+  readonly sender_id: string;
+  readonly recipient_id: string;
+  readonly media_contract_digest: string;
+  readonly hello_digests: readonly [
+    Readonly<{ peer_id: string; digest: string }>,
+    Readonly<{ peer_id: string; digest: string }>,
+  ];
+  readonly expires_at_ms: number;
+}
+
+interface Runtime {
+  readonly sessionId: string;
+  readonly generation: number;
+  readonly adapterGeneration: number;
+  readonly contract: Readonly<PublicPairMediaSecurityContractV1>;
+  readonly binding: Readonly<VerifiedPeerBinding>;
+  port: PairMediaE2eeTransportPort | null;
+  dataChannelOpen: boolean;
+  topologyReady: boolean;
+  localActivated: boolean;
+  localHello: MediaHelloV1 | null;
+  localHelloDigest: string;
+  remoteHello: MediaHelloV1 | null;
+  remoteHelloDigest: string;
+  localAck: MediaHelloAckV1 | null;
+  remoteAck: MediaHelloAckV1 | null;
+  localAckSent: boolean;
+  helloSendPromise: Promise<void> | null;
+  ackSendPromise: Promise<void> | null;
+  installPromise: Promise<void> | null;
+  installAttempted: boolean;
+  peerMayBeReady: boolean;
+  installed: boolean;
+  failed: boolean;
+  poisoned: boolean;
+  expiryTimer: ReturnType<typeof setTimeout> | null;
+}
+
+const ACTIVATION_WAIT_MS = 15_000;
+const CONTROL_TTL_MS = 30_000;
+const CONTROL_MESSAGE_PREFIX = 'pair-media-';
+const DIGEST_RE = /^[a-f0-9]{64}$/;
+const ID_RE = /^[A-Za-z0-9][A-Za-z0-9._:@-]{0,127}$/;
+
+@Injectable({ providedIn: 'root' })
+export class PairMediaE2eeCoordinatorService {
+  private readonly bootstrap = inject(PairViewSecurityBootstrapService);
+  private readonly peerKeys = inject(WebrtcPeerKeyService);
+  private readonly encryption = inject(E2eEncryptionService);
+  private readonly sequences = inject(PairSecureSequenceService);
+  private readonly transforms = inject(PairMediaE2eeTransformAdapter);
+  private readonly statusSubject = new BehaviorSubject<PublicPairMediaE2eeState>(
+    Object.freeze({ sessionId: '', state: 'inactive' }),
+  );
+  readonly status$: Observable<PublicPairMediaE2eeState> = this.statusSubject.asObservable();
+  private runtime: Runtime | null = null;
+  private runtimeGeneration = 0;
+
+  statusFor(sessionId: string): PublicPairMediaE2eeState {
+    if (!sessionId) return Object.freeze({ sessionId: '', state: 'inactive' });
+    const runtime = this.runtime;
+    if (runtime?.sessionId === sessionId) {
+      if (runtime.contract.expires_at_ms <= Date.now()) {
+        this.failRuntime(runtime, 'public_media_contract_expired', true);
+      }
+      return this.statusSubject.value.sessionId === sessionId
+        ? this.statusSubject.value
+        : this.derivedStatus(sessionId);
+    }
+    return this.derivedStatus(sessionId);
+  }
+
+  canActivate(sessionId: string): boolean {
+    const contract = this.bootstrap.mediaContractFor(sessionId);
+    if (!contract || contract.expires_at_ms <= Date.now()) return false;
+    const runtime = this.runtime;
+    if (runtime?.sessionId === sessionId && (runtime.failed || runtime.installed)) return false;
+    return this.transforms.isPrepared(sessionId, contract.epoch, contract.digest);
+  }
+
+  async activate(sessionId: string): Promise<PublicPairMediaE2eeState> {
+    let runtime: Runtime;
+    try {
+      runtime = this.ensureRuntime(sessionId);
+    } catch (error) {
+      const state = Object.freeze({
+        sessionId,
+        state: 'failed' as const,
+        reasonCode: reason(error, 'public_media_contract_not_ready'),
+      });
+      this.statusSubject.next(state);
+      return state;
+    }
+    if (runtime.contract.expires_at_ms <= Date.now()) {
+      this.failRuntime(runtime, 'public_media_contract_expired', true);
+      return this.statusFor(sessionId);
+    }
+    if (runtime.installed) return this.statusFor(sessionId);
+    try {
+      this.refreshExpiredPreKeyHandshake(runtime);
+    } catch (error) {
+      this.failRuntime(runtime, reason(error, 'public_media_control_refresh_failed'), true);
+      return this.statusFor(sessionId);
+    }
+    runtime.localActivated = true;
+    this.emit(runtime, 'awaiting-peer');
+    void this.maybeSendHello(runtime).catch(error => {
+      this.failRuntime(runtime, reason(error, 'public_media_hello_send_failed'), true);
+    });
+    return this.waitForActivation(runtime);
+  }
+
+  deactivate(sessionId: string, reasonCode = 'public_media_deactivated'): void {
+    const runtime = this.runtime;
+    if (!runtime || runtime.sessionId !== sessionId) {
+      this.statusSubject.next(Object.freeze({ sessionId, state: 'inactive', reasonCode }));
+      return;
+    }
+    const port = runtime.port;
+    this.clearExpiry(runtime);
+    runtime.poisoned = true;
+    runtime.port = null;
+    runtime.dataChannelOpen = false;
+    runtime.localActivated = false;
+    runtime.failed = false;
+    this.transforms.releaseSession(sessionId, runtime.adapterGeneration);
+    this.runtime = null;
+    this.statusSubject.next(Object.freeze({
+      sessionId, state: 'inactive', reasonCode, contractDigest: runtime.contract.digest,
+    }));
+    try { port?.failClosed(reasonCode); } catch { /* Local teardown is already complete. */ }
+  }
+
+  bindTransport(sessionId: string, port: PairMediaE2eeTransportPort): void {
+    const runtime = this.ensureRuntime(sessionId);
+    runtime.port = port;
+    if (runtime.localActivated && runtime.dataChannelOpen) {
+      void this.maybeSendHello(runtime).catch(error => {
+        this.failRuntime(runtime, reason(error, 'public_media_hello_send_failed'), true);
+      });
+    }
+  }
+
+  unbindTransport(sessionId: string, reasonCode = 'public_media_transport_closed'): void {
+    const runtime = this.runtime;
+    if (!runtime || runtime.sessionId !== sessionId) return;
+    this.clearExpiry(runtime);
+    runtime.poisoned = true;
+    runtime.dataChannelOpen = false;
+    runtime.port = null;
+    this.transforms.releaseSession(sessionId, runtime.adapterGeneration);
+    this.runtime = null;
+    this.statusSubject.next(Object.freeze({
+      sessionId, state: 'inactive', reasonCode, contractDigest: runtime.contract.digest,
+    }));
+  }
+
+  markDataChannelOpen(sessionId: string): void {
+    const runtime = this.ensureRuntime(sessionId);
+    runtime.dataChannelOpen = true;
+    if (runtime.localActivated) {
+      void this.maybeSendHello(runtime).catch(error => {
+        this.failRuntime(runtime, reason(error, 'public_media_hello_send_failed'), true);
+      });
+    }
+  }
+
+  markTopologyNegotiated(sessionId: string): void {
+    const runtime = this.ensureRuntime(sessionId);
+    try {
+      this.transforms.validateFinalTopology(sessionId);
+      runtime.topologyReady = true;
+      void this.maybeInstall(runtime);
+    } catch (error) {
+      // A peer that could not advertise the optional media extension may
+      // still have a valid authenticated DataChannel. No key was installed,
+      // so dropping all transforms is sufficient to preserve data-only Pair.
+      this.failRuntime(
+        runtime,
+        reason(error, 'public_media_topology_invalid'),
+        true,
+        runtime.peerMayBeReady || runtime.installAttempted || runtime.installed,
+      );
+    }
+  }
+
+  /** Returns true when the message belonged to the private media protocol. */
+  async acceptSemantic(message: SemanticDataChannelMessage): Promise<boolean> {
+    if (!message.message_id.startsWith(CONTROL_MESSAGE_PREFIX)) return false;
+    const runtime = this.runtime;
+    if (!runtime || runtime.sessionId !== message.session_id) return false;
+    try {
+      const control = await this.openControl(runtime, message);
+      this.assertCurrent(runtime);
+      if (control.kind === 'hello') await this.acceptHello(runtime, control);
+      else await this.acceptAck(runtime, control);
+    } catch (error) {
+      this.failRuntime(runtime, reason(error, 'public_media_control_invalid'), true);
+    }
+    return true;
+  }
+
+  fail(sessionId: string, reasonCode: string): void {
+    const runtime = this.runtime;
+    if (runtime?.sessionId === sessionId) this.failRuntime(runtime, reasonCode, true);
+    else this.statusSubject.next(Object.freeze({ sessionId, state: 'failed', reasonCode }));
+  }
+
+  /**
+   * Fails only the optional media extension while it is still DROP-first.
+   * Once media keys were released, the same failure is transport-fatal.
+   */
+  failMediaExtension(sessionId: string, reasonCode: string): void {
+    const runtime = this.runtime;
+    if (runtime?.sessionId === sessionId) {
+      this.failRuntime(
+        runtime, reasonCode, true,
+        runtime.peerMayBeReady || runtime.installAttempted || runtime.installed,
+      );
+    } else {
+      this.statusSubject.next(Object.freeze({ sessionId, state: 'failed', reasonCode }));
+    }
+  }
+
+  private ensureRuntime(sessionId: string): Runtime {
+    const contract = this.bootstrap.mediaContractFor(sessionId);
+    const binding = this.peerKeys.requireBinding(true);
+    const adapterGeneration = contract
+      ? this.transforms.generationForSession(sessionId) : null;
+    if (
+      !contract
+      || contract.session_id !== sessionId
+      || contract.epoch !== binding.epoch
+      || contract.expires_at_ms <= Date.now()
+      || binding.scopeId !== sessionId
+      || adapterGeneration === null
+      || !this.transforms.isPrepared(sessionId, contract.epoch, contract.digest, adapterGeneration)
+    ) throw new Error('public_media_contract_not_ready');
+    const current = this.runtime;
+    if (
+      current
+      && current.sessionId === sessionId
+      && current.contract.digest === contract.digest
+      && current.contract.epoch === contract.epoch
+      && current.binding.keyId === binding.keyId
+      && current.adapterGeneration === adapterGeneration
+      && !current.failed && !current.poisoned
+    ) return current;
+    if (current) this.unbindTransport(current.sessionId, 'public_media_security_context_changed');
+    const runtime: Runtime = {
+      sessionId,
+      generation: ++this.runtimeGeneration,
+      adapterGeneration,
+      contract,
+      binding,
+      port: null,
+      dataChannelOpen: false,
+      topologyReady: false,
+      localActivated: false,
+      localHello: null,
+      localHelloDigest: '',
+      remoteHello: null,
+      remoteHelloDigest: '',
+      localAck: null,
+      remoteAck: null,
+      localAckSent: false,
+      helloSendPromise: null,
+      ackSendPromise: null,
+      installPromise: null,
+      installAttempted: false,
+      peerMayBeReady: false,
+      installed: false,
+      failed: false,
+      poisoned: false,
+      expiryTimer: null,
+    };
+    this.runtime = runtime;
+    this.armExpiry(runtime);
+    this.emit(runtime, 'inactive');
+    return runtime;
+  }
+
+  private async maybeSendHello(runtime: Runtime): Promise<void> {
+    this.assertCurrent(runtime);
+    this.refreshExpiredPreKeyHandshake(runtime);
+    if (
+      runtime.failed || !runtime.localActivated || !runtime.dataChannelOpen || !runtime.port
+      || runtime.helloSendPromise || runtime.localHello
+    ) return runtime.helloSendPromise ?? Promise.resolve();
+    runtime.helloSendPromise = (async () => {
+      const expiresAtMs = Math.min(runtime.contract.expires_at_ms, Date.now() + CONTROL_TTL_MS);
+      if (expiresAtMs <= Date.now()) throw new Error('public_media_contract_expired');
+      const salt = crypto.getRandomValues(new Uint8Array(16));
+      const hello = parseHello({
+        schema: 'ananta.public-pair.media-hello.v1',
+        kind: 'hello',
+        session_id: runtime.sessionId,
+        epoch: runtime.contract.epoch,
+        sender_id: runtime.binding.localPeerId,
+        recipient_id: runtime.binding.remotePeerId,
+        media_contract_digest: runtime.contract.digest,
+        connection_salt_b64: encodeB64(salt),
+        slots: PUBLIC_PAIR_MEDIA_GRANTS,
+        expires_at_ms: expiresAtMs,
+      }, runtime, 'outbound');
+      const helloDigest = await digestCanonical(hello);
+      this.assertCurrent(runtime);
+      // Publish the hello and its digest atomically before transport send. A
+      // loopback/fast peer may answer before send() resolves.
+      runtime.localHello = hello;
+      runtime.localHelloDigest = helloDigest;
+      await this.sendControl(runtime, hello);
+      this.assertCurrent(runtime);
+      await this.maybeSendAck(runtime);
+    })().finally(() => { runtime.helloSendPromise = null; });
+    return runtime.helloSendPromise;
+  }
+
+  private async acceptHello(runtime: Runtime, hello: MediaHelloV1): Promise<void> {
+    const digest = await digestCanonical(hello);
+    this.assertCurrent(runtime);
+    if (runtime.remoteHello && runtime.remoteHelloDigest !== digest) {
+      if (
+        runtime.remoteHello.expires_at_ms <= Date.now()
+        && !runtime.peerMayBeReady
+        && !runtime.installAttempted
+        && !runtime.installed
+        && !runtime.helloSendPromise
+        && !runtime.ackSendPromise
+      ) {
+        runtime.remoteHello = null;
+        runtime.remoteHelloDigest = '';
+        this.resetAcks(runtime);
+      } else {
+        throw new Error('public_media_hello_conflict');
+      }
+    }
+    runtime.remoteHello = hello;
+    runtime.remoteHelloDigest = digest;
+    if (runtime.localActivated) {
+      await this.maybeSendHello(runtime);
+      await this.maybeSendAck(runtime);
+    }
+  }
+
+  private async maybeSendAck(runtime: Runtime): Promise<void> {
+    this.assertCurrent(runtime);
+    if (
+      runtime.failed || !runtime.localActivated || !runtime.localHello || !runtime.remoteHello
+      || runtime.localAckSent || runtime.ackSendPromise
+    ) return runtime.ackSendPromise ?? Promise.resolve();
+    runtime.ackSendPromise = (async () => {
+      const ack = parseAck({
+        schema: 'ananta.public-pair.media-hello-ack.v1',
+        kind: 'hello_ack',
+        session_id: runtime.sessionId,
+        epoch: runtime.contract.epoch,
+        sender_id: runtime.binding.localPeerId,
+        recipient_id: runtime.binding.remotePeerId,
+        media_contract_digest: runtime.contract.digest,
+        hello_digests: helloDigestRows(runtime),
+        expires_at_ms: Math.min(runtime.contract.expires_at_ms, Date.now() + CONTROL_TTL_MS),
+      }, runtime, 'outbound');
+      // After this point send() may have delivered the ACK even if its Promise
+      // is unresolved/rejected. The peer can derive and release media keys.
+      runtime.peerMayBeReady = true;
+      await this.sendControl(runtime, ack);
+      this.assertCurrent(runtime);
+      runtime.localAck = ack;
+      runtime.localAckSent = true;
+      await this.maybeInstall(runtime);
+    })().finally(() => { runtime.ackSendPromise = null; });
+    return runtime.ackSendPromise;
+  }
+
+  private async acceptAck(runtime: Runtime, ack: MediaHelloAckV1): Promise<void> {
+    this.assertCurrent(runtime);
+    if (!runtime.localHello || !runtime.remoteHello) throw new Error('public_media_hello_missing');
+    if (canonicalSecurityJson(ack.hello_digests) !== canonicalSecurityJson(helloDigestRows(runtime))) {
+      throw new Error('public_media_ack_binding_invalid');
+    }
+    if (runtime.remoteAck && canonicalSecurityJson(runtime.remoteAck) !== canonicalSecurityJson(ack)) {
+      throw new Error('public_media_ack_conflict');
+    }
+    runtime.remoteAck = ack;
+    await this.maybeInstall(runtime);
+  }
+
+  private async maybeInstall(runtime: Runtime): Promise<void> {
+    this.assertCurrent(runtime);
+    if (
+      runtime.failed || runtime.installed || runtime.installPromise
+      || !runtime.topologyReady || !runtime.localAckSent || !runtime.localAck || !runtime.remoteAck
+      || !runtime.localHello || !runtime.remoteHello
+    ) return runtime.installPromise ?? Promise.resolve();
+    this.emit(runtime, 'negotiating');
+    runtime.installPromise = (async () => {
+      assertFreshHandshake(runtime);
+      const connectionId = await connectionDigest(runtime);
+      this.assertCurrent(runtime);
+      const keys = await this.deriveSlotKeys(runtime, connectionId);
+      this.assertCurrent(runtime);
+      assertFreshHandshake(runtime);
+      if (runtime.contract.expires_at_ms <= Date.now()) throw new Error('public_media_contract_expired');
+      runtime.installAttempted = true;
+      await this.transforms.installKeys(runtime.sessionId, keys, runtime.adapterGeneration);
+      this.assertCurrent(runtime);
+      runtime.installed = true;
+      this.emit(runtime, 'ready');
+    })().catch(error => {
+      this.failRuntime(runtime, reason(error, 'media_e2ee_key_install_failed'), true);
+      throw error;
+    }).finally(() => { runtime.installPromise = null; });
+    return runtime.installPromise;
+  }
+
+  private async deriveSlotKeys(
+    runtime: Runtime,
+    connectionId: string,
+  ): Promise<readonly PublicPairMediaSlotKeySet[]> {
+    const values: PublicPairMediaSlotKeySet[] = [];
+    for (const definition of PUBLIC_PAIR_MEDIA_SLOTS) {
+      const sendBindingId = await frameKeyBindingDigest(
+        runtime, connectionId, runtime.binding.localPeerId, runtime.binding.remotePeerId, definition.slot,
+      );
+      const receiveBindingId = await frameKeyBindingDigest(
+        runtime, connectionId, runtime.binding.remotePeerId, runtime.binding.localPeerId, definition.slot,
+      );
+      const [sendKey, receiveKey] = await Promise.all([
+        this.encryption.derivePurposeAesKey(runtime.binding, 'public-pair-media-frame', sendBindingId),
+        this.encryption.derivePurposeAesKey(runtime.binding, 'public-pair-media-frame', receiveBindingId),
+      ]);
+      this.assertCurrent(runtime);
+      values.push(Object.freeze({
+        slot: definition.slot,
+        sendKey,
+        receiveKey,
+        sendContext: Object.freeze({
+          sessionId: runtime.sessionId,
+          mediaContractDigest: runtime.contract.digest,
+          connectionId,
+          senderId: runtime.binding.localPeerId,
+          recipientId: runtime.binding.remotePeerId,
+          slot: definition.slot,
+          codec: definition.codec,
+          kind: definition.kind,
+          keyEpoch: runtime.contract.epoch,
+          contractExpiresAtMs: runtime.contract.expires_at_ms,
+        }),
+        receiveContext: Object.freeze({
+          sessionId: runtime.sessionId,
+          mediaContractDigest: runtime.contract.digest,
+          connectionId,
+          senderId: runtime.binding.remotePeerId,
+          recipientId: runtime.binding.localPeerId,
+          slot: definition.slot,
+          codec: definition.codec,
+          kind: definition.kind,
+          keyEpoch: runtime.contract.epoch,
+          contractExpiresAtMs: runtime.contract.expires_at_ms,
+        }),
+      }));
+    }
+    return Object.freeze(values);
+  }
+
+  private refreshExpiredPreKeyHandshake(runtime: Runtime): void {
+    this.assertCurrent(runtime);
+    const now = Date.now();
+    const localExpired = runtime.localHello !== null && runtime.localHello.expires_at_ms <= now;
+    const remoteExpired = runtime.remoteHello !== null && runtime.remoteHello.expires_at_ms <= now;
+    if (!localExpired && !remoteExpired) return;
+    if (
+      runtime.peerMayBeReady
+      || runtime.installAttempted
+      || runtime.installed
+      || runtime.helloSendPromise
+      || runtime.ackSendPromise
+    ) throw new Error('public_media_control_refresh_unsafe');
+    if (localExpired) {
+      runtime.localHello = null;
+      runtime.localHelloDigest = '';
+    }
+    if (remoteExpired) {
+      runtime.remoteHello = null;
+      runtime.remoteHelloDigest = '';
+    }
+    this.resetAcks(runtime);
+  }
+
+  private resetAcks(runtime: Runtime): void {
+    runtime.localAck = null;
+    runtime.remoteAck = null;
+    runtime.localAckSent = false;
+  }
+
+  private async sendControl(runtime: Runtime, control: MediaHelloV1 | MediaHelloAckV1): Promise<void> {
+    this.assertCurrent(runtime);
+    if (!runtime.port || !runtime.dataChannelOpen) throw new Error('public_media_transport_not_open');
+    const sequence = await this.sequences.next(
+      runtime.sessionId, runtime.contract.epoch, runtime.binding.localPeerId, 'media',
+    );
+    this.assertCurrent(runtime);
+    const envelope = await this.encryption.seal(
+      runtime.binding,
+      new TextEncoder().encode(canonicalSecurityJson(control)),
+      {
+        sequence,
+        payloadType: 'public_pair_media_control',
+        trafficClass: 'media',
+        expiresAtMs: control.expires_at_ms,
+      },
+    );
+    this.assertCurrent(runtime);
+    const envelopeBytes = new TextEncoder().encode(canonicalSecurityJson(envelope));
+    const message = await validateSemanticDcMessage({
+      version: SEMANTIC_DC_VERSION,
+      traffic_class: 'control',
+      message_id: `${CONTROL_MESSAGE_PREFIX}${control.kind}-${runtime.contract.epoch}-${sequence}`,
+      session_id: runtime.sessionId,
+      epoch: runtime.contract.epoch,
+      sender_id: runtime.binding.localPeerId,
+      audience_id: runtime.binding.remotePeerId,
+      sequence,
+      expires_at_ms: control.expires_at_ms,
+      compression: 'none',
+      security: { algorithm: 'AES-GCM-256', key_id: runtime.binding.keyId },
+      payload_bytes: envelopeBytes.byteLength,
+      payload_digest: await digestBytes(envelopeBytes),
+      ciphertext: encodeB64(envelopeBytes),
+    });
+    this.assertCurrent(runtime);
+    await runtime.port.send(message);
+    this.assertCurrent(runtime);
+  }
+
+  private async openControl(
+    runtime: Runtime,
+    raw: SemanticDataChannelMessage,
+  ): Promise<MediaHelloV1 | MediaHelloAckV1> {
+    const message = await validateSemanticDcMessage(raw);
+    this.assertCurrent(runtime);
+    if (
+      message.session_id !== runtime.sessionId
+      || message.epoch !== runtime.contract.epoch
+      || message.sender_id !== runtime.binding.remotePeerId
+      || message.audience_id !== runtime.binding.localPeerId
+      || message.security.key_id !== runtime.binding.keyId
+      || message.expires_at_ms <= Date.now()
+      || message.expires_at_ms > runtime.contract.expires_at_ms
+    ) throw new Error('public_media_control_context_mismatch');
+    let envelope: unknown;
+    try {
+      envelope = JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(decodeB64(message.ciphertext)));
+    } catch {
+      throw new Error('public_media_control_ciphertext_invalid');
+    }
+    const opened = await this.encryption.open(runtime.binding, envelope);
+    this.assertCurrent(runtime);
+    if (
+      opened.envelope.payload_type !== 'public_pair_media_control'
+      || opened.envelope.aad.traffic_class !== 'media'
+      || opened.envelope.sequence !== message.sequence
+      || opened.envelope.expires_at_ms !== message.expires_at_ms
+    ) throw new Error('public_media_control_envelope_mismatch');
+    let control: unknown;
+    try {
+      control = JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(opened.plaintext));
+    } catch {
+      throw new Error('public_media_control_plaintext_invalid');
+    }
+    const kind = (control as Record<string, unknown> | null)?.['kind'];
+    return kind === 'hello'
+      ? parseHello(control, runtime, 'inbound')
+      : parseAck(control, runtime, 'inbound');
+  }
+
+  private waitForActivation(runtime: Runtime): Promise<PublicPairMediaE2eeState> {
+    const current = this.statusFor(runtime.sessionId);
+    if (current.state === 'ready' || current.state === 'failed') return Promise.resolve(current);
+    return new Promise(resolve => {
+      let settled = false;
+      let timeout: ReturnType<typeof setTimeout> | null = null;
+      const subscription = this.status$.subscribe(state => {
+        if (settled || state.sessionId !== runtime.sessionId) return;
+        if (this.runtime === runtime && state.state === 'failed') {
+          settled = true;
+          if (timeout !== null) clearTimeout(timeout);
+          subscription.unsubscribe();
+          resolve(state);
+          return;
+        }
+        if (this.runtime !== runtime || runtime.poisoned) {
+          settled = true;
+          if (timeout !== null) clearTimeout(timeout);
+          subscription.unsubscribe();
+          resolve(state.state === 'inactive' ? state : Object.freeze({
+            sessionId: runtime.sessionId,
+            state: 'inactive',
+            reasonCode: 'public_media_activation_superseded',
+            contractDigest: runtime.contract.digest,
+          }));
+          return;
+        }
+        if (state.state === 'ready') {
+          settled = true;
+          if (timeout !== null) clearTimeout(timeout);
+          subscription.unsubscribe();
+          resolve(state);
+        }
+      });
+      timeout = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        subscription.unsubscribe();
+        if (this.runtime !== runtime || runtime.poisoned) {
+          resolve(Object.freeze({
+            sessionId: runtime.sessionId,
+            state: 'failed',
+            reasonCode: 'public_media_activation_superseded',
+            contractDigest: runtime.contract.digest,
+          }));
+          return;
+        }
+        const state = Object.freeze({
+          ...this.statusFor(runtime.sessionId),
+          reasonCode: 'public_media_peer_activation_pending',
+        });
+        this.statusSubject.next(state);
+        resolve(state);
+      }, ACTIVATION_WAIT_MS);
+    });
+  }
+
+  private derivedStatus(sessionId: string): PublicPairMediaE2eeState {
+    const contract = this.bootstrap.mediaContractFor(sessionId);
+    if (!contract) return Object.freeze({
+      sessionId, state: 'awaiting-security', reasonCode: 'public_media_contract_missing',
+    });
+    if (contract.expires_at_ms <= Date.now()) return Object.freeze({
+      sessionId, state: 'failed', reasonCode: 'public_media_contract_expired', contractDigest: contract.digest,
+    });
+    if (!this.transforms.isPrepared(sessionId, contract.epoch, contract.digest)) return Object.freeze({
+      sessionId, state: 'awaiting-peer', reasonCode: 'public_media_transform_not_prepared',
+      contractDigest: contract.digest,
+    });
+    return Object.freeze({ sessionId, state: 'inactive', contractDigest: contract.digest });
+  }
+
+  private emit(runtime: Runtime, state: PublicPairMediaE2eeStateName, reasonCode?: string): void {
+    if (this.runtime !== runtime) return;
+    this.statusSubject.next(Object.freeze({
+      sessionId: runtime.sessionId,
+      state,
+      ...(reasonCode ? { reasonCode } : {}),
+      contractDigest: runtime.contract.digest,
+    }));
+  }
+
+  private failRuntime(
+    runtime: Runtime,
+    reasonCode: string,
+    releaseWorker: boolean,
+    terminateTransport = true,
+  ): void {
+    if (runtime.failed || runtime.poisoned || this.runtime !== runtime) return;
+    const port = runtime.port;
+    runtime.failed = true;
+    runtime.poisoned = true;
+    runtime.port = null;
+    runtime.dataChannelOpen = false;
+    runtime.localActivated = false;
+    this.clearExpiry(runtime);
+    if (releaseWorker) this.transforms.releaseSession(runtime.sessionId, runtime.adapterGeneration);
+    if (!terminateTransport) {
+      try { port?.disableMedia(reasonCode); } catch { /* Media is already locally disabled. */ }
+    }
+    this.emit(runtime, 'failed', reasonCode);
+    if (terminateTransport) {
+      try { port?.failClosed(reasonCode); } catch { /* Fail-closed state remains authoritative. */ }
+    }
+  }
+
+  private armExpiry(runtime: Runtime): void {
+    this.clearExpiry(runtime);
+    const delay = Math.max(1, Math.min(2_147_483_647, runtime.contract.expires_at_ms - Date.now()));
+    runtime.expiryTimer = setTimeout(() => {
+      this.failRuntime(runtime, 'public_media_contract_expired', true);
+    }, delay);
+  }
+
+  private clearExpiry(runtime: Runtime): void {
+    if (runtime.expiryTimer !== null) clearTimeout(runtime.expiryTimer);
+    runtime.expiryTimer = null;
+  }
+
+  private assertCurrent(runtime: Runtime): void {
+    if (
+      this.runtime !== runtime
+      || runtime.generation !== this.runtimeGeneration
+      || runtime.failed
+      || runtime.poisoned
+      || runtime.contract.expires_at_ms <= Date.now()
+      || !this.transforms.isPrepared(
+        runtime.sessionId,
+        runtime.contract.epoch,
+        runtime.contract.digest,
+        runtime.adapterGeneration,
+      )
+    ) throw new Error('public_media_runtime_superseded');
+  }
+}
+
+function parseHello(
+  raw: unknown,
+  runtime: Runtime,
+  direction: 'inbound' | 'outbound',
+): MediaHelloV1 {
+  const value = closedObject(raw, [
+    'schema', 'kind', 'session_id', 'epoch', 'sender_id', 'recipient_id',
+    'media_contract_digest', 'connection_salt_b64', 'slots', 'expires_at_ms',
+  ], 'public_media_hello_invalid');
+  if (
+    value['schema'] !== 'ananta.public-pair.media-hello.v1'
+    || value['kind'] !== 'hello'
+    || value['session_id'] !== runtime.sessionId
+    || value['epoch'] !== runtime.contract.epoch
+    || value['media_contract_digest'] !== runtime.contract.digest
+    || !exactStrings(value['slots'], PUBLIC_PAIR_MEDIA_GRANTS)
+    || !validControlExpiry(value['expires_at_ms'], runtime.contract.expires_at_ms)
+  ) throw new Error('public_media_hello_invalid');
+  validateDirectedPeers(value, runtime, direction);
+  const salt = decodeB64(value['connection_salt_b64']);
+  if (salt.byteLength !== 16 || encodeB64(salt) !== value['connection_salt_b64']) {
+    throw new Error('public_media_hello_invalid');
+  }
+  return Object.freeze(value as unknown as MediaHelloV1);
+}
+
+function parseAck(
+  raw: unknown,
+  runtime: Runtime,
+  direction: 'inbound' | 'outbound',
+): MediaHelloAckV1 {
+  const value = closedObject(raw, [
+    'schema', 'kind', 'session_id', 'epoch', 'sender_id', 'recipient_id',
+    'media_contract_digest', 'hello_digests', 'expires_at_ms',
+  ], 'public_media_ack_invalid');
+  if (
+    value['schema'] !== 'ananta.public-pair.media-hello-ack.v1'
+    || value['kind'] !== 'hello_ack'
+    || value['session_id'] !== runtime.sessionId
+    || value['epoch'] !== runtime.contract.epoch
+    || value['media_contract_digest'] !== runtime.contract.digest
+    || !validControlExpiry(value['expires_at_ms'], runtime.contract.expires_at_ms)
+  ) throw new Error('public_media_ack_invalid');
+  validateDirectedPeers(value, runtime, direction);
+  if (!Array.isArray(value['hello_digests']) || value['hello_digests'].length !== 2) {
+    throw new Error('public_media_ack_invalid');
+  }
+  const rows = value['hello_digests'].map(item => {
+    const row = closedObject(item, ['peer_id', 'digest'], 'public_media_ack_invalid');
+    if (!ID_RE.test(String(row['peer_id'] ?? '')) || !DIGEST_RE.test(String(row['digest'] ?? ''))) {
+      throw new Error('public_media_ack_invalid');
+    }
+    return Object.freeze(row as unknown as { peer_id: string; digest: string });
+  });
+  if (rows[0].peer_id >= rows[1].peer_id) throw new Error('public_media_ack_invalid');
+  return Object.freeze({
+    ...(value as unknown as MediaHelloAckV1),
+    hello_digests: Object.freeze(rows) as MediaHelloAckV1['hello_digests'],
+  });
+}
+
+function validateDirectedPeers(
+  value: Record<string, unknown>,
+  runtime: Runtime,
+  direction: 'inbound' | 'outbound',
+): void {
+  const sender = value['sender_id'];
+  const recipient = value['recipient_id'];
+  const outbound = sender === runtime.binding.localPeerId && recipient === runtime.binding.remotePeerId;
+  const inbound = sender === runtime.binding.remotePeerId && recipient === runtime.binding.localPeerId;
+  if ((direction === 'outbound' && !outbound) || (direction === 'inbound' && !inbound)) {
+    throw new Error('public_media_control_context_mismatch');
+  }
+}
+
+function helloDigestRows(runtime: Runtime): MediaHelloAckV1['hello_digests'] {
+  if (!runtime.localHelloDigest || !runtime.remoteHelloDigest) throw new Error('public_media_hello_missing');
+  const rows = [
+    Object.freeze({ peer_id: runtime.binding.localPeerId, digest: runtime.localHelloDigest }),
+    Object.freeze({ peer_id: runtime.binding.remotePeerId, digest: runtime.remoteHelloDigest }),
+  ].sort((left, right) => left.peer_id.localeCompare(right.peer_id));
+  return Object.freeze(rows) as unknown as MediaHelloAckV1['hello_digests'];
+}
+
+function assertFreshHandshake(runtime: Runtime): void {
+  const now = Date.now();
+  if (
+    !runtime.localHello
+    || !runtime.remoteHello
+    || !runtime.localAck
+    || !runtime.remoteAck
+    || runtime.localHello.expires_at_ms <= now
+    || runtime.remoteHello.expires_at_ms <= now
+    || runtime.localAck.expires_at_ms <= now
+    || runtime.remoteAck.expires_at_ms <= now
+    || canonicalSecurityJson(runtime.localAck.hello_digests)
+      !== canonicalSecurityJson(helloDigestRows(runtime))
+    || canonicalSecurityJson(runtime.remoteAck.hello_digests)
+      !== canonicalSecurityJson(helloDigestRows(runtime))
+  ) throw new Error('public_media_handshake_expired');
+}
+
+async function connectionDigest(runtime: Runtime): Promise<string> {
+  if (!runtime.localHello || !runtime.remoteHello) throw new Error('public_media_hello_missing');
+  const salts = [runtime.localHello, runtime.remoteHello]
+    .map(hello => ({ peer_id: hello.sender_id, salt_b64: hello.connection_salt_b64 }))
+    .sort((left, right) => left.peer_id.localeCompare(right.peer_id));
+  return digestCanonical({
+    domain: 'ananta.public-pair.media-connection.v1',
+    session_id: runtime.sessionId,
+    epoch: runtime.contract.epoch,
+    media_contract_digest: runtime.contract.digest,
+    salts,
+  });
+}
+
+function frameKeyBindingDigest(
+  runtime: Runtime,
+  connectionId: string,
+  senderId: string,
+  recipientId: string,
+  slot: string,
+): Promise<string> {
+  return digestCanonical({
+    domain: 'ananta.public-pair.media-frame-key-binding.v1',
+    session_id: runtime.sessionId,
+    epoch: runtime.contract.epoch,
+    media_contract_digest: runtime.contract.digest,
+    connection_id: connectionId,
+    sender_id: senderId,
+    recipient_id: recipientId,
+    slot,
+  });
+}
+
+function validControlExpiry(value: unknown, contractExpiry: number): boolean {
+  return Number.isSafeInteger(value) && (value as number) > Date.now() && (value as number) <= contractExpiry;
+}
+
+function closedObject(raw: unknown, fields: readonly string[], reasonCode: string): Record<string, unknown> {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) throw new Error(reasonCode);
+  const value = raw as Record<string, unknown>;
+  const keys = Object.keys(value);
+  if (keys.length !== fields.length || fields.some(field => !(field in value))) throw new Error(reasonCode);
+  return value;
+}
+
+function exactStrings(value: unknown, expected: readonly string[]): boolean {
+  return Array.isArray(value)
+    && value.length === expected.length
+    && value.every((item, index) => item === expected[index]);
+}
+
+function reason(error: unknown, fallback: string): string {
+  return error instanceof Error && /^[a-z][a-z0-9_]{2,119}$/.test(error.message)
+    ? error.message : fallback;
+}
+
+function digestCanonical(value: unknown): Promise<string> {
+  return digestBytes(new TextEncoder().encode(canonicalSecurityJson(value)));
+}
+
+async function digestBytes(value: Uint8Array): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', Uint8Array.from(value).buffer);
+  return [...new Uint8Array(digest)].map(byte => byte.toString(16).padStart(2, '0')).join('');
+}

--- a/frontend-angular/src/app/services/pair-media-e2ee-frame-codec.spec.ts
+++ b/frontend-angular/src/app/services/pair-media-e2ee-frame-codec.spec.ts
@@ -1,0 +1,157 @@
+import {
+  PairMediaE2eeFrameCipher,
+  PairMediaE2eeFrameContext,
+} from './pair-media-e2ee-frame-codec';
+
+const context = (overrides: Partial<PairMediaE2eeFrameContext> = {}): PairMediaE2eeFrameContext => ({
+  sessionId: 'session-a',
+  mediaContractDigest: 'a'.repeat(64),
+  connectionId: 'b'.repeat(64),
+  senderId: 'peer:sender',
+  recipientId: 'peer:recipient',
+  slot: 'camera-vp8',
+  codec: 'vp8',
+  kind: 'video',
+  keyEpoch: 7,
+  contractExpiresAtMs: 2_000_000_000_000,
+  ...overrides,
+});
+
+async function key(): Promise<CryptoKey> {
+  return crypto.subtle.generateKey(
+    { name: 'AES-GCM', length: 256 }, false, ['encrypt', 'decrypt'],
+  );
+}
+
+function counter(frame: ArrayBuffer): bigint {
+  return new DataView(frame).getBigUint64(12);
+}
+
+describe('PairMediaE2eeFrameCipher', () => {
+  it('round-trips while binding exact direction, slot, contract and connection', async () => {
+    const aes = await key();
+    const sender = new PairMediaE2eeFrameCipher(context());
+    const receiver = new PairMediaE2eeFrameCipher(context());
+    const encoded = await sender.seal(aes, new TextEncoder().encode('secret').buffer, 'key');
+    await expect(receiver.open(aes, encoded, 'key')).resolves.toEqual(
+      new TextEncoder().encode('secret').buffer,
+    );
+    await expect(new PairMediaE2eeFrameCipher(context({ slot: 'screen-vp8' })).open(aes, encoded, 'key'))
+      .rejects.toThrow('media_e2ee_authentication_failed');
+    await expect(new PairMediaE2eeFrameCipher(context({ connectionId: 'c'.repeat(64) })).open(aes, encoded, 'key'))
+      .rejects.toThrow('media_e2ee_authentication_failed');
+  });
+
+  it('reserves distinct counters before concurrent encryption awaits', async () => {
+    const aes = await key();
+    const sender = new PairMediaE2eeFrameCipher(context());
+    const frames = await Promise.all([
+      sender.seal(aes, Uint8Array.of(1).buffer, 'delta'),
+      sender.seal(aes, Uint8Array.of(2).buffer, 'delta'),
+      sender.seal(aes, Uint8Array.of(3).buffer, 'delta'),
+    ]);
+    expect(new Set(frames.map(counter))).toEqual(new Set([1n, 2n, 3n]));
+  });
+
+  it('authenticates an empty encoded frame without treating DTX as fatal', async () => {
+    const aes = await key();
+    const encoded = await new PairMediaE2eeFrameCipher(context())
+      .seal(aes, new ArrayBuffer(0), 'empty');
+    await expect(new PairMediaE2eeFrameCipher(context()).open(aes, encoded, 'empty'))
+      .resolves.toEqual(new ArrayBuffer(0));
+  });
+
+  it('rejects every frame at the signed contract expiry boundary', async () => {
+    const aes = await key();
+    let now = 99;
+    const expiringContext = context({ contractExpiresAtMs: 100 });
+    const sender = new PairMediaE2eeFrameCipher(expiringContext, () => now);
+    const receiver = new PairMediaE2eeFrameCipher(expiringContext, () => now);
+    const encoded = await sender.seal(aes, Uint8Array.of(1).buffer, 'delta');
+    now = 100;
+
+    await expect(sender.seal(aes, Uint8Array.of(2).buffer, 'delta'))
+      .rejects.toThrow('media_e2ee_contract_expired');
+    await expect(receiver.open(aes, encoded, 'delta'))
+      .rejects.toThrow('media_e2ee_contract_expired');
+  });
+
+  it('does not release a frame when WebCrypto crosses the expiry boundary', async () => {
+    const aes = await key();
+    let now = 99;
+    const gate = deferred<void>();
+    const originalEncrypt = crypto.subtle.encrypt.bind(crypto.subtle);
+    const encryptSpy = vi.spyOn(crypto.subtle, 'encrypt').mockImplementationOnce(async (...args) => {
+      await gate.promise;
+      return originalEncrypt(...args);
+    });
+    try {
+      const sealing = new PairMediaE2eeFrameCipher(
+        context({ contractExpiresAtMs: 100 }), () => now,
+      ).seal(aes, Uint8Array.of(1).buffer, 'delta');
+      const rejected = expect(sealing).rejects.toThrow('media_e2ee_contract_expired');
+      await Promise.resolve();
+      now = 100;
+      gate.resolve(undefined);
+      await rejected;
+    } finally {
+      encryptSpy.mockRestore();
+    }
+
+    now = 99;
+    const expiringContext = context({ contractExpiresAtMs: 100 });
+    const encoded = await new PairMediaE2eeFrameCipher(expiringContext, () => now)
+      .seal(aes, Uint8Array.of(2).buffer, 'delta');
+    const decryptGate = deferred<void>();
+    const originalDecrypt = crypto.subtle.decrypt.bind(crypto.subtle);
+    const decryptSpy = vi.spyOn(crypto.subtle, 'decrypt').mockImplementationOnce(async (...args) => {
+      await decryptGate.promise;
+      return originalDecrypt(...args);
+    });
+    try {
+      const opening = new PairMediaE2eeFrameCipher(expiringContext, () => now)
+        .open(aes, encoded, 'delta');
+      const rejected = expect(opening).rejects.toThrow('media_e2ee_contract_expired');
+      await Promise.resolve();
+      now = 100;
+      decryptGate.resolve(undefined);
+      await rejected;
+    } finally {
+      decryptSpy.mockRestore();
+    }
+  });
+
+  it('admits a ciphertext only once when concurrent opens race', async () => {
+    const aes = await key();
+    const encoded = await new PairMediaE2eeFrameCipher(context())
+      .seal(aes, Uint8Array.of(1, 2, 3).buffer, 'delta');
+    const receiver = new PairMediaE2eeFrameCipher(context());
+    const results = await Promise.allSettled([
+      receiver.open(aes, encoded, 'delta'),
+      receiver.open(aes, encoded, 'delta'),
+    ]);
+    expect(results.filter(result => result.status === 'fulfilled')).toHaveLength(1);
+    expect(results.filter(result => result.status === 'rejected')).toHaveLength(1);
+    expect(String((results.find(result => result.status === 'rejected') as PromiseRejectedResult).reason))
+      .toContain('media_e2ee_replay');
+  });
+
+  it('permanently rejects frames older than the strict sliding window', async () => {
+    const aes = await key();
+    const sender = new PairMediaE2eeFrameCipher(context());
+    const receiver = new PairMediaE2eeFrameCipher(context());
+    const first = await sender.seal(aes, Uint8Array.of(1).buffer, 'delta');
+    await receiver.open(aes, first, 'delta');
+    for (let index = 0; index < 2_049; index += 1) {
+      const encoded = await sender.seal(aes, Uint8Array.of(index & 0xff).buffer, 'delta');
+      await receiver.open(aes, encoded, 'delta');
+    }
+    await expect(receiver.open(aes, first, 'delta')).rejects.toThrow('media_e2ee_replay_too_old');
+  });
+});
+
+function deferred<T>(): { promise: Promise<T>; resolve(value: T): void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(accept => { resolve = accept; });
+  return { promise, resolve };
+}

--- a/frontend-angular/src/app/services/pair-media-e2ee-frame-codec.ts
+++ b/frontend-angular/src/app/services/pair-media-e2ee-frame-codec.ts
@@ -1,0 +1,283 @@
+import { canonicalSecurityJson } from './webrtc-secure-envelope';
+
+export interface PairMediaE2eeFrameContext {
+  readonly sessionId: string;
+  readonly mediaContractDigest: string;
+  readonly connectionId: string;
+  readonly senderId: string;
+  readonly recipientId: string;
+  readonly slot: string;
+  readonly codec: string;
+  readonly kind: 'audio' | 'video';
+  readonly keyEpoch: number;
+  readonly contractExpiresAtMs: number;
+}
+
+const MAGIC = Uint8Array.of(0x41, 0x4e, 0x4d, 0x46); // ANMF
+const VERSION = 1;
+const HEADER_BYTES = 20;
+const TAG_BYTES = 16;
+const MAX_FRAME_BYTES = 8 * 1024 * 1024;
+const MAX_COUNTER = 0xffff_ffff_ffff_ffffn;
+const REPLAY_WINDOW = 2_048n;
+const DIGEST_RE = /^[a-f0-9]{64}$/;
+const IDENTIFIER_RE = /^[A-Za-z0-9][A-Za-z0-9._:@-]{0,127}$/;
+const CODEC_RE = /^[a-z0-9][a-z0-9._+-]{0,31}$/;
+
+type FrameType = 'audio' | 'key' | 'delta' | 'empty';
+
+/**
+ * Stateful AEAD codec for exactly one direction/slot/connection key.
+ *
+ * The 96-bit nonce is epoch || uint64(counter). The caller must derive a
+ * fresh key for every connectionId/direction/slot. A 128-bit salt from each
+ * peer is included in that connectionId, so a counter reset cannot reuse a
+ * nonce under the same key after reconnect or reload.
+ */
+export class PairMediaE2eeFrameCipher {
+  private sendCounter = 0n;
+  private highestReceived = 0n;
+  private readonly received = new Set<bigint>();
+  private readonly pendingReceived = new Set<bigint>();
+
+  constructor(
+    readonly context: Readonly<PairMediaE2eeFrameContext>,
+    private readonly now: () => number = () => Date.now(),
+  ) {
+    validateContext(context);
+  }
+
+  async seal(key: CryptoKey, plaintext: ArrayBuffer, frameType: string): Promise<ArrayBuffer> {
+    this.assertContractLive();
+    validateKey(key);
+    validatePayload(plaintext);
+    const normalizedType = normalizeFrameType(frameType, this.context.kind);
+    const counter = this.sendCounter + 1n;
+    if (counter > MAX_COUNTER) throw new Error('media_e2ee_counter_exhausted');
+    // Reserve before the first await. Concurrent callers may leave a gap on
+    // encryption failure, but can never reuse a nonce under this key.
+    this.sendCounter = counter;
+    const header = encodeHeader(this.context.keyEpoch, counter, normalizedType);
+    const nonce = nonceFor(this.context.keyEpoch, counter);
+    const ciphertext = await crypto.subtle.encrypt(
+      {
+        name: 'AES-GCM',
+        iv: arrayBuffer(nonce),
+        additionalData: arrayBuffer(aad(this.context, header)),
+        tagLength: 128,
+      },
+      key,
+      plaintext,
+    );
+    this.assertContractLive();
+    const output = new Uint8Array(HEADER_BYTES + ciphertext.byteLength);
+    output.set(header);
+    output.set(new Uint8Array(ciphertext), HEADER_BYTES);
+    return output.buffer;
+  }
+
+  async open(
+    key: CryptoKey,
+    encoded: ArrayBuffer,
+    expectedFrameType?: string,
+  ): Promise<ArrayBuffer> {
+    this.assertContractLive();
+    validateKey(key);
+    if (
+      !isArrayBuffer(encoded)
+      || encoded.byteLength < HEADER_BYTES + TAG_BYTES
+      || encoded.byteLength > HEADER_BYTES + TAG_BYTES + MAX_FRAME_BYTES
+    ) throw new Error('media_e2ee_frame_size_invalid');
+    const frame = new Uint8Array(encoded);
+    const parsed = decodeHeader(frame);
+    if (parsed.epoch !== this.context.keyEpoch) throw new Error('media_e2ee_epoch_stale');
+    if (expectedFrameType !== undefined) {
+      const expected = normalizeFrameType(expectedFrameType, this.context.kind);
+      if (parsed.frameType !== expected) throw new Error('media_e2ee_frame_type_mismatch');
+    }
+    this.assertReplayAdmissible(parsed.counter);
+    // TransformStream serializes frames in production, but the primitive is
+    // independently safe when multiple callers race the same ciphertext.
+    this.pendingReceived.add(parsed.counter);
+    let plaintext: ArrayBuffer;
+    try {
+      plaintext = await crypto.subtle.decrypt(
+        {
+          name: 'AES-GCM',
+          iv: arrayBuffer(nonceFor(parsed.epoch, parsed.counter)),
+          additionalData: arrayBuffer(aad(this.context, frame.slice(0, HEADER_BYTES))),
+          tagLength: 128,
+        },
+        key,
+        frame.slice(HEADER_BYTES),
+      );
+    } catch (error) {
+      if (error instanceof Error && error.message.startsWith('media_e2ee_')) throw error;
+      throw new Error('media_e2ee_authentication_failed');
+    } finally {
+      this.pendingReceived.delete(parsed.counter);
+    }
+    this.assertContractLive();
+    this.claimCounter(parsed.counter);
+    return plaintext;
+  }
+
+  clear(): void {
+    this.sendCounter = 0n;
+    this.highestReceived = 0n;
+    this.received.clear();
+    this.pendingReceived.clear();
+  }
+
+  private assertReplayAdmissible(counter: bigint): void {
+    if (counter < 1n) throw new Error('media_e2ee_counter_invalid');
+    if (this.received.has(counter) || this.pendingReceived.has(counter)) {
+      throw new Error('media_e2ee_replay');
+    }
+    const floor = replayFloor(this.highestReceived);
+    if (counter < floor) throw new Error('media_e2ee_replay_too_old');
+  }
+
+  private claimCounter(counter: bigint): void {
+    if (counter > this.highestReceived) this.highestReceived = counter;
+    this.received.add(counter);
+    const floor = replayFloor(this.highestReceived);
+    for (const seen of this.received) {
+      if (seen < floor) this.received.delete(seen);
+    }
+  }
+
+  private assertContractLive(): void {
+    if (this.context.contractExpiresAtMs <= this.now()) {
+      throw new Error('media_e2ee_contract_expired');
+    }
+  }
+}
+
+function replayFloor(highest: bigint): bigint {
+  return highest >= REPLAY_WINDOW ? highest - REPLAY_WINDOW + 1n : 1n;
+}
+
+function encodeHeader(epoch: number, counter: bigint, frameType: FrameType): Uint8Array {
+  const header = new Uint8Array(HEADER_BYTES);
+  header.set(MAGIC, 0);
+  header[4] = VERSION;
+  header[5] = frameTypeCode(frameType);
+  const view = new DataView(header.buffer);
+  view.setUint32(8, epoch);
+  view.setBigUint64(12, counter);
+  return header;
+}
+
+function decodeHeader(frame: Uint8Array): { epoch: number; counter: bigint; frameType: FrameType } {
+  if (
+    frame.byteLength < HEADER_BYTES
+    || !MAGIC.every((byte, index) => frame[index] === byte)
+    || frame[4] !== VERSION
+    || frame[6] !== 0
+    || frame[7] !== 0
+  ) throw new Error('media_e2ee_header_invalid');
+  const frameType = frameTypeFromCode(frame[5]);
+  const view = new DataView(frame.buffer, frame.byteOffset, HEADER_BYTES);
+  const epoch = view.getUint32(8);
+  const counter = view.getBigUint64(12);
+  if (epoch < 1 || counter < 1n) throw new Error('media_e2ee_header_invalid');
+  return { epoch, counter, frameType };
+}
+
+function nonceFor(epoch: number, counter: bigint): Uint8Array {
+  const nonce = new Uint8Array(12);
+  const view = new DataView(nonce.buffer);
+  view.setUint32(0, epoch);
+  view.setBigUint64(4, counter);
+  return nonce;
+}
+
+function aad(context: Readonly<PairMediaE2eeFrameContext>, header: Uint8Array): Uint8Array {
+  return new TextEncoder().encode(canonicalSecurityJson({
+    domain: 'ananta.public-pair.media-frame.v1',
+    session_id: context.sessionId,
+    media_contract_digest: context.mediaContractDigest,
+    connection_id: context.connectionId,
+    sender_id: context.senderId,
+    recipient_id: context.recipientId,
+    slot: context.slot,
+    kind: context.kind,
+    codec: context.codec,
+    key_epoch: context.keyEpoch,
+    contract_expires_at_ms: context.contractExpiresAtMs,
+    header_hex: [...header].map(byte => byte.toString(16).padStart(2, '0')).join(''),
+  }));
+}
+
+function frameTypeCode(value: FrameType): number {
+  switch (value) {
+    case 'audio': return 0;
+    case 'key': return 1;
+    case 'delta': return 2;
+    case 'empty': return 3;
+  }
+}
+
+function frameTypeFromCode(value: number): FrameType {
+  switch (value) {
+    case 0: return 'audio';
+    case 1: return 'key';
+    case 2: return 'delta';
+    case 3: return 'empty';
+    default: throw new Error('media_e2ee_header_invalid');
+  }
+}
+
+function normalizeFrameType(value: string, kind: 'audio' | 'video'): FrameType {
+  if (kind === 'audio') return 'audio';
+  if (value === 'key' || value === 'delta' || value === 'empty') return value;
+  throw new Error('media_e2ee_frame_type_invalid');
+}
+
+function validateContext(value: Readonly<PairMediaE2eeFrameContext>): void {
+  if (
+    !IDENTIFIER_RE.test(value.sessionId)
+    || !DIGEST_RE.test(value.mediaContractDigest)
+    || !DIGEST_RE.test(value.connectionId)
+    || !IDENTIFIER_RE.test(value.senderId)
+    || !IDENTIFIER_RE.test(value.recipientId)
+    || value.senderId === value.recipientId
+    || !IDENTIFIER_RE.test(value.slot)
+    || !CODEC_RE.test(value.codec)
+    || (value.kind !== 'audio' && value.kind !== 'video')
+    || !Number.isSafeInteger(value.keyEpoch)
+    || value.keyEpoch < 1
+    || value.keyEpoch > 0xffff_ffff
+    || !Number.isSafeInteger(value.contractExpiresAtMs)
+    || value.contractExpiresAtMs < 1
+  ) throw new Error('media_e2ee_context_invalid');
+}
+
+function validateKey(key: CryptoKey): void {
+  if (
+    !key
+    || key.type !== 'secret'
+    || key.algorithm.name !== 'AES-GCM'
+    || key.extractable
+    || !key.usages.includes('encrypt')
+    || !key.usages.includes('decrypt')
+  ) throw new Error('media_e2ee_key_invalid');
+}
+
+function validatePayload(value: ArrayBuffer): void {
+  if (
+    !isArrayBuffer(value)
+    || value.byteLength > MAX_FRAME_BYTES
+  ) throw new Error('media_e2ee_frame_size_invalid');
+}
+
+function isArrayBuffer(value: unknown): value is ArrayBuffer {
+  // Media frames may cross a Worker/Window realm. `instanceof` is therefore
+  // not a valid brand check even though WebCrypto accepts the ArrayBuffer.
+  return Object.prototype.toString.call(value) === '[object ArrayBuffer]';
+}
+
+function arrayBuffer(value: Uint8Array): ArrayBuffer {
+  return Uint8Array.from(value).buffer;
+}

--- a/frontend-angular/src/app/services/pair-media-e2ee-transform.adapter.spec.ts
+++ b/frontend-angular/src/app/services/pair-media-e2ee-transform.adapter.spec.ts
@@ -1,0 +1,319 @@
+import { TestBed } from '@angular/core/testing';
+
+import {
+  PAIR_MEDIA_E2EE_WORKER_FACTORY,
+  PairMediaE2eeTransformAdapter,
+  PublicPairMediaSlotKeySet,
+} from './pair-media-e2ee-transform.adapter';
+import {
+  PUBLIC_PAIR_MEDIA_SLOTS,
+  PublicPairMediaSecurityContractV1,
+} from './public-pair-media-security-contract';
+
+class FakeWorker {
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: ((event: ErrorEvent) => void) | null = null;
+  onmessageerror: ((event: MessageEvent) => void) | null = null;
+  readonly messages: unknown[] = [];
+  terminated = false;
+  acknowledgeInstall = true;
+
+  postMessage(message: any): void {
+    this.messages.push(message);
+    if (message?.type === 'install-keys' && this.acknowledgeInstall) {
+      queueMicrotask(() => this.emit({
+        version: 1,
+        type: 'keys-installed',
+        sessionId: message.sessionId,
+        transformIds: message.entries.map((entry: any) => entry.transformId),
+      }));
+    }
+  }
+
+  terminate(): void { this.terminated = true; }
+
+  emit(data: unknown): void {
+    this.onmessage?.({ data } as MessageEvent);
+  }
+}
+
+class FakeScriptTransform {
+  constructor(worker: FakeWorker, options: { transformId: string }) {
+    queueMicrotask(() => worker.emit({
+      version: 1, type: 'transform-ready', transformId: options.transformId,
+    }));
+  }
+}
+
+interface FakeTransceiver {
+  mid: string | null;
+  direction: RTCRtpTransceiverDirection;
+  currentDirection: RTCRtpTransceiverDirection | null;
+  sender: RTCRtpSender & { transform?: unknown };
+  receiver: RTCRtpReceiver & { transform?: unknown };
+  setCodecPreferences: ReturnType<typeof vi.fn>;
+}
+
+class FakePeerConnection {
+  readonly transceivers: FakeTransceiver[] = [];
+  addTransceiverCalls = 0;
+
+  addTransceiver(kind: string, init: RTCRtpTransceiverInit): RTCRtpTransceiver {
+    this.addTransceiverCalls += 1;
+    const index = this.transceivers.length;
+    const value: FakeTransceiver = {
+      mid: String(index),
+      direction: init.direction ?? 'sendrecv',
+      currentDirection: 'sendrecv',
+      sender: { replaceTrack: vi.fn(async () => undefined), transform: null } as unknown as FakeTransceiver['sender'],
+      receiver: { transform: null } as unknown as FakeTransceiver['receiver'],
+      setCodecPreferences: vi.fn(),
+    };
+    expect(kind).toBe(index === 0 ? 'audio' : 'video');
+    this.transceivers.push(value);
+    return value as unknown as RTCRtpTransceiver;
+  }
+
+  getTransceivers(): RTCRtpTransceiver[] {
+    return this.transceivers as unknown as RTCRtpTransceiver[];
+  }
+
+  receiveExactMediaOffer(): void {
+    for (const [index, definition] of PUBLIC_PAIR_MEDIA_SLOTS.entries()) {
+      this.transceivers.push({
+        mid: String(index), direction: 'recvonly', currentDirection: null,
+        sender: {
+          replaceTrack: vi.fn(async () => undefined), transform: null,
+        } as unknown as FakeTransceiver['sender'],
+        receiver: {
+          track: { kind: definition.kind }, transform: null,
+        } as unknown as FakeTransceiver['receiver'],
+        setCodecPreferences: vi.fn(),
+      });
+    }
+  }
+}
+
+describe('PairMediaE2eeTransformAdapter', () => {
+  const runtime = globalThis as typeof globalThis & {
+    RTCRtpScriptTransform: typeof RTCRtpScriptTransform;
+    RTCRtpSender: typeof RTCRtpSender;
+  };
+  const originalTransform = runtime.RTCRtpScriptTransform;
+  const originalSender = runtime.RTCRtpSender;
+  let workers: FakeWorker[];
+  let adapter: PairMediaE2eeTransformAdapter;
+
+  beforeAll(() => {
+    runtime.RTCRtpScriptTransform = FakeScriptTransform as unknown as typeof RTCRtpScriptTransform;
+    runtime.RTCRtpSender = class {
+      static getCapabilities(kind: string): RTCRtpCapabilities {
+        return {
+          codecs: [{
+            mimeType: kind === 'audio' ? 'audio/opus' : 'video/VP8',
+            clockRate: kind === 'audio' ? 48_000 : 90_000,
+            ...(kind === 'audio' ? { channels: 2 } : {}),
+          }],
+          headerExtensions: [],
+        };
+      }
+    } as unknown as typeof RTCRtpSender;
+  });
+
+  afterAll(() => {
+    runtime.RTCRtpScriptTransform = originalTransform;
+    runtime.RTCRtpSender = originalSender;
+  });
+
+  beforeEach(() => {
+    workers = [];
+    TestBed.configureTestingModule({ providers: [
+      PairMediaE2eeTransformAdapter,
+      {
+        provide: PAIR_MEDIA_E2EE_WORKER_FACTORY,
+        useValue: () => {
+          const worker = new FakeWorker();
+          workers.push(worker);
+          return worker as unknown as Worker;
+        },
+      },
+    ] });
+    adapter = TestBed.inject(PairMediaE2eeTransformAdapter);
+  });
+
+  afterEach(() => {
+    adapter.releaseSession();
+    vi.useRealTimers();
+    TestBed.resetTestingModule();
+  });
+
+  it('prepares exactly three fixed sendrecv Opus/VP8 slots and validates bilateral topology', async () => {
+    const peer = new FakePeerConnection();
+    const generation = await adapter.prepareSession(
+      peer as unknown as RTCPeerConnection, 'session-a', contract(), vi.fn(),
+    );
+
+    expect(generation).toBeGreaterThan(0);
+    expect(peer.transceivers).toHaveLength(3);
+    expect(peer.transceivers.map(item => item.direction)).toEqual(['sendrecv', 'sendrecv', 'sendrecv']);
+    expect(peer.transceivers.map(item => item.setCodecPreferences.mock.calls[0][0][0].mimeType))
+      .toEqual(['audio/opus', 'video/VP8', 'video/VP8']);
+    for (const [index, definition] of PUBLIC_PAIR_MEDIA_SLOTS.entries()) {
+      expect(adapter.senderForSlot('session-a', definition.slot)).toBe(peer.transceivers[index].sender);
+      expect(adapter.slotForReceiver('session-a', peer.transceivers[index].receiver))
+        .toBe(definition.slot);
+    }
+    expect(() => adapter.validateFinalTopology('session-a')).not.toThrow();
+
+    peer.transceivers[2].currentDirection = 'sendonly';
+    expect(() => adapter.validateFinalTopology('session-a')).toThrow('public_media_topology_invalid');
+  });
+
+  it('stays unkeyed until the exact worker ACK and terminates all slots when the ACK is lost', async () => {
+    vi.useFakeTimers();
+    const fatal = vi.fn();
+    const generation = await adapter.prepareSession(
+      new FakePeerConnection() as unknown as RTCPeerConnection, 'session-a', contract(), fatal,
+    );
+    workers[0].acknowledgeInstall = false;
+    const installing = adapter.installKeys('session-a', await keySets(), generation);
+    const rejectedInstall = expect(installing).rejects.toThrow('media_e2ee_worker_ack_timeout');
+
+    expect(adapter.isKeyed('session-a')).toBe(false);
+    await vi.advanceTimersByTimeAsync(5_000);
+    await rejectedInstall;
+    expect(workers[0].terminated).toBe(true);
+    expect(adapter.isPrepared('session-a')).toBe(false);
+    expect(fatal).toHaveBeenCalledWith('media_e2ee_worker_ack_timeout');
+  });
+
+  it('does not precreate answerer slots and DROP-binds the exact remote-offer transceivers', async () => {
+    const peer = new FakePeerConnection();
+    const generation = await adapter.prepareSession(
+      peer as unknown as RTCPeerConnection,
+      'session-a',
+      contract(),
+      vi.fn(),
+      'answerer',
+    );
+    expect(peer.addTransceiverCalls).toBe(0);
+    expect(adapter.isAwaitingRemoteTopology('session-a', generation)).toBe(true);
+
+    peer.receiveExactMediaOffer();
+    const stagedSlot = adapter.stageRemoteOfferTrack(
+      'session-a',
+      peer.transceivers[0] as unknown as RTCRtpTransceiver,
+      peer.transceivers[0].receiver,
+      generation,
+    );
+    expect(stagedSlot).toBe('microphone-opus');
+    expect(peer.transceivers[0].sender.transform).toBeInstanceOf(FakeScriptTransform);
+    expect(peer.transceivers[0].receiver.transform).toBeInstanceOf(FakeScriptTransform);
+    await adapter.bindRemoteOfferTopology('session-a', generation);
+
+    expect(peer.addTransceiverCalls).toBe(0);
+    expect(peer.transceivers.map(value => value.direction))
+      .toEqual(['sendrecv', 'sendrecv', 'sendrecv']);
+    expect(adapter.isAwaitingRemoteTopology('session-a', generation)).toBe(false);
+    for (const [index, definition] of PUBLIC_PAIR_MEDIA_SLOTS.entries()) {
+      expect(adapter.senderForSlot('session-a', definition.slot)).toBe(peer.transceivers[index].sender);
+      expect(adapter.slotForReceiver('session-a', peer.transceivers[index].receiver))
+        .toBe(definition.slot);
+    }
+  });
+
+  it('sets every offered answerer transceiver inactive on partial topology fallback', async () => {
+    const peer = new FakePeerConnection();
+    const generation = await adapter.prepareSession(
+      peer as unknown as RTCPeerConnection, 'session-a', contract(), vi.fn(), 'answerer',
+    );
+    peer.receiveExactMediaOffer();
+    (peer.transceivers[2].receiver.track as { kind: string }).kind = 'audio';
+
+    await expect(adapter.bindRemoteOfferTopology('session-a', generation))
+      .rejects.toThrow('public_media_topology_invalid');
+    adapter.releaseSession('session-a', generation);
+
+    expect(peer.transceivers.map(value => value.direction))
+      .toEqual(['inactive', 'inactive', 'inactive']);
+    for (const transceiver of peer.transceivers) {
+      expect(transceiver.sender.replaceTrack).toHaveBeenCalledWith(null);
+    }
+  });
+
+  it('drops unexpected extra transceivers as well as contracted offerer slots on release', async () => {
+    const peer = new FakePeerConnection();
+    const generation = await adapter.prepareSession(
+      peer as unknown as RTCPeerConnection, 'session-a', contract(), vi.fn(), 'offerer',
+    );
+    peer.receiveExactMediaOffer();
+
+    adapter.releaseSession('session-a', generation);
+
+    expect(peer.transceivers).toHaveLength(6);
+    expect(peer.transceivers.every(value => value.direction === 'inactive')).toBe(true);
+    expect(peer.transceivers.every(value => {
+      const replaceTrack = value.sender.replaceTrack as ReturnType<typeof vi.fn>;
+      return replaceTrack.mock.calls.some(([track]) => track === null);
+    })).toBe(true);
+  });
+
+  it('allows one key installation only and globally terminates on a single transform fatal', async () => {
+    const fatal = vi.fn();
+    const generation = await adapter.prepareSession(
+      new FakePeerConnection() as unknown as RTCPeerConnection, 'session-a', contract(), fatal,
+    );
+    const keys = await keySets();
+    await adapter.installKeys('session-a', keys, generation);
+    expect(adapter.isKeyed('session-a')).toBe(true);
+    await expect(adapter.installKeys('session-a', keys, generation))
+      .rejects.toThrow('media_e2ee_key_reinstall_forbidden');
+
+    workers[0].emit({
+      version: 1, type: 'fatal', transformId: 'session-a:camera-vp8:receive',
+      reasonCode: 'media_e2ee_authentication_failed',
+    });
+    expect(workers[0].terminated).toBe(true);
+    expect(adapter.isPrepared('session-a')).toBe(false);
+    expect(fatal).toHaveBeenCalledWith('media_e2ee_authentication_failed');
+    expect(() => adapter.senderForSlot('session-a', 'camera-vp8'))
+      .toThrow('public_media_transform_not_prepared');
+  });
+});
+
+function contract(): PublicPairMediaSecurityContractV1 {
+  return {
+    session_id: 'session-a', epoch: 7, digest: 'a'.repeat(64),
+    expires_at_ms: 2_000_000_000_000, transform: 'RTCRtpScriptTransform',
+  } as PublicPairMediaSecurityContractV1;
+}
+
+async function keySets(): Promise<readonly PublicPairMediaSlotKeySet[]> {
+  const connectionId = 'b'.repeat(64);
+  const values: PublicPairMediaSlotKeySet[] = [];
+  for (const definition of PUBLIC_PAIR_MEDIA_SLOTS) {
+    const [sendKey, receiveKey] = await Promise.all([key(), key()]);
+    values.push({
+      slot: definition.slot,
+      sendKey,
+      receiveKey,
+      sendContext: {
+        sessionId: 'session-a', mediaContractDigest: 'a'.repeat(64), connectionId,
+        senderId: 'peer:local', recipientId: 'peer:remote', slot: definition.slot,
+        kind: definition.kind, codec: definition.codec, keyEpoch: 7,
+        contractExpiresAtMs: 2_000_000_000_000,
+      },
+      receiveContext: {
+        sessionId: 'session-a', mediaContractDigest: 'a'.repeat(64), connectionId,
+        senderId: 'peer:remote', recipientId: 'peer:local', slot: definition.slot,
+        kind: definition.kind, codec: definition.codec, keyEpoch: 7,
+        contractExpiresAtMs: 2_000_000_000_000,
+      },
+    });
+  }
+  return values;
+}
+
+function key(): Promise<CryptoKey> {
+  return crypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, false, ['encrypt', 'decrypt']);
+}

--- a/frontend-angular/src/app/services/pair-media-e2ee-transform.adapter.ts
+++ b/frontend-angular/src/app/services/pair-media-e2ee-transform.adapter.ts
@@ -1,0 +1,511 @@
+import { Injectable, InjectionToken, inject } from '@angular/core';
+
+import type { PairMediaE2eeFrameContext } from './pair-media-e2ee-frame-codec';
+import {
+  PUBLIC_PAIR_MEDIA_SLOTS,
+  PublicPairMediaSecurityContractV1,
+  PublicPairMediaSlot,
+} from './public-pair-media-security-contract';
+
+export interface PublicPairMediaSlotKeySet {
+  readonly slot: PublicPairMediaSlot;
+  readonly sendKey: CryptoKey;
+  readonly receiveKey: CryptoKey;
+  readonly sendContext: PairMediaE2eeFrameContext;
+  readonly receiveContext: PairMediaE2eeFrameContext;
+}
+
+export type PairMediaE2eeWorkerFactory = () => Worker;
+
+export const PAIR_MEDIA_E2EE_WORKER_FACTORY = new InjectionToken<PairMediaE2eeWorkerFactory>(
+  'PAIR_MEDIA_E2EE_WORKER_FACTORY',
+  {
+    providedIn: 'root',
+    factory: () => () => new Worker(
+      new URL('../workers/pair-media-e2ee.worker', import.meta.url),
+      { type: 'module', name: 'ananta-public-pair-media-e2ee' },
+    ),
+  },
+);
+
+interface SlotTransformState {
+  readonly slot: PublicPairMediaSlot;
+  readonly transceiver: RTCRtpTransceiver;
+  readonly sendTransformId: string;
+  readonly receiveTransformId: string;
+}
+
+interface AdapterState {
+  readonly sessionId: string;
+  readonly generation: number;
+  readonly epoch: number;
+  readonly contractDigest: string;
+  readonly contractExpiresAtMs: number;
+  readonly peer: RTCPeerConnection;
+  readonly worker: Worker;
+  readonly slots: Map<PublicPairMediaSlot, SlotTransformState>;
+  readonly receiverSlots: WeakMap<RTCRtpReceiver, PublicPairMediaSlot>;
+  readonly slotReadiness: Map<PublicPairMediaSlot, Promise<void>>;
+  readonly pending: Map<string, Deferred<void>>;
+  readonly onFatal: (reasonCode: string) => void;
+  readonly role: 'offerer' | 'answerer';
+  keyed: boolean;
+  everInstalled: boolean;
+  failed: boolean;
+  remoteTopologyFinalized: boolean;
+}
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  resolve(value?: T): void;
+  reject(error: unknown): void;
+  readonly timeout: ReturnType<typeof setTimeout>;
+}
+
+const WORKER_ACK_TIMEOUT_MS = 5_000;
+
+/** Standards-only RTCRtpScriptTransform adapter for one active Pair session. */
+@Injectable({ providedIn: 'root' })
+export class PairMediaE2eeTransformAdapter {
+  private readonly createWorker = inject(PAIR_MEDIA_E2EE_WORKER_FACTORY);
+  private active: AdapterState | null = null;
+  private generationSerial = 0;
+
+  isPrepared(sessionId: string, epoch?: number, contractDigest?: string, generation?: number): boolean {
+    return this.active?.sessionId === sessionId
+      && (epoch === undefined || this.active.epoch === epoch)
+      && (contractDigest === undefined || this.active.contractDigest === contractDigest)
+      && (generation === undefined || this.active.generation === generation)
+      && !this.active.failed;
+  }
+
+  isKeyed(sessionId: string, epoch?: number, contractDigest?: string, generation?: number): boolean {
+    return this.isPrepared(sessionId, epoch, contractDigest, generation) && this.active?.keyed === true;
+  }
+
+  generationForSession(sessionId: string): number | null {
+    return this.isPrepared(sessionId) ? this.active!.generation : null;
+  }
+
+  async prepareSession(
+    peer: RTCPeerConnection,
+    sessionId: string,
+    contract: Readonly<PublicPairMediaSecurityContractV1>,
+    onFatal: (reasonCode: string) => void,
+    role: 'offerer' | 'answerer' = 'offerer',
+  ): Promise<number> {
+    if (
+      !sessionId
+      || contract.session_id !== sessionId
+      || contract.expires_at_ms <= Date.now()
+      || contract.transform !== 'RTCRtpScriptTransform'
+    ) throw new Error('public_media_contract_not_ready');
+    if (
+      this.active?.sessionId === sessionId
+      && this.active.peer === peer
+      && this.active.epoch === contract.epoch
+      && this.active.contractDigest === contract.digest
+      && this.active.contractExpiresAtMs === contract.expires_at_ms
+      && this.active.role === role
+      && !this.active.failed
+    ) return this.active.generation;
+    this.releaseSession();
+    const worker = this.createWorker();
+    const pending = new Map<string, Deferred<void>>();
+    const receiverSlots = new WeakMap<RTCRtpReceiver, PublicPairMediaSlot>();
+    const slots = new Map<PublicPairMediaSlot, SlotTransformState>();
+    const slotReadiness = new Map<PublicPairMediaSlot, Promise<void>>();
+    const state: AdapterState = {
+      sessionId, generation: ++this.generationSerial,
+      epoch: contract.epoch, contractDigest: contract.digest,
+      contractExpiresAtMs: contract.expires_at_ms,
+      peer, worker, pending, receiverSlots, slots, slotReadiness, onFatal, role,
+      keyed: false, everInstalled: false, failed: false,
+      remoteTopologyFinalized: role === 'offerer',
+    };
+    this.active = state;
+    worker.onmessage = event => this.handleWorkerMessage(state, event.data);
+    worker.onerror = () => this.fail(state, 'media_e2ee_worker_failed');
+    worker.onmessageerror = () => this.fail(state, 'media_e2ee_worker_message_invalid');
+    try {
+      if (role === 'offerer') {
+        for (const definition of PUBLIC_PAIR_MEDIA_SLOTS) {
+          const transceiver = peer.addTransceiver(definition.kind, { direction: 'sendrecv' });
+          await this.attachSlot(state, definition, transceiver);
+        }
+      }
+      return state.generation;
+    } catch (error) {
+      this.fail(state, reason(error, 'media_e2ee_transform_prepare_failed'));
+      throw error;
+    }
+  }
+
+  /**
+   * Binds the transceivers created from the remote offer. Precreating them on
+   * the answerer duplicates m-lines in both Firefox and Chromium.
+   */
+  async bindRemoteOfferTopology(sessionId: string, generation: number): Promise<void> {
+    const state = this.requireState(sessionId, generation);
+    if (state.role !== 'answerer') {
+      throw new Error('public_media_topology_invalid');
+    }
+    const transceivers = state.peer.getTransceivers();
+    if (transceivers.length !== PUBLIC_PAIR_MEDIA_SLOTS.length) {
+      throw new Error('public_media_topology_invalid');
+    }
+    const mids = new Set<string>();
+    for (const [index, definition] of PUBLIC_PAIR_MEDIA_SLOTS.entries()) {
+      const transceiver = transceivers[index];
+      if (
+        transceiver.receiver.track.kind !== definition.kind
+        || !transceiver.mid
+        || mids.has(transceiver.mid)
+      ) throw new Error('public_media_topology_invalid');
+      mids.add(transceiver.mid);
+      transceiver.direction = 'sendrecv';
+      const existing = state.slots.get(definition.slot);
+      if (existing && existing.transceiver !== transceiver) {
+        throw new Error('public_media_topology_invalid');
+      }
+      if (existing) setExactCodecPreference(transceiver, definition.kind, definition.codec);
+      else this.attachSlot(state, definition, transceiver);
+    }
+    await Promise.all(PUBLIC_PAIR_MEDIA_SLOTS.map(definition => state.slotReadiness.get(definition.slot)));
+    if (this.active !== state || state.failed) throw new Error('media_e2ee_session_released');
+    state.remoteTopologyFinalized = true;
+  }
+
+  isAwaitingRemoteTopology(sessionId: string, generation?: number): boolean {
+    return this.isPrepared(sessionId, undefined, undefined, generation)
+      && this.active?.role === 'answerer'
+      && !this.active.remoteTopologyFinalized;
+  }
+
+  /**
+   * Called synchronously from `ontrack` while setRemoteDescription is still
+   * applying the offer. Transform assignment occurs before this method
+   * returns, satisfying the first-full-frame Insertable Streams boundary.
+   */
+  stageRemoteOfferTrack(
+    sessionId: string,
+    transceiver: RTCRtpTransceiver,
+    receiver: RTCRtpReceiver,
+    generation: number,
+  ): PublicPairMediaSlot {
+    const state = this.requireState(sessionId, generation);
+    if (state.role !== 'answerer' || transceiver.receiver !== receiver) {
+      throw new Error('public_media_topology_invalid');
+    }
+    const index = state.peer.getTransceivers().findIndex(value => value === transceiver);
+    const definition = PUBLIC_PAIR_MEDIA_SLOTS[index];
+    if (!definition || receiver.track.kind !== definition.kind || !transceiver.mid) {
+      throw new Error('public_media_topology_invalid');
+    }
+    const existing = state.slots.get(definition.slot);
+    if (existing && existing.transceiver !== transceiver) {
+      throw new Error('public_media_topology_invalid');
+    }
+    if (!existing) {
+      const readiness = this.attachSlot(state, definition, transceiver);
+      void readiness.catch(error => this.fail(state, reason(error, 'media_e2ee_transform_prepare_failed')));
+    }
+    return definition.slot;
+  }
+
+  async installKeys(
+    sessionId: string,
+    keys: readonly PublicPairMediaSlotKeySet[],
+    generation: number,
+  ): Promise<void> {
+    const state = this.requireState(sessionId, generation);
+    if (state.everInstalled) throw new Error('media_e2ee_key_reinstall_forbidden');
+    if (keys.length !== PUBLIC_PAIR_MEDIA_SLOTS.length) throw new Error('media_e2ee_key_set_invalid');
+    const entries: Array<{ transformId: string; context: PairMediaE2eeFrameContext; key: CryptoKey }> = [];
+    const keyObjects = new Set<CryptoKey>();
+    let connectionId = '';
+    let localPeerId = '';
+    let remotePeerId = '';
+    for (const definition of PUBLIC_PAIR_MEDIA_SLOTS) {
+      const values = keys.filter(value => value.slot === definition.slot);
+      const slot = state.slots.get(definition.slot);
+      if (values.length !== 1 || !slot) throw new Error('media_e2ee_key_set_invalid');
+      const value = values[0];
+      validateSlotContext(value.sendContext, definition.slot, definition.kind, definition.codec);
+      validateSlotContext(value.receiveContext, definition.slot, definition.kind, definition.codec);
+      if (
+        value.sendContext.sessionId !== state.sessionId
+        || value.receiveContext.sessionId !== state.sessionId
+        || value.sendContext.keyEpoch !== state.epoch
+        || value.receiveContext.keyEpoch !== state.epoch
+        || value.sendContext.mediaContractDigest !== state.contractDigest
+        || value.receiveContext.mediaContractDigest !== state.contractDigest
+        || value.sendContext.contractExpiresAtMs !== state.contractExpiresAtMs
+        || value.receiveContext.contractExpiresAtMs !== state.contractExpiresAtMs
+      ) throw new Error('media_e2ee_key_set_binding_mismatch');
+      if (
+        value.sendContext.connectionId !== value.receiveContext.connectionId
+        || value.sendContext.senderId !== value.receiveContext.recipientId
+        || value.sendContext.recipientId !== value.receiveContext.senderId
+        || value.sendKey === value.receiveKey
+        || keyObjects.has(value.sendKey)
+        || keyObjects.has(value.receiveKey)
+      ) throw new Error('media_e2ee_key_set_direction_invalid');
+      if (!connectionId) {
+        connectionId = value.sendContext.connectionId;
+        localPeerId = value.sendContext.senderId;
+        remotePeerId = value.sendContext.recipientId;
+      } else if (
+        value.sendContext.connectionId !== connectionId
+        || value.sendContext.senderId !== localPeerId
+        || value.sendContext.recipientId !== remotePeerId
+      ) throw new Error('media_e2ee_key_set_direction_invalid');
+      keyObjects.add(value.sendKey);
+      keyObjects.add(value.receiveKey);
+      entries.push(
+        { transformId: slot.sendTransformId, context: value.sendContext, key: value.sendKey },
+        { transformId: slot.receiveTransformId, context: value.receiveContext, key: value.receiveKey },
+      );
+    }
+    const installed = this.expect(state, `installed:${sessionId}`);
+    // Once a key-install message can reach the worker this worker generation
+    // is one-shot. Lost ACK/failure terminates it; it is never retried with a
+    // reset counter under an ambiguous key context.
+    state.everInstalled = true;
+    state.worker.postMessage({ version: 1, type: 'install-keys', sessionId, entries });
+    await installed;
+    if (state.failed || this.active !== state) throw new Error('media_e2ee_worker_failed');
+    state.keyed = true;
+  }
+
+  clearKeys(sessionId: string): void {
+    const state = this.active;
+    if (!state || state.sessionId !== sessionId || state.failed) return;
+    state.keyed = false;
+    state.worker.postMessage({ version: 1, type: 'clear-keys', sessionId });
+  }
+
+  releaseSession(sessionId?: string, generation?: number): void {
+    const state = this.active;
+    if (
+      !state
+      || (sessionId !== undefined && state.sessionId !== sessionId)
+      || (generation !== undefined && state.generation !== generation)
+    ) return;
+    this.active = null;
+    state.keyed = false;
+    this.dropAllTransceivers(state);
+    for (const deferred of state.pending.values()) {
+      clearTimeout(deferred.timeout);
+      deferred.reject(new Error('media_e2ee_session_released'));
+    }
+    state.pending.clear();
+    state.worker.onmessage = null;
+    state.worker.onerror = null;
+    state.worker.onmessageerror = null;
+    state.worker.terminate();
+  }
+
+  senderForSlot(sessionId: string, slot: PublicPairMediaSlot): RTCRtpSender {
+    const state = this.requireState(sessionId);
+    const value = state.slots.get(slot);
+    if (!value) throw new Error('public_media_slot_invalid');
+    return value.transceiver.sender;
+  }
+
+  slotForReceiver(sessionId: string, receiver: RTCRtpReceiver): PublicPairMediaSlot | null {
+    const state = this.active;
+    return state?.sessionId === sessionId ? state.receiverSlots.get(receiver) ?? null : null;
+  }
+
+  validateFinalTopology(sessionId: string): void {
+    const state = this.requireState(sessionId);
+    if (state.peer.getTransceivers().length !== PUBLIC_PAIR_MEDIA_SLOTS.length) {
+      throw new Error('public_media_topology_invalid');
+    }
+    const mids = new Set<string>();
+    for (const definition of PUBLIC_PAIR_MEDIA_SLOTS) {
+      const transceiver = state.slots.get(definition.slot)?.transceiver;
+      const mid = transceiver?.mid;
+      if (
+        !transceiver
+        || !mid
+        || mids.has(mid)
+        || transceiver.direction !== 'sendrecv'
+        || transceiver.currentDirection !== 'sendrecv'
+      ) throw new Error('public_media_topology_invalid');
+      mids.add(mid);
+    }
+  }
+
+  private handleWorkerMessage(state: AdapterState, raw: unknown): void {
+    if (this.active !== state || state.failed || !raw || typeof raw !== 'object' || Array.isArray(raw)) return;
+    const message = raw as Record<string, unknown>;
+    if (message['version'] !== 1 || typeof message['type'] !== 'string') {
+      this.fail(state, 'media_e2ee_worker_message_invalid');
+      return;
+    }
+    if (message['type'] === 'fatal') {
+      this.fail(state, reasonCode(message['reasonCode'], 'media_e2ee_transform_failed'));
+      return;
+    }
+    if (message['type'] === 'transform-ready' && typeof message['transformId'] === 'string') {
+      this.resolve(state, `ready:${message['transformId']}`);
+      return;
+    }
+    if (message['type'] === 'keys-installed' && message['sessionId'] === state.sessionId) {
+      const expectedIds = [...state.slots.values()]
+        .flatMap(slot => [slot.sendTransformId, slot.receiveTransformId]);
+      if (!exactStrings(message['transformIds'], expectedIds)) {
+        this.fail(state, 'media_e2ee_key_ack_invalid');
+        return;
+      }
+      this.resolve(state, `installed:${state.sessionId}`);
+      return;
+    }
+    if (message['type'] !== 'keys-cleared') this.fail(state, 'media_e2ee_worker_message_invalid');
+  }
+
+  private attachSlot(
+    state: AdapterState,
+    definition: typeof PUBLIC_PAIR_MEDIA_SLOTS[number],
+    transceiver: RTCRtpTransceiver,
+  ): Promise<void> {
+    if (this.active !== state || state.failed || state.slots.has(definition.slot)) {
+      throw new Error('public_media_topology_invalid');
+    }
+    const sendTransformId = transformId(state.sessionId, definition.slot, 'send');
+    const receiveTransformId = transformId(state.sessionId, definition.slot, 'receive');
+    const sendReady = this.expect(state, `ready:${sendTransformId}`);
+    const receiveReady = this.expect(state, `ready:${receiveTransformId}`);
+    const slot = Object.freeze({
+      slot: definition.slot, transceiver, sendTransformId, receiveTransformId,
+    });
+    state.slots.set(definition.slot, slot);
+    state.receiverSlots.set(transceiver.receiver, definition.slot);
+    transceiver.sender.transform = new RTCRtpScriptTransform(state.worker, {
+      version: 1, transformId: sendTransformId, operation: 'encrypt',
+    });
+    transceiver.receiver.transform = new RTCRtpScriptTransform(state.worker, {
+      version: 1, transformId: receiveTransformId, operation: 'decrypt',
+    });
+    setExactCodecPreference(transceiver, definition.kind, definition.codec);
+    const readiness = Promise.all([sendReady, receiveReady]).then(() => {
+      if (this.active !== state || state.failed) throw new Error('media_e2ee_session_released');
+    });
+    state.slotReadiness.set(definition.slot, readiness);
+    return readiness;
+  }
+
+  private expect(state: AdapterState, key: string): Promise<void> {
+    if (state.pending.has(key)) throw new Error('media_e2ee_worker_ack_duplicate');
+    let resolve!: () => void;
+    let reject!: (error: unknown) => void;
+    const promise = new Promise<void>((accept, deny) => { resolve = accept; reject = deny; });
+    const timeout = setTimeout(() => {
+      if (!state.pending.delete(key)) return;
+      reject(new Error('media_e2ee_worker_ack_timeout'));
+      this.fail(state, 'media_e2ee_worker_ack_timeout');
+    }, WORKER_ACK_TIMEOUT_MS);
+    state.pending.set(key, { promise, resolve, reject, timeout });
+    return promise;
+  }
+
+  private resolve(state: AdapterState, key: string): void {
+    const deferred = state.pending.get(key);
+    if (!deferred) {
+      this.fail(state, 'media_e2ee_worker_ack_unexpected');
+      return;
+    }
+    state.pending.delete(key);
+    clearTimeout(deferred.timeout);
+    deferred.resolve();
+  }
+
+  private requireState(sessionId: string, generation?: number): AdapterState {
+    const state = this.active;
+    if (!state || state.sessionId !== sessionId
+        || (generation !== undefined && state.generation !== generation) || state.failed) {
+      throw new Error('public_media_transform_not_prepared');
+    }
+    return state;
+  }
+
+  private fail(state: AdapterState, reasonCode: string): void {
+    if (state.failed || this.active !== state) return;
+    this.active = null;
+    state.failed = true;
+    state.keyed = false;
+    this.dropAllTransceivers(state);
+    for (const deferred of state.pending.values()) {
+      clearTimeout(deferred.timeout);
+      deferred.reject(new Error(reasonCode));
+    }
+    state.pending.clear();
+    state.worker.onmessage = null;
+    state.worker.onerror = null;
+    state.worker.onmessageerror = null;
+    state.worker.terminate();
+    try { state.onFatal(reasonCode); } catch { /* Fatal cleanup remains complete. */ }
+  }
+
+  private dropAllTransceivers(state: AdapterState): void {
+    for (const transceiver of state.peer.getTransceivers()) {
+      try { transceiver.direction = 'inactive'; } catch { /* Closing peer already rejects media. */ }
+      void transceiver.sender.replaceTrack(null).catch(() => undefined);
+    }
+  }
+}
+
+function setExactCodecPreference(
+  transceiver: RTCRtpTransceiver,
+  kind: 'audio' | 'video',
+  codec: 'opus' | 'vp8',
+): void {
+  const capabilities = RTCRtpSender.getCapabilities(kind);
+  const codecs = capabilities?.codecs.filter(
+    candidate => candidate.mimeType.toLowerCase() === `${kind}/${codec}`,
+  ) ?? [];
+  if (codecs.length < 1) throw new Error(`public_media_${codec}_unsupported`);
+  transceiver.setCodecPreferences(codecs);
+}
+
+function transformId(
+  sessionId: string,
+  slot: PublicPairMediaSlot,
+  direction: 'send' | 'receive',
+): string {
+  const value = `${sessionId}:${slot}:${direction}`;
+  if (value.length > 128) throw new Error('media_e2ee_transform_id_invalid');
+  return value;
+}
+
+function validateSlotContext(
+  context: PairMediaE2eeFrameContext,
+  slot: PublicPairMediaSlot,
+  kind: 'audio' | 'video',
+  codec: 'opus' | 'vp8',
+): void {
+  if (context.slot !== slot || context.kind !== kind || context.codec !== codec) {
+    throw new Error('media_e2ee_key_set_invalid');
+  }
+}
+
+function deferredReason(value: unknown): string {
+  return value instanceof Error ? value.message : String(value);
+}
+
+function reason(error: unknown, fallback: string): string {
+  const candidate = deferredReason(error);
+  return /^[a-z][a-z0-9_]{2,119}$/.test(candidate) ? candidate : fallback;
+}
+
+function reasonCode(value: unknown, fallback: string): string {
+  return typeof value === 'string' && /^[a-z][a-z0-9_]{2,119}$/.test(value) ? value : fallback;
+}
+
+function exactStrings(value: unknown, expected: readonly string[]): boolean {
+  return Array.isArray(value)
+    && value.length === expected.length
+    && value.every((item, index) => item === expected[index]);
+}

--- a/frontend-angular/src/app/services/pair-ordinary-media.policy.spec.ts
+++ b/frontend-angular/src/app/services/pair-ordinary-media.policy.spec.ts
@@ -3,18 +3,33 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   PUBLIC_ORDINARY_MEDIA_E2EE_UNAVAILABLE,
+  PUBLIC_ORDINARY_MEDIA_E2EE_NOT_READY,
   PairOrdinaryMediaPolicy,
 } from './pair-ordinary-media.policy';
+import { PairMediaE2eeCoordinatorService } from './pair-media-e2ee-coordinator.service';
 import { PairSessionControlPlaneService } from './pair-session-control-plane.service';
 
 describe('PairOrdinaryMediaPolicy', () => {
-  it('rejects public Pair media independently of mutable feature flags', () => {
+  function configure() {
     const authorities = new Map<string, 'hub' | 'public'>([
       ['public-session', 'public'],
       ['private-session', 'hub'],
     ]);
+    const statuses = new Map<string, any>([[
+      'public-session',
+      { sessionId: 'public-session', state: 'awaiting-security' },
+    ]]);
+    const activatable = new Set<string>();
     TestBed.configureTestingModule({ providers: [
       PairOrdinaryMediaPolicy,
+      {
+        provide: PairMediaE2eeCoordinatorService,
+        useValue: {
+          statusFor: vi.fn((sessionId: string) => statuses.get(sessionId)
+            ?? { sessionId, state: 'inactive' }),
+          canActivate: vi.fn((sessionId: string) => activatable.has(sessionId)),
+        },
+      },
       {
         provide: PairSessionControlPlaneService,
         useValue: { authorityKindForSession: vi.fn((sessionId: string) => {
@@ -24,13 +39,60 @@ describe('PairOrdinaryMediaPolicy', () => {
         }) },
       },
     ] });
-    const policy = TestBed.inject(PairOrdinaryMediaPolicy);
+    return { policy: TestBed.inject(PairOrdinaryMediaPolicy), statuses, activatable };
+  }
+
+  it('preserves Hub media independently of the Public E2EE coordinator', () => {
+    const { policy } = configure();
+
+    expect(policy.canActivate('private-session')).toBe(true);
+    expect(policy.allows('private-session')).toBe(true);
+    expect(() => policy.assertActivationAllowed('private-session')).not.toThrow();
+    expect(() => policy.assertAllowed('private-session')).not.toThrow();
+  });
+
+  it('separates Public activation admission from capture readiness', () => {
+    const { policy, statuses, activatable } = configure();
 
     expect(() => policy.assertAllowed('public-session'))
-      .toThrow(PUBLIC_ORDINARY_MEDIA_E2EE_UNAVAILABLE);
-    expect(() => policy.assertAllowed('private-session')).not.toThrow();
+      .toThrow('public_ordinary_media_e2ee_awaiting_security');
+    expect(() => policy.assertActivationAllowed('public-session'))
+      .toThrow('public_ordinary_media_e2ee_awaiting_security');
+
+    statuses.set('public-session', { sessionId: 'public-session', state: 'awaiting-peer' });
+    expect(() => policy.assertAllowed('public-session'))
+      .toThrow('public_ordinary_media_e2ee_awaiting_peer');
+
+    statuses.set('public-session', { sessionId: 'public-session', state: 'inactive' });
+    activatable.add('public-session');
+    expect(policy.canActivate('public-session')).toBe(true);
+    expect(() => policy.assertActivationAllowed('public-session')).not.toThrow();
+    expect(policy.allows('public-session')).toBe(false);
+    expect(() => policy.assertAllowed('public-session'))
+      .toThrow(PUBLIC_ORDINARY_MEDIA_E2EE_NOT_READY);
+
+    statuses.set('public-session', { sessionId: 'public-session', state: 'ready' });
+    activatable.delete('public-session');
+    expect(policy.canActivate('public-session')).toBe(true);
+    expect(policy.allows('public-session')).toBe(true);
+    expect(() => policy.assertAllowed('public-session')).not.toThrow();
+  });
+
+  it('projects a coordinator failure without weakening missing-binding checks', () => {
+    const { policy, statuses } = configure();
+    statuses.set('public-session', {
+      sessionId: 'public-session', state: 'failed', reasonCode: 'media_e2ee_transform_unsupported',
+    });
+
+    expect(() => policy.assertActivationAllowed('public-session'))
+      .toThrow('media_e2ee_transform_unsupported');
+    expect(() => policy.assertAllowed('public-session'))
+      .toThrow('media_e2ee_transform_unsupported');
     expect(policy.allows('missing-session')).toBe(false);
     expect(() => policy.assertAllowed('missing-session'))
       .toThrow('ordinary_media_session_binding_missing');
+    statuses.set('public-session', { sessionId: 'public-session', state: 'failed' });
+    expect(() => policy.assertAllowed('public-session'))
+      .toThrow(PUBLIC_ORDINARY_MEDIA_E2EE_UNAVAILABLE);
   });
 });

--- a/frontend-angular/src/app/services/pair-ordinary-media.policy.ts
+++ b/frontend-angular/src/app/services/pair-ordinary-media.policy.ts
@@ -1,25 +1,78 @@
 import { Injectable, inject } from '@angular/core';
 
+import {
+  PairMediaE2eeCoordinatorService,
+  type PublicPairMediaE2eeState,
+} from './pair-media-e2ee-coordinator.service';
 import { PairSessionControlPlaneService } from './pair-session-control-plane.service';
 
 export const PUBLIC_ORDINARY_MEDIA_E2EE_UNAVAILABLE = 'public_ordinary_media_e2ee_unavailable';
+export const PUBLIC_ORDINARY_MEDIA_E2EE_NOT_READY = 'public_ordinary_media_e2ee_not_ready';
 
-/** Blocks ordinary audio/video until Public Pair has a key-bound media transform. */
+/** Separates Public media activation admission from key-bound capture readiness. */
 @Injectable({ providedIn: 'root' })
 export class PairOrdinaryMediaPolicy {
   private readonly controlPlane = inject(PairSessionControlPlaneService);
+  private readonly coordinator = inject(PairMediaE2eeCoordinatorService);
+
+  canActivate(sessionId: string): boolean {
+    const authority = this.authority(sessionId);
+    if (authority === 'hub') return true;
+    if (authority !== 'public') return false;
+    try {
+      const status = this.coordinator.statusFor(sessionId);
+      if (status.sessionId !== sessionId) return false;
+      return status.state === 'ready' || this.coordinator.canActivate(sessionId);
+    } catch { return false; }
+  }
+
+  assertActivationAllowed(sessionId: string): void {
+    const authority = this.requireAuthority(sessionId);
+    if (authority === 'hub') return;
+    const status = this.coordinator.statusFor(sessionId);
+    if (status.sessionId !== sessionId) throw new Error('public_ordinary_media_e2ee_context_mismatch');
+    if (status.state === 'ready' || this.coordinator.canActivate(sessionId)) return;
+    throw new Error(publicMediaReason(status));
+  }
 
   allows(sessionId: string): boolean {
-    if (!sessionId) return false;
-    try { return this.controlPlane.authorityKindForSession(sessionId) === 'hub'; } catch { return false; }
+    const authority = this.authority(sessionId);
+    if (authority === 'hub') return true;
+    if (authority !== 'public') return false;
+    try {
+      const status = this.coordinator.statusFor(sessionId);
+      return status.sessionId === sessionId && status.state === 'ready';
+    } catch { return false; }
   }
 
   assertAllowed(sessionId: string): void {
-    if (!sessionId) throw new Error('ordinary_media_session_missing');
-    let authority: 'hub' | 'public';
-    try { authority = this.controlPlane.authorityKindForSession(sessionId); } catch {
-      throw new Error('ordinary_media_session_binding_missing');
-    }
-    if (authority !== 'hub') throw new Error(PUBLIC_ORDINARY_MEDIA_E2EE_UNAVAILABLE);
+    const authority = this.requireAuthority(sessionId);
+    if (authority === 'hub') return;
+    const status = this.coordinator.statusFor(sessionId);
+    if (status.sessionId !== sessionId) throw new Error('public_ordinary_media_e2ee_context_mismatch');
+    if (status.state !== 'ready') throw new Error(publicMediaReason(status));
   }
+
+  private authority(sessionId: string): 'hub' | 'public' | null {
+    if (!sessionId) return null;
+    try { return this.controlPlane.authorityKindForSession(sessionId); } catch { return null; }
+  }
+
+  private requireAuthority(sessionId: string): 'hub' | 'public' {
+    if (!sessionId) throw new Error('ordinary_media_session_missing');
+    const authority = this.authority(sessionId);
+    if (!authority) throw new Error('ordinary_media_session_binding_missing');
+    return authority;
+  }
+}
+
+function publicMediaReason(status: PublicPairMediaE2eeState): string {
+  if (status.reasonCode) return status.reasonCode;
+  return ({
+    'awaiting-security': 'public_ordinary_media_e2ee_awaiting_security',
+    'awaiting-peer': 'public_ordinary_media_e2ee_awaiting_peer',
+    negotiating: 'public_ordinary_media_e2ee_negotiating',
+    failed: PUBLIC_ORDINARY_MEDIA_E2EE_UNAVAILABLE,
+  } as Partial<Record<PublicPairMediaE2eeState['state'], string>>)[status.state]
+    ?? PUBLIC_ORDINARY_MEDIA_E2EE_NOT_READY;
 }

--- a/frontend-angular/src/app/services/pair-session-control-plane.service.spec.ts
+++ b/frontend-angular/src/app/services/pair-session-control-plane.service.spec.ts
@@ -7,6 +7,8 @@ import { HubApiCoreService } from './hub-api-core.service';
 import { NetworkProfileService } from './network-profile.service';
 import { PairMembershipCapabilityStore } from './pair-membership-capability.store';
 import { PairSessionControlPlaneService } from './pair-session-control-plane.service';
+import { PublicPairMediaRuntimeCapabilityService } from './public-pair-media-runtime-capability.service';
+import { PUBLIC_PAIR_MEDIA_CAPABILITIES_V1 } from './public-pair-media-security-contract';
 import { PUBLIC_OIDC_ISSUER } from './public-ananta-endpoints';
 import { UserAuthService } from './user-auth.service';
 
@@ -36,6 +38,7 @@ describe('PairSessionControlPlaneService', () => {
   let createdResponse: Record<string, unknown>;
   let joinedResponse: Record<string, unknown>;
   let listedResponses: Array<Record<string, unknown>>;
+  let publicMediaAdvertisement: Record<string, unknown> | null;
 
   beforeEach(() => {
     posts.length = 0;
@@ -48,6 +51,7 @@ describe('PairSessionControlPlaneService', () => {
     createdResponse = publicSession('created-session', ownerPeerId);
     joinedResponse = publicSession('joined-session', joinerPeerId);
     listedResponses = [publicSession('listed-session', listedPeerId)];
+    publicMediaAdvertisement = null;
     localStorage.clear();
     localStorage.setItem('ananta.pair-device-id.v1', 'device-a');
     sessionStorage.clear();
@@ -57,6 +61,10 @@ describe('PairSessionControlPlaneService', () => {
       { provide: AgentDirectoryService, useValue: { list: () => [{ role: 'hub', url: 'http://127.0.0.1:5000' }] } },
       { provide: NetworkProfileService, useValue: profile },
       { provide: UserAuthService, useValue: auth },
+      {
+        provide: PublicPairMediaRuntimeCapabilityService,
+        useValue: { membershipAdvertisement: () => publicMediaAdvertisement },
+      },
       { provide: HubApiCoreService, useValue: {
         retryCount: 2,
         request: vi.fn((
@@ -175,6 +183,43 @@ describe('PairSessionControlPlaneService', () => {
       { 'X-Ananta-Membership-Capability': expect.stringMatching(/^[A-Za-z0-9_-]{43}$/) },
       { 'X-Ananta-Membership-Capability': expect.stringMatching(/^[A-Za-z0-9_-]{43}$/) },
     ]);
+  });
+
+  it('adds the exact immutable media capability advertisement to public create and join', () => {
+    publicMediaAdvertisement = Object.freeze({
+      public_media_e2ee_version: 1,
+      public_media_capabilities: PUBLIC_PAIR_MEDIA_CAPABILITIES_V1,
+    });
+    const service = TestBed.inject(PairSessionControlPlaneService);
+
+    service.create({ title: 'Pair', permissions: { chat: true } }).subscribe();
+    service.join({ invite_code: 'INVITE' }).subscribe();
+
+    for (const body of requests.map(request => request.body as Record<string, unknown>)) {
+      expect(body['public_media_e2ee_version']).toBe(1);
+      expect(body['public_media_capabilities']).toEqual({
+        version: 1,
+        transform: 'RTCRtpScriptTransform',
+        grants: ['microphone-opus', 'camera-vp8', 'screen-vp8'],
+      });
+      expect(Object.isFrozen(body)).toBe(true);
+      expect(Object.isFrozen(body['public_media_capabilities'])).toBe(true);
+      expect(Object.isFrozen(
+        (body['public_media_capabilities'] as { grants: readonly string[] }).grants,
+      )).toBe(true);
+    }
+  });
+
+  it('omits both media capability fields when the standards-only runtime is unavailable', () => {
+    const service = TestBed.inject(PairSessionControlPlaneService);
+
+    service.create({ title: 'Pair' }).subscribe();
+    service.join({ invite_code: 'INVITE' }).subscribe();
+
+    for (const body of requests.map(request => request.body as Record<string, unknown>)) {
+      expect(body).not.toHaveProperty('public_media_e2ee_version');
+      expect(body).not.toHaveProperty('public_media_capabilities');
+    }
   });
 
   it('restores public bindings only from an explicit authenticated list response', () => {
@@ -398,6 +443,10 @@ describe('PairSessionControlPlaneService', () => {
   });
 
   it('retries an ambiguous create with the same persisted capability and exact wire body', async () => {
+    publicMediaAdvertisement = Object.freeze({
+      public_media_e2ee_version: 1,
+      public_media_capabilities: PUBLIC_PAIR_MEDIA_CAPABILITIES_V1,
+    });
     const service = TestBed.inject(PairSessionControlPlaneService);
     const core = TestBed.inject(HubApiCoreService);
     vi.mocked(core.request).mockReturnValueOnce(throwError(() => ({ status: 0 })));
@@ -416,6 +465,14 @@ describe('PairSessionControlPlaneService', () => {
     const secondOptions = vi.mocked(core.request).mock.calls[1][3];
 
     expect(secondOptions?.body).toEqual(firstOptions?.body);
+    expect(secondOptions?.body).toMatchObject({
+      public_media_e2ee_version: 1,
+      public_media_capabilities: {
+        version: 1,
+        transform: 'RTCRtpScriptTransform',
+        grants: ['microphone-opus', 'camera-vp8', 'screen-vp8'],
+      },
+    });
     expect(secondOptions?.headers?.['X-Ananta-Membership-Capability'])
       .toBe(firstOptions?.headers?.['X-Ananta-Membership-Capability']);
     expect(JSON.stringify(firstOptions?.body)).not.toContain(

--- a/frontend-angular/src/app/services/pair-session-control-plane.service.ts
+++ b/frontend-angular/src/app/services/pair-session-control-plane.service.ts
@@ -13,6 +13,7 @@ import {
 } from './pair-membership-capability.store';
 import { PairPublicAuthorityPolicy } from './pair-public-authority.policy';
 import { PairPublicSessionContractPolicy } from './pair-public-session-contract.policy';
+import { PublicPairMediaRuntimeCapabilityService } from './public-pair-media-runtime-capability.service';
 import {
   PairControlPlaneKind,
   PairSessionBinding,
@@ -117,6 +118,7 @@ export class PairSessionControlPlaneService {
   private readonly capabilities = inject(PairMembershipCapabilityStore);
   private readonly publicAuthority = inject(PairPublicAuthorityPolicy);
   private readonly publicContract = inject(PairPublicSessionContractPolicy);
+  private readonly publicMediaRuntime = inject(PublicPairMediaRuntimeCapabilityService);
 
   /** Compatibility/read-model property for a not-yet-created session. */
   get isPublic(): boolean {
@@ -172,6 +174,7 @@ export class PairSessionControlPlaneService {
       owner_device_fingerprint: body['public_key_fingerprint'],
       allowed_permissions: body['permissions'],
       identity_binding_version: 2,
+      ...(this.publicMediaRuntime.membershipAdvertisement() ?? {}),
     };
     return this.publicV2Mutation<T>('create', authority, '/rendezvous/sessions', publicBody);
   }
@@ -188,6 +191,7 @@ export class PairSessionControlPlaneService {
       device_id: this.deviceId,
       device_fingerprint: body['public_key_fingerprint'],
       identity_binding_version: 2,
+      ...(this.publicMediaRuntime.membershipAdvertisement() ?? {}),
     });
   }
 

--- a/frontend-angular/src/app/services/pair-view-security-bootstrap.service.spec.ts
+++ b/frontend-angular/src/app/services/pair-view-security-bootstrap.service.spec.ts
@@ -3,9 +3,14 @@ import { of } from 'rxjs';
 import { describe, expect, it, vi } from 'vitest';
 
 import { AgentDirectoryService } from './agent-directory.service';
+import { E2eEncryptionService } from './e2e-encryption.service';
 import { HubApiCoreService } from './hub-api-core.service';
 import { PairViewSecurityBootstrapService } from './pair-view-security-bootstrap.service';
 import { PairSessionControlPlaneService } from './pair-session-control-plane.service';
+import {
+  PUBLIC_PAIR_MEDIA_GRANTS,
+  PUBLIC_PAIR_MEDIA_SLOTS,
+} from './public-pair-media-security-contract';
 import { ShareSession } from './share-session.service';
 import { WebrtcPeerKeyService } from './webrtc-peer-key.service';
 import { canonicalSecurityJson } from './webrtc-secure-envelope';
@@ -19,6 +24,10 @@ const session: ShareSession = {
   permissions: { chat: true }, created_at: 1, expires_at: null, revoked_at: null,
   owner_user_id: 'alice', security_epoch: 3, security_contract_version: 1, security_mode: 'strict_e2ee',
 };
+const localMediaPeerId = `peer:${'1'.repeat(64)}`;
+const remoteMediaPeerId = `peer:${'2'.repeat(64)}`;
+const localMediaFingerprint = 'a'.repeat(64);
+const remoteMediaFingerprint = 'b'.repeat(64);
 
 describe('PairViewSecurityBootstrapService production contract seam', () => {
   it('validates the final transcript before binding and confirming the peer', async () => {
@@ -157,9 +166,160 @@ describe('PairViewSecurityBootstrapService production contract seam', () => {
     expect(peerKeys.acceptPeerConfirmation).not.toHaveBeenCalled();
     expect(bootstrap.state$.value).toMatchObject({ status: 'failed', reasonCode: 'key_confirmation_stale' });
   });
+
+  it('exposes a signed media contract only after the exact peer confirmation completes', async () => {
+    const response = await mediaKeyPackageResponse();
+    const acceptance = deferred<void>();
+    const peerKeys = fakeMediaPeerKeys(acceptance.promise);
+    const core = mediaCore(() => response);
+    configure(core, peerKeys, localMediaFingerprint);
+    const bootstrap = TestBed.inject(PairViewSecurityBootstrapService);
+    const verify = vi.spyOn(crypto.subtle, 'verify').mockResolvedValue(true);
+
+    try {
+      const pending = bootstrap.ensure(session, localMediaPeerId);
+      await vi.waitFor(() => expect(peerKeys.acceptPeerConfirmation).toHaveBeenCalledOnce());
+      expect(bootstrap.mediaContractFor(session.id)).toBeNull();
+
+      acceptance.resolve();
+      await expect(pending).resolves.toBe(true);
+      expect(bootstrap.mediaContractFor(session.id)).toMatchObject({
+        domain: 'ananta.public-pair.media-security-contract.v1',
+        session_id: session.id,
+        epoch: 3,
+        base_security_contract_digest: response.security_contract_digest,
+        grants: ['microphone-opus', 'camera-vp8', 'screen-vp8'],
+      });
+      expect(verify).toHaveBeenCalledWith(
+        'Ed25519', expect.anything(), expect.any(ArrayBuffer), expect.any(ArrayBuffer),
+      );
+    } finally {
+      verify.mockRestore();
+    }
+  });
+
+  it('drops a stale media bootstrap when clear wins the local-key await race', async () => {
+    const response = await mediaKeyPackageResponse();
+    const localKey = deferred<{ fingerprint: string }>();
+    const encryption = { ensureLocalKeyPair: vi.fn(() => localKey.promise) };
+    const peerKeys = fakeMediaPeerKeys();
+    configure(mediaCore(() => response), peerKeys, localMediaFingerprint, encryption);
+    const bootstrap = TestBed.inject(PairViewSecurityBootstrapService);
+
+    const pending = bootstrap.ensure(session, localMediaPeerId);
+    await vi.waitFor(() => expect(encryption.ensureLocalKeyPair).toHaveBeenCalledOnce());
+    bootstrap.clear();
+    localKey.resolve({ fingerprint: localMediaFingerprint });
+
+    await expect(pending).resolves.toBe(false);
+    expect(peerKeys.verifyAndRefreshBinding).not.toHaveBeenCalled();
+    expect(bootstrap.mediaContractFor(session.id)).toBeNull();
+    expect(bootstrap.state$.value).toEqual({ status: 'idle' });
+  });
+
+  it('drops a stale media bootstrap when clear wins authority-signature validation', async () => {
+    const response = await mediaKeyPackageResponse();
+    const validation = deferred<boolean>();
+    const peerKeys = fakeMediaPeerKeys();
+    configure(mediaCore(() => response), peerKeys, localMediaFingerprint);
+    const bootstrap = TestBed.inject(PairViewSecurityBootstrapService);
+    const verify = vi.spyOn(crypto.subtle, 'verify').mockImplementation(() => validation.promise);
+
+    try {
+      const pending = bootstrap.ensure(session, localMediaPeerId);
+      await vi.waitFor(() => expect(verify).toHaveBeenCalledOnce());
+      bootstrap.clear();
+      validation.resolve(true);
+
+      await expect(pending).resolves.toBe(false);
+      expect(peerKeys.verifyAndRefreshBinding).not.toHaveBeenCalled();
+      expect(bootstrap.mediaContractFor(session.id)).toBeNull();
+      expect(bootstrap.state$.value).toEqual({ status: 'idle' });
+    } finally {
+      verify.mockRestore();
+    }
+  });
+
+  it('does not cache null or invalid media contracts', async () => {
+    let response = await mediaKeyPackageResponse();
+    const peerKeys = fakeMediaPeerKeys();
+    configure(mediaCore(() => response), peerKeys, localMediaFingerprint);
+    const bootstrap = TestBed.inject(PairViewSecurityBootstrapService);
+    const verify = vi.spyOn(crypto.subtle, 'verify').mockResolvedValue(true);
+
+    try {
+      await expect(bootstrap.ensure(session, localMediaPeerId)).resolves.toBe(true);
+      expect(bootstrap.mediaContractFor(session.id)).not.toBeNull();
+
+      response = await mediaKeyPackageResponse();
+      response.public_media_security_contract_v1 = null;
+      await expect(bootstrap.ensure(session, localMediaPeerId)).resolves.toBe(true);
+      expect(bootstrap.mediaContractFor(session.id)).toBeNull();
+
+      response = await mediaKeyPackageResponse();
+      response.public_media_security_contract_v1 = {
+        ...response.public_media_security_contract_v1,
+        session_id: 'attacker-session',
+      };
+      const bindingCallsBeforeInvalidContract = peerKeys.verifyAndRefreshBinding.mock.calls.length;
+      await expect(bootstrap.ensure(session, localMediaPeerId)).resolves.toBe(false);
+      expect(bootstrap.mediaContractFor(session.id)).toBeNull();
+      expect(peerKeys.verifyAndRefreshBinding).toHaveBeenCalledTimes(bindingCallsBeforeInvalidContract);
+      expect(bootstrap.state$.value).toMatchObject({
+        status: 'failed', reasonCode: 'public_media_contract_binding_mismatch',
+      });
+    } finally {
+      verify.mockRestore();
+    }
+  });
+
+  it('makes cached media authority unavailable on clear, epoch change and session replacement', async () => {
+    let response = await mediaKeyPackageResponse('session-a', 3);
+    const peerKeys = fakeMediaPeerKeys();
+    const core = mediaCore(() => response);
+    configure(core, peerKeys, localMediaFingerprint);
+    const bootstrap = TestBed.inject(PairViewSecurityBootstrapService);
+    const verify = vi.spyOn(crypto.subtle, 'verify').mockResolvedValue(true);
+
+    try {
+      await expect(bootstrap.ensure(session, localMediaPeerId)).resolves.toBe(true);
+      expect(bootstrap.mediaContractFor('session-a')).not.toBeNull();
+
+      bootstrap.clear();
+      expect(bootstrap.mediaContractFor('session-a')).toBeNull();
+
+      await expect(bootstrap.ensure(session, localMediaPeerId)).resolves.toBe(true);
+      expect(bootstrap.mediaContractFor('session-a')).not.toBeNull();
+      response = waitingKeyPackageResponse(4);
+      const epochReplacement = bootstrap.ensure({ ...session, security_epoch: 4 }, localMediaPeerId);
+      expect(bootstrap.mediaContractFor('session-a')).toBeNull();
+      await expect(epochReplacement).resolves.toBe(false);
+      expect(bootstrap.mediaContractFor('session-a')).toBeNull();
+
+      response = await mediaKeyPackageResponse('session-a', 4);
+      await expect(bootstrap.ensure({ ...session, security_epoch: 4 }, localMediaPeerId))
+        .resolves.toBe(true);
+      expect(bootstrap.mediaContractFor('session-a')).not.toBeNull();
+      response = waitingKeyPackageResponse(5);
+      const sessionReplacement = bootstrap.ensure(
+        { ...session, id: 'session-b', security_epoch: 5 }, localMediaPeerId,
+      );
+      expect(bootstrap.mediaContractFor('session-a')).toBeNull();
+      await expect(sessionReplacement).resolves.toBe(false);
+      expect(bootstrap.mediaContractFor('session-a')).toBeNull();
+      expect(bootstrap.mediaContractFor('session-b')).toBeNull();
+    } finally {
+      verify.mockRestore();
+    }
+  });
 });
 
-function configure(core: any, peerKeys: unknown): void {
+function configure(
+  core: any,
+  peerKeys: unknown,
+  localFingerprint = localMediaFingerprint,
+  encryption?: unknown,
+): void {
   TestBed.resetTestingModule();
   TestBed.configureTestingModule({ providers: [
     { provide: HubApiCoreService, useValue: core },
@@ -170,6 +330,12 @@ function configure(core: any, peerKeys: unknown): void {
       isPublicSession: () => true,
     } },
     { provide: WebrtcPeerKeyService, useValue: peerKeys },
+    {
+      provide: E2eEncryptionService,
+      useValue: encryption ?? {
+        ensureLocalKeyPair: vi.fn(async () => ({ fingerprint: localFingerprint })),
+      },
+    },
   ] });
 }
 
@@ -188,15 +354,140 @@ function fakePeerKeys() {
   };
 }
 
-async function keyPackageResponse(): Promise<any> {
-  const offer: any = proposal('owner-session-a', 'participant-a');
-  const answer: any = proposal('participant-a', 'owner-session-a');
+function fakeMediaPeerKeys(acceptance: Promise<void> = Promise.resolve()) {
+  let binding: any = null;
+  return {
+    get currentBinding() { return binding; },
+    clear: vi.fn(() => { binding = null; }),
+    approveFingerprintChange: vi.fn(),
+    verifyAndRefreshBinding: vi.fn(async (remotePackage: any, options: any) => {
+      if (
+        binding?.packageId === remotePackage.package_id
+        && binding.scopeId === options.expectedScopeId
+        && binding.epoch === options.expectedEpoch
+      ) return binding;
+      binding = {
+        packageId: remotePackage.package_id,
+        scopeKind: 'session',
+        scopeId: options.expectedScopeId,
+        epoch: options.expectedEpoch,
+        localPeerId: options.localPeerId,
+        remotePeerId: remotePackage.peer_id,
+        peerPublicKeySpkiB64: remotePackage.ecdh_public_key_spki_b64 ?? 'spki',
+        keyId: 'media-key-id',
+        contractDigest: options.contractDigest,
+        tenantId: 'tenant-a',
+        deviceId: remotePackage.device_id ?? 'device-b',
+        membershipId: remotePackage.membership_id,
+        membershipVersion: remotePackage.membership_version,
+        peerFingerprint: remotePackage.device_key_fingerprint,
+        transcriptDigest: 'transcript-digest',
+        authorityKeyId: options.expectedHubKeyId,
+        confirmed: false,
+        fingerprintChanged: false,
+      };
+      return binding;
+    }),
+    createConfirmation: vi.fn(async () => 'local-tag'),
+    acceptPeerConfirmation: vi.fn(async () => {
+      await acceptance;
+      if (binding) binding.confirmed = true;
+    }),
+  };
+}
+
+function mediaCore(response: () => any) {
+  return {
+    get: vi.fn((url: string) => {
+      const current = response();
+      return of(url.includes('key-packages') ? current : {
+        ok: true,
+        local_peer_id: localMediaPeerId,
+        confirmation: confirmation(current.epoch, current.local_package_id),
+      });
+    }),
+    post: vi.fn(() => of({ ok: true, local_peer_id: localMediaPeerId })),
+  };
+}
+
+async function mediaKeyPackageResponse(scopeId = 'session-a', epoch = 3): Promise<any> {
+  const response = await keyPackageResponse(scopeId, epoch);
+  response.local_peer_id = localMediaPeerId;
+  response.packages = [{
+    ...response.packages[0],
+    membership_version: 1,
+    peer_id: remoteMediaPeerId,
+    device_id: 'device-b',
+    device_key_fingerprint: remoteMediaFingerprint,
+  }];
+  const unsigned = {
+    domain: 'ananta.public-pair.media-security-contract.v1',
+    version: 1,
+    session_id: scopeId,
+    epoch,
+    identity_binding_version: 2,
+    base_security_contract_digest: response.security_contract_digest,
+    memberships: [
+      {
+        membership_id: 'owner-session-a', membership_version: 1,
+        peer_id: localMediaPeerId, device_key_fingerprint: localMediaFingerprint,
+        public_media_e2ee_version: 1,
+      },
+      {
+        membership_id: 'participant-a', membership_version: 1,
+        peer_id: remoteMediaPeerId, device_key_fingerprint: remoteMediaFingerprint,
+        public_media_e2ee_version: 1,
+      },
+    ],
+    grants: [...PUBLIC_PAIR_MEDIA_GRANTS],
+    slots: PUBLIC_PAIR_MEDIA_SLOTS.map(slot => ({ ...slot })),
+    transform: 'RTCRtpScriptTransform',
+    algorithms: { aead: 'AES-256-GCM', kdf: 'HKDF-SHA-256' },
+    expires_at_ms: Date.now() + 240_000,
+    authority_key_id: PUBLIC_RENDEZVOUS_SIGNING_KEY_ID,
+  };
+  const digest = await sha256(canonicalSecurityJson(unsigned));
+  response.public_media_security_contract_v1 = {
+    ...unsigned,
+    digest,
+    signature_algorithm: 'Ed25519',
+    signature_b64: btoa('s'.repeat(64)),
+  };
+  return response;
+}
+
+function waitingKeyPackageResponse(epoch: number): any {
+  return {
+    ok: true,
+    epoch,
+    tenant_id: 'tenant-a',
+    security_contract_digest: null,
+    security_contract: null,
+    hub_key_id: PUBLIC_RENDEZVOUS_SIGNING_KEY_ID,
+    hub_public_key_b64: PUBLIC_RENDEZVOUS_SIGNING_PUBLIC_KEY_B64,
+    local_membership_id: 'owner-session-a',
+    local_peer_id: localMediaPeerId,
+    local_package_id: null,
+    packages: [],
+    public_media_security_contract_v1: null,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>(innerResolve => { resolve = innerResolve; });
+  return { promise, resolve };
+}
+
+async function keyPackageResponse(scopeId = 'session-a', epoch = 3): Promise<any> {
+  const offer: any = proposal('owner-session-a', 'participant-a', scopeId, epoch);
+  const answer: any = proposal('participant-a', 'owner-session-a', scopeId, epoch);
   const digest = await sha256(canonicalSecurityJson({
     domain: 'ananta.webrtc.security-negotiation.v1', offer, answer,
   }));
   return {
     ok: true,
-    epoch: 3,
+    epoch,
     tenant_id: 'tenant-a',
     security_contract_digest: digest,
     security_contract: {
@@ -212,10 +503,10 @@ async function keyPackageResponse(): Promise<any> {
   };
 }
 
-function confirmation() {
+function confirmation(epoch = 3, packageId = 'b'.repeat(64)) {
   const now = Date.now();
   return {
-    confirmation_tag: confirmationTag(), package_id: 'b'.repeat(64), epoch: 3,
+    confirmation_tag: confirmationTag(), package_id: packageId, epoch,
     created_at_ms: now - 1_000, expires_at_ms: now + 240_000,
   };
 }
@@ -224,11 +515,11 @@ function confirmationTag(): string {
   return btoa('t'.repeat(32));
 }
 
-function proposal(sender: string, recipient: string) {
+function proposal(sender: string, recipient: string, scopeId = 'session-a', epoch = 3) {
   return {
-    version: 1, negotiation_id: 'neg:0123456789abcdef', scope_kind: 'session', scope_id: 'session-a',
+    version: 1, negotiation_id: 'neg:0123456789abcdef', scope_kind: 'session', scope_id: scopeId,
     sender_id: sender, recipient_id: recipient, minimum_mode: 'strict_e2ee', selected_mode: 'strict_e2ee',
-    algorithms: ['AES-256-GCM', 'ECDH-P256-HKDF-SHA256'], key_epoch: 3,
+    algorithms: ['AES-256-GCM', 'ECDH-P256-HKDF-SHA256'], key_epoch: epoch,
     payload_classes: ['bulk', 'control', 'semantic'], expires_at_ms: Number.MAX_SAFE_INTEGER,
   };
 }

--- a/frontend-angular/src/app/services/pair-view-security-bootstrap.service.ts
+++ b/frontend-angular/src/app/services/pair-view-security-bootstrap.service.ts
@@ -2,6 +2,11 @@ import { Injectable, inject } from '@angular/core';
 import { BehaviorSubject, firstValueFrom } from 'rxjs';
 
 import { PairSessionControlPlaneService } from './pair-session-control-plane.service';
+import { E2eEncryptionService } from './e2e-encryption.service';
+import {
+  PublicPairMediaSecurityContractV1,
+  validatePublicPairMediaSecurityContract,
+} from './public-pair-media-security-contract';
 import type { ShareSession } from './share-session.service';
 import { SignedPeerKeyPackage, WebrtcPeerKeyService } from './webrtc-peer-key.service';
 import {
@@ -35,6 +40,8 @@ interface KeyPackageResponse {
   local_peer_id?: string;
   /** Local device package addressed to the remote peer (opposite direction). */
   local_package_id?: string | null;
+  /** Present only when both Public Pair memberships advertised exact v1 media support. */
+  public_media_security_contract_v1?: PublicPairMediaSecurityContractV1 | null;
 }
 
 interface KeyConfirmation {
@@ -51,10 +58,13 @@ interface KeyConfirmation {
 export class PairViewSecurityBootstrapService {
   private readonly controlPlane = inject(PairSessionControlPlaneService);
   private readonly peerKeys = inject(WebrtcPeerKeyService);
+  private readonly encryption = inject(E2eEncryptionService);
   private inFlight: { key: string; promise: Promise<boolean> } | null = null;
   private lastPackageId = '';
   private lastConfirmationRefreshAt = 0;
   private generation = 0;
+  private activeBootstrapKey = '';
+  private readonly mediaContracts = new Map<string, PublicPairMediaSecurityContractV1>();
   currentEpoch = 0;
 
   readonly state$ = new BehaviorSubject<PairSecurityBootstrapState>({ status: 'idle' });
@@ -69,9 +79,30 @@ export class PairViewSecurityBootstrapService {
     return binding?.confirmed ? binding.remotePeerId : '';
   }
 
+  /** Returns only a currently verified, authority-signed media extension. */
+  mediaContractFor(sessionId: string): Readonly<PublicPairMediaSecurityContractV1> | null {
+    const contract = this.mediaContracts.get(sessionId);
+    const binding = this.peerKeys.currentBinding;
+    return contract
+      && binding?.confirmed
+      && binding.scopeId === sessionId
+      && binding.epoch === contract.epoch
+      ? contract : null;
+  }
+
   ensure(session: ShareSession, localPeerId: string): Promise<boolean> {
     const key = `${session.id}:${session.security_epoch ?? 0}:${localPeerId}`;
     if (this.inFlight?.key === key) return this.inFlight.promise;
+    if (this.activeBootstrapKey && this.activeBootstrapKey !== key) {
+      // An old same-session epoch must not remain available while its
+      // replacement is being verified asynchronously.
+      this.mediaContracts.clear();
+      this.peerKeys.clear();
+      this.currentEpoch = 0;
+      this.lastPackageId = '';
+      this.lastConfirmationRefreshAt = 0;
+    }
+    this.activeBootstrapKey = key;
     const generation = ++this.generation;
     const promise = this.run(session, localPeerId, generation).finally(() => {
       if (this.inFlight?.promise === promise) this.inFlight = null;
@@ -91,6 +122,8 @@ export class PairViewSecurityBootstrapService {
     this.lastPackageId = '';
     this.lastConfirmationRefreshAt = 0;
     this.currentEpoch = 0;
+    this.activeBootstrapKey = '';
+    this.mediaContracts.clear();
     this.peerKeys.clear();
     this.state$.next({ status: 'legacy' });
   }
@@ -101,6 +134,8 @@ export class PairViewSecurityBootstrapService {
     this.lastPackageId = '';
     this.lastConfirmationRefreshAt = 0;
     this.currentEpoch = 0;
+    this.activeBootstrapKey = '';
+    this.mediaContracts.clear();
     this.peerKeys.clear();
     this.state$.next({ status: 'idle' });
   }
@@ -128,6 +163,7 @@ export class PairViewSecurityBootstrapService {
         this.lastPackageId = '';
         this.lastConfirmationRefreshAt = 0;
         this.peerKeys.clear();
+        this.mediaContracts.delete(session.id);
         this.state$.next({ status: 'waiting_for_peer' });
         return false;
       }
@@ -144,6 +180,30 @@ export class PairViewSecurityBootstrapService {
       if (contract.digest !== response.security_contract_digest) {
         throw new Error('security_contract_digest_mismatch');
       }
+      let mediaContract: PublicPairMediaSecurityContractV1 | null = null;
+      if (response.public_media_security_contract_v1 != null) {
+        if (!publicSession || !response.local_membership_id) {
+          throw new Error('public_media_contract_authority_invalid');
+        }
+        const localDevice = await this.encryption.ensureLocalKeyPair();
+        if (generation !== this.generation) return false;
+        mediaContract = await validatePublicPairMediaSecurityContract(
+          response.public_media_security_contract_v1,
+          {
+            sessionId: session.id,
+            epoch: response.epoch,
+            localPeerId,
+            localMembershipId: response.local_membership_id,
+            localDeviceFingerprint: localDevice.fingerprint,
+            remotePackage: peerPackage,
+            baseContract: contract,
+            authorityKeyId: response.hub_key_id,
+            authorityPublicKeyB64: response.hub_public_key_b64,
+          },
+        );
+        if (generation !== this.generation) return false;
+      }
+      if (generation !== this.generation) return false;
       const priorBinding = this.peerKeys.currentBinding;
       const current = await this.peerKeys.verifyAndRefreshBinding(peerPackage, {
         hubPublicKeyB64: response.hub_public_key_b64,
@@ -153,12 +213,14 @@ export class PairViewSecurityBootstrapService {
         expectedEpoch: response.epoch,
         localPeerId,
         contractDigest: contract.digest,
-      });
+      }, () => generation === this.generation);
+      if (generation !== this.generation) return false;
       this.lastPackageId = peerPackage.package_id;
       if (priorBinding !== current) {
         this.lastConfirmationRefreshAt = 0;
       }
       if (current.confirmed && Date.now() - this.lastConfirmationRefreshAt < CONFIRMATION_REFRESH_MS) {
+        this.replaceMediaContract(session.id, mediaContract);
         this.state$.next({ status: 'ready', fingerprint: current.peerFingerprint });
         return true;
       }
@@ -207,8 +269,11 @@ export class PairViewSecurityBootstrapService {
         current.epoch,
         publicSession,
       );
+      if (generation !== this.generation) return false;
       await this.peerKeys.acceptPeerConfirmation(verifiedConfirmation.confirmation_tag);
+      if (generation !== this.generation) return false;
       this.lastConfirmationRefreshAt = Date.now();
+      this.replaceMediaContract(session.id, mediaContract);
       this.state$.next({ status: 'ready', fingerprint: current.peerFingerprint });
       return true;
     } catch (error) {
@@ -217,9 +282,18 @@ export class PairViewSecurityBootstrapService {
       const reasonCode = typeof responseCode === 'string'
         ? responseCode
         : error instanceof Error ? error.message : 'security_bootstrap_failed';
+      this.mediaContracts.delete(session.id);
       this.state$.next({ status: 'failed', reasonCode });
       return false;
     }
+  }
+
+  private replaceMediaContract(
+    sessionId: string,
+    contract: PublicPairMediaSecurityContractV1 | null,
+  ): void {
+    if (contract) this.mediaContracts.set(sessionId, contract);
+    else this.mediaContracts.delete(sessionId);
   }
 }
 

--- a/frontend-angular/src/app/services/public-pair-media-runtime-capability.service.spec.ts
+++ b/frontend-angular/src/app/services/public-pair-media-runtime-capability.service.spec.ts
@@ -1,0 +1,61 @@
+import {
+  PUBLIC_PAIR_MEDIA_CAPABILITIES_V1,
+} from './public-pair-media-security-contract';
+import {
+  PublicPairMediaRuntimeCapabilityService,
+  supportsPublicPairMediaRuntime,
+} from './public-pair-media-runtime-capability.service';
+
+describe('PublicPairMediaRuntimeCapabilityService', () => {
+  const supportedRuntime = () => ({
+    RTCRtpScriptTransform: class {},
+    Worker: class {},
+    TransformStream: class {},
+    crypto: {
+      getRandomValues: () => undefined,
+      subtle: {
+        digest: () => undefined, importKey: () => undefined, deriveKey: () => undefined,
+        encrypt: () => undefined, decrypt: () => undefined,
+      } as unknown as SubtleCrypto,
+    },
+    RTCRtpSender: {
+      prototype: { transform: null },
+      getCapabilities: (kind: string) => ({
+        codecs: [{ mimeType: kind === 'audio' ? 'audio/opus' : 'video/VP8' }],
+      }),
+    },
+    RTCRtpReceiver: { prototype: { transform: null } },
+    RTCRtpTransceiver: { prototype: { setCodecPreferences: () => undefined } },
+  });
+
+  it('advertises the exact immutable v1 profile only with the complete standard surface', () => {
+    const service = new PublicPairMediaRuntimeCapabilityService();
+    vi.spyOn(service, 'supported').mockReturnValue(true);
+
+    expect(service.membershipAdvertisement()).toEqual({
+      public_media_e2ee_version: 1,
+      public_media_capabilities: PUBLIC_PAIR_MEDIA_CAPABILITIES_V1,
+    });
+    expect(Object.isFrozen(service.membershipAdvertisement())).toBe(true);
+  });
+
+  it.each([
+    'RTCRtpScriptTransform', 'Worker', 'TransformStream', 'crypto',
+    'RTCRtpSender', 'RTCRtpReceiver', 'RTCRtpTransceiver',
+  ] as const)(
+    'omits the extension when %s is unavailable',
+    missing => {
+      const runtime = supportedRuntime() as Record<string, unknown>;
+      delete runtime[missing];
+      expect(supportsPublicPairMediaRuntime(runtime)).toBe(false);
+    },
+  );
+
+  it('omits the extension when exact Opus/VP8 codec preferences cannot be enforced', () => {
+    const runtime = supportedRuntime();
+    runtime.RTCRtpSender.getCapabilities = kind => ({
+      codecs: [{ mimeType: kind === 'audio' ? 'audio/PCMU' : 'video/H264' }],
+    });
+    expect(supportsPublicPairMediaRuntime(runtime)).toBe(false);
+  });
+});

--- a/frontend-angular/src/app/services/public-pair-media-runtime-capability.service.ts
+++ b/frontend-angular/src/app/services/public-pair-media-runtime-capability.service.ts
@@ -1,0 +1,76 @@
+import { Injectable } from '@angular/core';
+
+import { PUBLIC_PAIR_MEDIA_CAPABILITIES_V1 } from './public-pair-media-security-contract';
+
+export interface PublicPairMediaMembershipAdvertisementV1 {
+  readonly public_media_e2ee_version: 1;
+  readonly public_media_capabilities: typeof PUBLIC_PAIR_MEDIA_CAPABILITIES_V1;
+}
+
+/** Runtime surface required by the standards-only first Public Pair slice. */
+interface EncodedTransformRuntime {
+  readonly RTCRtpScriptTransform?: unknown;
+  readonly RTCRtpSender?: {
+    readonly prototype?: object;
+    getCapabilities?(kind: string): RTCRtpCapabilities | null;
+  };
+  readonly RTCRtpReceiver?: { readonly prototype?: object };
+  readonly RTCRtpTransceiver?: { readonly prototype?: object };
+  readonly Worker?: unknown;
+  readonly TransformStream?: unknown;
+  readonly crypto?: {
+    readonly getRandomValues?: unknown;
+    readonly subtle?: Partial<SubtleCrypto>;
+  };
+}
+
+@Injectable({ providedIn: 'root' })
+export class PublicPairMediaRuntimeCapabilityService {
+  supported(): boolean {
+    return supportsPublicPairMediaRuntime(globalThis as EncodedTransformRuntime);
+  }
+
+  membershipAdvertisement(): PublicPairMediaMembershipAdvertisementV1 | null {
+    if (!this.supported()) return null;
+    return Object.freeze({
+      public_media_e2ee_version: 1,
+      public_media_capabilities: PUBLIC_PAIR_MEDIA_CAPABILITIES_V1,
+    });
+  }
+}
+
+export function supportsPublicPairMediaRuntime(runtime: EncodedTransformRuntime): boolean {
+  const subtle = runtime.crypto?.subtle;
+  return typeof runtime.RTCRtpScriptTransform === 'function'
+    && typeof runtime.Worker === 'function'
+    && typeof runtime.TransformStream === 'function'
+    && typeof runtime.crypto?.getRandomValues === 'function'
+    && typeof subtle?.digest === 'function'
+    && typeof subtle?.importKey === 'function'
+    && typeof subtle?.deriveKey === 'function'
+    && typeof subtle?.encrypt === 'function'
+    && typeof subtle?.decrypt === 'function'
+    && hasTransformProperty(runtime.RTCRtpSender?.prototype)
+    && hasTransformProperty(runtime.RTCRtpReceiver?.prototype)
+    && typeof (runtime.RTCRtpTransceiver?.prototype as { setCodecPreferences?: unknown } | undefined)
+      ?.setCodecPreferences === 'function'
+    && hasCodec(runtime.RTCRtpSender, 'audio', 'audio/opus')
+    && hasCodec(runtime.RTCRtpSender, 'video', 'video/vp8');
+}
+
+function hasTransformProperty(value: object | undefined): boolean {
+  return Boolean(value && 'transform' in value);
+}
+
+function hasCodec(
+  sender: EncodedTransformRuntime['RTCRtpSender'],
+  kind: 'audio' | 'video',
+  mimeType: string,
+): boolean {
+  try {
+    return sender?.getCapabilities?.(kind)?.codecs
+      .some(codec => codec.mimeType.toLowerCase() === mimeType) === true;
+  } catch {
+    return false;
+  }
+}

--- a/frontend-angular/src/app/services/public-pair-media-security-contract.spec.ts
+++ b/frontend-angular/src/app/services/public-pair-media-security-contract.spec.ts
@@ -1,0 +1,110 @@
+import {
+  PUBLIC_PAIR_MEDIA_GRANTS,
+  PUBLIC_PAIR_MEDIA_SLOTS,
+  PublicPairMediaContractError,
+  validatePublicPairMediaSecurityContract,
+} from './public-pair-media-security-contract';
+import type { FinalStrictPairSecurityContractV1 } from './webrtc-security-negotiation';
+import type { SignedPeerKeyPackage } from './webrtc-peer-key.service';
+import { canonicalSecurityJson, encodeB64 } from './webrtc-secure-envelope';
+
+const NOW = 1_000_000;
+const BASE_DIGEST = 'd'.repeat(64);
+const LOCAL_FP = 'a'.repeat(64);
+const REMOTE_FP = 'b'.repeat(64);
+
+const baseContract = {
+  version: 1,
+  negotiation_id: 'neg:test',
+  offer: { sender_id: 'member:owner', recipient_id: 'member:guest', expires_at_ms: NOW + 60_000 },
+  answer: { sender_id: 'member:guest', recipient_id: 'member:owner', expires_at_ms: NOW + 60_000 },
+  digest: BASE_DIGEST,
+  signature: 'c'.repeat(64),
+  signature_algorithm: 'HMAC-SHA256',
+} as unknown as FinalStrictPairSecurityContractV1;
+
+async function fixture() {
+  const authority = await crypto.subtle.generateKey('Ed25519', true, ['sign', 'verify']);
+  const publicBytes = new Uint8Array(await crypto.subtle.exportKey('raw', authority.publicKey));
+  const authorityKeyId = `rv:${(await digestBytes(publicBytes)).slice(0, 24)}`;
+  const unsigned = {
+    domain: 'ananta.public-pair.media-security-contract.v1',
+    version: 1,
+    session_id: 'session-a',
+    epoch: 3,
+    identity_binding_version: 2,
+    base_security_contract_digest: BASE_DIGEST,
+    memberships: [
+      {
+        membership_id: 'member:owner', membership_version: 1,
+        peer_id: `peer:${'1'.repeat(64)}`, device_key_fingerprint: LOCAL_FP,
+        public_media_e2ee_version: 1,
+      },
+      {
+        membership_id: 'member:guest', membership_version: 1,
+        peer_id: `peer:${'2'.repeat(64)}`, device_key_fingerprint: REMOTE_FP,
+        public_media_e2ee_version: 1,
+      },
+    ],
+    grants: [...PUBLIC_PAIR_MEDIA_GRANTS],
+    slots: PUBLIC_PAIR_MEDIA_SLOTS.map(value => ({ ...value })),
+    transform: 'RTCRtpScriptTransform',
+    algorithms: { aead: 'AES-256-GCM', kdf: 'HKDF-SHA-256' },
+    expires_at_ms: NOW + 60_000,
+    authority_key_id: authorityKeyId,
+  };
+  const digest = await digestText(canonicalSecurityJson(unsigned));
+  const signed = { ...unsigned, digest, signature_algorithm: 'Ed25519' };
+  const signature = await crypto.subtle.sign(
+    'Ed25519', authority.privateKey,
+    new TextEncoder().encode(canonicalSecurityJson(signed)),
+  );
+  const contract = { ...signed, signature_b64: encodeB64(signature) };
+  const remotePackage = {
+    membership_id: 'member:guest', membership_version: 1,
+    peer_id: `peer:${'2'.repeat(64)}`, device_key_fingerprint: REMOTE_FP,
+  } as SignedPeerKeyPackage;
+  const options = {
+    sessionId: 'session-a', epoch: 3,
+    localPeerId: `peer:${'1'.repeat(64)}`,
+    localMembershipId: 'member:owner', localDeviceFingerprint: LOCAL_FP,
+    remotePackage, baseContract, authorityKeyId,
+    authorityPublicKeyB64: encodeB64(publicBytes), nowMs: NOW,
+  };
+  return { contract, options };
+}
+
+describe('Public Pair media security contract', () => {
+  it('verifies the exact profile, membership binding, digest and authority signature', async () => {
+    const { contract, options } = await fixture();
+    await expect(validatePublicPairMediaSecurityContract(contract, options))
+      .resolves.toMatchObject({ digest: contract.digest, transform: 'RTCRtpScriptTransform' });
+  });
+
+  it('rejects profile expansion, unknown fields and signature tampering', async () => {
+    const { contract, options } = await fixture();
+    await expect(validatePublicPairMediaSecurityContract({
+      ...contract, grants: [...contract.grants, 'h264'],
+    }, options)).rejects.toMatchObject<Partial<PublicPairMediaContractError>>({
+      reasonCode: 'public_media_contract_grants_invalid',
+    });
+    await expect(validatePublicPairMediaSecurityContract({ ...contract, extra: true }, options))
+      .rejects.toMatchObject<Partial<PublicPairMediaContractError>>({
+        reasonCode: 'public_media_contract_fields_invalid',
+      });
+    await expect(validatePublicPairMediaSecurityContract({
+      ...contract, signature_b64: encodeB64(new Uint8Array(64)),
+    }, options)).rejects.toMatchObject<Partial<PublicPairMediaContractError>>({
+      reasonCode: 'public_media_contract_signature_invalid',
+    });
+  });
+});
+
+async function digestText(value: string): Promise<string> {
+  return digestBytes(new TextEncoder().encode(value));
+}
+
+async function digestBytes(value: Uint8Array): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', Uint8Array.from(value).buffer);
+  return [...new Uint8Array(digest)].map(byte => byte.toString(16).padStart(2, '0')).join('');
+}

--- a/frontend-angular/src/app/services/public-pair-media-security-contract.ts
+++ b/frontend-angular/src/app/services/public-pair-media-security-contract.ts
@@ -1,0 +1,282 @@
+import type { FinalStrictPairSecurityContractV1 } from './webrtc-security-negotiation';
+import type { SignedPeerKeyPackage } from './webrtc-peer-key.service';
+import { canonicalSecurityJson, decodeB64 } from './webrtc-secure-envelope';
+
+export const PUBLIC_PAIR_MEDIA_GRANTS = Object.freeze([
+  'microphone-opus',
+  'camera-vp8',
+  'screen-vp8',
+] as const);
+
+export const PUBLIC_PAIR_MEDIA_SLOTS = Object.freeze([
+  Object.freeze({ slot: 'microphone-opus', kind: 'audio', codec: 'opus' }),
+  Object.freeze({ slot: 'camera-vp8', kind: 'video', codec: 'vp8' }),
+  Object.freeze({ slot: 'screen-vp8', kind: 'video', codec: 'vp8' }),
+] as const);
+
+export type PublicPairMediaGrant = typeof PUBLIC_PAIR_MEDIA_GRANTS[number];
+export type PublicPairMediaSlot = typeof PUBLIC_PAIR_MEDIA_SLOTS[number]['slot'];
+export type PublicPairMediaKind = typeof PUBLIC_PAIR_MEDIA_SLOTS[number]['kind'];
+export type PublicPairMediaCodec = typeof PUBLIC_PAIR_MEDIA_SLOTS[number]['codec'];
+
+export const PUBLIC_PAIR_MEDIA_CAPABILITIES_V1 = Object.freeze({
+  version: 1 as const,
+  transform: 'RTCRtpScriptTransform' as const,
+  grants: PUBLIC_PAIR_MEDIA_GRANTS,
+});
+
+export interface PublicPairMediaMembershipV1 {
+  readonly membership_id: string;
+  readonly membership_version: number;
+  readonly peer_id: string;
+  readonly device_key_fingerprint: string;
+  readonly public_media_e2ee_version: 1;
+}
+
+export interface PublicPairMediaSecurityContractV1 {
+  readonly domain: 'ananta.public-pair.media-security-contract.v1';
+  readonly version: 1;
+  readonly session_id: string;
+  readonly epoch: number;
+  readonly identity_binding_version: 2;
+  readonly base_security_contract_digest: string;
+  readonly memberships: readonly [PublicPairMediaMembershipV1, PublicPairMediaMembershipV1];
+  readonly grants: typeof PUBLIC_PAIR_MEDIA_GRANTS;
+  readonly slots: typeof PUBLIC_PAIR_MEDIA_SLOTS;
+  readonly transform: 'RTCRtpScriptTransform';
+  readonly algorithms: Readonly<{ aead: 'AES-256-GCM'; kdf: 'HKDF-SHA-256' }>;
+  readonly expires_at_ms: number;
+  readonly authority_key_id: string;
+  readonly digest: string;
+  readonly signature_algorithm: 'Ed25519';
+  readonly signature_b64: string;
+}
+
+export interface PublicPairMediaContractValidationOptions {
+  readonly sessionId: string;
+  readonly epoch: number;
+  readonly localPeerId: string;
+  readonly localMembershipId: string;
+  readonly localDeviceFingerprint: string;
+  readonly remotePackage: SignedPeerKeyPackage;
+  readonly baseContract: FinalStrictPairSecurityContractV1;
+  readonly authorityKeyId: string;
+  readonly authorityPublicKeyB64: string;
+  readonly nowMs?: number;
+}
+
+export class PublicPairMediaContractError extends Error {
+  constructor(readonly reasonCode: string) { super(reasonCode); }
+}
+
+const CONTRACT_FIELDS = [
+  'domain', 'version', 'session_id', 'epoch', 'identity_binding_version',
+  'base_security_contract_digest', 'memberships', 'grants', 'slots', 'transform',
+  'algorithms', 'expires_at_ms', 'authority_key_id', 'digest',
+  'signature_algorithm', 'signature_b64',
+] as const;
+const MEMBERSHIP_FIELDS = [
+  'membership_id', 'membership_version', 'peer_id', 'device_key_fingerprint',
+  'public_media_e2ee_version',
+] as const;
+const SLOT_FIELDS = ['slot', 'kind', 'codec'] as const;
+const DIGEST_RE = /^[a-f0-9]{64}$/;
+const IDENTIFIER_RE = /^[A-Za-z0-9][A-Za-z0-9._:@-]{0,127}$/;
+const DEVICE_PEER_RE = /^peer:[a-f0-9]{64}$/;
+
+/**
+ * Validate the separately signed Public Pair media grant. The base Pair v1
+ * contract deliberately remains data-only; this authority-signed object is
+ * the sole additive authorization for encoded audio/video frames.
+ */
+export async function validatePublicPairMediaSecurityContract(
+  raw: unknown,
+  options: PublicPairMediaContractValidationOptions,
+): Promise<PublicPairMediaSecurityContractV1> {
+  const value = closedObject(raw, CONTRACT_FIELDS, 'public_media_contract_fields_invalid');
+  if (
+    value['domain'] !== 'ananta.public-pair.media-security-contract.v1'
+    || value['version'] !== 1
+    || value['identity_binding_version'] !== 2
+    || value['transform'] !== 'RTCRtpScriptTransform'
+    || value['signature_algorithm'] !== 'Ed25519'
+  ) throw new PublicPairMediaContractError('public_media_contract_version_invalid');
+  if (
+    value['session_id'] !== options.sessionId
+    || value['epoch'] !== options.epoch
+    || value['base_security_contract_digest'] !== options.baseContract.digest
+    || value['authority_key_id'] !== options.authorityKeyId
+  ) throw new PublicPairMediaContractError('public_media_contract_binding_mismatch');
+  if (!Number.isSafeInteger(value['epoch']) || (value['epoch'] as number) < 1) {
+    throw new PublicPairMediaContractError('public_media_contract_epoch_invalid');
+  }
+  const expiresAtMs = value['expires_at_ms'];
+  const baseExpiry = Math.min(
+    options.baseContract.offer.expires_at_ms,
+    options.baseContract.answer.expires_at_ms,
+  );
+  if (
+    !Number.isSafeInteger(expiresAtMs)
+    || (expiresAtMs as number) <= (options.nowMs ?? Date.now())
+    || (expiresAtMs as number) > baseExpiry
+  ) throw new PublicPairMediaContractError('public_media_contract_expired');
+  if (!exactStrings(value['grants'], PUBLIC_PAIR_MEDIA_GRANTS)) {
+    throw new PublicPairMediaContractError('public_media_contract_grants_invalid');
+  }
+  validateSlots(value['slots']);
+  const algorithms = closedObject(
+    value['algorithms'], ['aead', 'kdf'], 'public_media_contract_algorithms_invalid',
+  );
+  if (algorithms['aead'] !== 'AES-256-GCM' || algorithms['kdf'] !== 'HKDF-SHA-256') {
+    throw new PublicPairMediaContractError('public_media_contract_algorithms_invalid');
+  }
+  const memberships = validateMemberships(value['memberships'], options);
+  if (!DIGEST_RE.test(String(value['digest'] ?? ''))) {
+    throw new PublicPairMediaContractError('public_media_contract_digest_invalid');
+  }
+  const unsigned = { ...value };
+  delete unsigned['digest'];
+  delete unsigned['signature_algorithm'];
+  delete unsigned['signature_b64'];
+  const expectedDigest = await sha256Hex(canonicalSecurityJson(unsigned));
+  if (expectedDigest !== value['digest']) {
+    throw new PublicPairMediaContractError('public_media_contract_digest_mismatch');
+  }
+  await verifyAuthoritySignature(value, options);
+  return Object.freeze({
+    ...(value as unknown as PublicPairMediaSecurityContractV1),
+    memberships,
+    grants: PUBLIC_PAIR_MEDIA_GRANTS,
+    slots: PUBLIC_PAIR_MEDIA_SLOTS,
+    algorithms: Object.freeze({ aead: 'AES-256-GCM', kdf: 'HKDF-SHA-256' }),
+  });
+}
+
+function validateMemberships(
+  raw: unknown,
+  options: PublicPairMediaContractValidationOptions,
+): readonly [PublicPairMediaMembershipV1, PublicPairMediaMembershipV1] {
+  if (!Array.isArray(raw) || raw.length !== 2) {
+    throw new PublicPairMediaContractError('public_media_contract_memberships_invalid');
+  }
+  const parsed = raw.map(item => {
+    const value = closedObject(
+      item, MEMBERSHIP_FIELDS, 'public_media_contract_memberships_invalid',
+    );
+    if (
+      !identifier(value['membership_id'])
+      || !DEVICE_PEER_RE.test(String(value['peer_id'] ?? ''))
+      || !DIGEST_RE.test(String(value['device_key_fingerprint'] ?? ''))
+      || !Number.isSafeInteger(value['membership_version'])
+      || (value['membership_version'] as number) < 1
+      || value['public_media_e2ee_version'] !== 1
+    ) throw new PublicPairMediaContractError('public_media_contract_memberships_invalid');
+    return Object.freeze(value as unknown as PublicPairMediaMembershipV1);
+  }) as [PublicPairMediaMembershipV1, PublicPairMediaMembershipV1];
+  const expectedMembershipOrder = [
+    options.baseContract.offer.sender_id,
+    options.baseContract.offer.recipient_id,
+  ];
+  if (
+    parsed.some((member, index) => member.membership_id !== expectedMembershipOrder[index])
+    || parsed[0].membership_id === parsed[1].membership_id
+    || parsed[0].peer_id === parsed[1].peer_id
+    || parsed[0].device_key_fingerprint === parsed[1].device_key_fingerprint
+  ) throw new PublicPairMediaContractError('public_media_contract_memberships_invalid');
+  const local = parsed.find(member => member.membership_id === options.localMembershipId);
+  const remote = parsed.find(member => member.membership_id === options.remotePackage.membership_id);
+  if (
+    !local || !remote || local === remote
+    || local.peer_id !== options.localPeerId
+    || local.device_key_fingerprint !== options.localDeviceFingerprint
+    || remote.peer_id !== options.remotePackage.peer_id
+    || remote.membership_version !== options.remotePackage.membership_version
+    || remote.device_key_fingerprint !== options.remotePackage.device_key_fingerprint
+  ) throw new PublicPairMediaContractError('public_media_contract_membership_binding_mismatch');
+  return Object.freeze(parsed);
+}
+
+function validateSlots(raw: unknown): void {
+  if (!Array.isArray(raw) || raw.length !== PUBLIC_PAIR_MEDIA_SLOTS.length) {
+    throw new PublicPairMediaContractError('public_media_contract_slots_invalid');
+  }
+  raw.forEach((item, index) => {
+    const value = closedObject(item, SLOT_FIELDS, 'public_media_contract_slots_invalid');
+    const expected = PUBLIC_PAIR_MEDIA_SLOTS[index];
+    if (
+      value['slot'] !== expected.slot
+      || value['kind'] !== expected.kind
+      || value['codec'] !== expected.codec
+    ) throw new PublicPairMediaContractError('public_media_contract_slots_invalid');
+  });
+}
+
+async function verifyAuthoritySignature(
+  value: Record<string, unknown>,
+  options: PublicPairMediaContractValidationOptions,
+): Promise<void> {
+  try {
+    const publicKeyBytes = decodeB64(options.authorityPublicKeyB64);
+    const signatureBytes = decodeB64(value['signature_b64']);
+    if (publicKeyBytes.byteLength !== 32 || signatureBytes.byteLength !== 64) {
+      throw new PublicPairMediaContractError('public_media_contract_signature_invalid');
+    }
+    const derivedKeyId = `rv:${(await sha256HexBytes(publicKeyBytes)).slice(0, 24)}`;
+    if (derivedKeyId !== options.authorityKeyId) {
+      throw new PublicPairMediaContractError('public_media_contract_authority_invalid');
+    }
+    const signed = { ...value };
+    delete signed['signature_b64'];
+    const publicKey = await crypto.subtle.importKey(
+      'raw', arrayBuffer(publicKeyBytes), { name: 'Ed25519' }, false, ['verify'],
+    );
+    const verified = await crypto.subtle.verify(
+      'Ed25519', publicKey, arrayBuffer(signatureBytes),
+      arrayBuffer(new TextEncoder().encode(canonicalSecurityJson(signed))),
+    );
+    if (!verified) throw new PublicPairMediaContractError('public_media_contract_signature_invalid');
+  } catch (error) {
+    if (error instanceof PublicPairMediaContractError) throw error;
+    throw new PublicPairMediaContractError('public_media_contract_signature_invalid');
+  }
+}
+
+function closedObject(
+  raw: unknown,
+  expected: readonly string[],
+  reasonCode: string,
+): Record<string, unknown> {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new PublicPairMediaContractError(reasonCode);
+  }
+  const value = raw as Record<string, unknown>;
+  const keys = Object.keys(value);
+  if (keys.length !== expected.length || expected.some(field => !(field in value))) {
+    throw new PublicPairMediaContractError(reasonCode);
+  }
+  return value;
+}
+
+function exactStrings(value: unknown, expected: readonly string[]): boolean {
+  return Array.isArray(value)
+    && value.length === expected.length
+    && value.every((item, index) => item === expected[index]);
+}
+
+function identifier(value: unknown): value is string {
+  return typeof value === 'string' && IDENTIFIER_RE.test(value);
+}
+
+async function sha256Hex(value: string): Promise<string> {
+  return sha256HexBytes(new TextEncoder().encode(value));
+}
+
+async function sha256HexBytes(value: Uint8Array): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', arrayBuffer(value));
+  return [...new Uint8Array(digest)].map(byte => byte.toString(16).padStart(2, '0')).join('');
+}
+
+function arrayBuffer(value: Uint8Array): ArrayBuffer {
+  const copy = Uint8Array.from(value);
+  return copy.buffer;
+}

--- a/frontend-angular/src/app/services/webrtc-media-publication.service.spec.ts
+++ b/frontend-angular/src/app/services/webrtc-media-publication.service.spec.ts
@@ -8,6 +8,7 @@ import {
 } from './webrtc-media-publication.service';
 import { WebrtcSessionService } from './webrtc-session.service';
 import { PairOrdinaryMediaPolicy } from './pair-ordinary-media.policy';
+import { PairMediaE2eeCoordinatorService } from './pair-media-e2ee-coordinator.service';
 
 class Track {
   kind = 'video'; id: string; enabled = true; readyState: MediaStreamTrackState = 'live';
@@ -35,6 +36,7 @@ describe('WebrtcMediaPublicationService', () => {
   let camera: Track[]; let screens: Track[]; let sender: any; let peer: any;
   let dispatchDeviceChange: () => void;
   const mediaPolicy = { assertAllowed: vi.fn(), allows: vi.fn(() => true) };
+  const mediaE2eeStatus = new BehaviorSubject({ sessionId: '', state: 'inactive' as const });
   beforeEach(() => {
     camera = []; screens = [];
     mediaPolicy.assertAllowed.mockReset();
@@ -43,6 +45,7 @@ describe('WebrtcMediaPublicationService', () => {
     sender = { getParameters: () => ({ encodings: [{}] }), setParameters: vi.fn(async () => undefined), replaceTrack: vi.fn() };
     peer = {
       addMediaTrack: vi.fn(() => sender), replaceMediaTrack: vi.fn(async () => undefined), removeMediaSender: vi.fn(),
+      attachMediaTrack: vi.fn(async () => sender), publicMediaSlotForReceiver: vi.fn(() => null),
       sessionStarted$: new Subject<string>(), state$: new BehaviorSubject('active'), remoteTrack$: new Subject<any>(),
     };
     let deviceChange: (() => void) | undefined;
@@ -56,6 +59,7 @@ describe('WebrtcMediaPublicationService', () => {
     TestBed.configureTestingModule({ providers: [
       WebrtcMediaPublicationService, { provide: WebrtcSessionService, useValue: peer },
       { provide: PairOrdinaryMediaPolicy, useValue: mediaPolicy },
+      { provide: PairMediaE2eeCoordinatorService, useValue: { status$: mediaE2eeStatus } },
       { provide: WEBRTC_MEDIA_DEVICES, useValue: devices },
     ] });
     service = TestBed.inject(WebrtcMediaPublicationService);
@@ -84,7 +88,7 @@ describe('WebrtcMediaPublicationService', () => {
     await expect(service.startLocal(AUTH, PREF, 1000))
       .rejects.toThrow('public_ordinary_media_e2ee_unavailable');
     expect(camera).toEqual([]);
-    expect(peer.addMediaTrack).not.toHaveBeenCalled();
+    expect(peer.attachMediaTrack).not.toHaveBeenCalled();
   });
 
   it('intersects Hub and user bounds and refuses silent source switches', async () => {
@@ -112,7 +116,7 @@ describe('WebrtcMediaPublicationService', () => {
     devices.getUserMedia.mockResolvedValueOnce(new Stream(oversized));
     await expect(service.startLocal(AUTH, PREF, 1000)).rejects.toThrow('browser_capture_exceeds_policy');
     expect(oversized.stops).toBeGreaterThan(0);
-    expect(peer.addMediaTrack).not.toHaveBeenCalled();
+    expect(peer.attachMediaTrack).not.toHaveBeenCalled();
   });
 
   it('cancels a pending permission result and never attaches its late track', async () => {
@@ -126,7 +130,7 @@ describe('WebrtcMediaPublicationService', () => {
     resolveCapture(new Stream(late));
     await expect(start).rejects.toThrow('publication_operation_superseded');
     expect(late.stops).toBeGreaterThan(0);
-    expect(peer.addMediaTrack).not.toHaveBeenCalled();
+    expect(peer.attachMediaTrack).not.toHaveBeenCalled();
     expect(service.publications$.value[0]).toMatchObject({ status: 'ended', reasonCode: 'publication_user_stop' });
   });
 

--- a/frontend-angular/src/app/services/webrtc-media-publication.service.ts
+++ b/frontend-angular/src/app/services/webrtc-media-publication.service.ts
@@ -7,6 +7,7 @@ import {
 } from './webrtc-media-session.service';
 import { WebrtcSessionService } from './webrtc-session.service';
 import { PairOrdinaryMediaPolicy } from './pair-ordinary-media.policy';
+import { PairMediaE2eeCoordinatorService } from './pair-media-e2ee-coordinator.service';
 
 export type MediaPublicationSource = 'camera' | 'screen' | 'remote_video';
 export type MediaPublicationStatus = 'requesting_permission' | 'active' | 'muted' | 'ended' | 'failed';
@@ -61,6 +62,7 @@ export class WebrtcMediaPublicationService implements OnDestroy {
   readonly publications$ = new BehaviorSubject<readonly MediaPublicationView[]>(Object.freeze([]));
   private readonly peer = inject(WebrtcSessionService);
   private readonly mediaPolicy = inject(PairOrdinaryMediaPolicy);
+  private readonly pairMediaE2ee = inject(PairMediaE2eeCoordinatorService);
   private readonly mediaSession = inject(WebrtcMediaSessionService);
   private readonly devices = inject(WEBRTC_MEDIA_DEVICES);
   private readonly local = new Map<string, LocalPublication>();
@@ -78,7 +80,13 @@ export class WebrtcMediaPublicationService implements OnDestroy {
       this.currentSessionId = sessionId;
     }));
     this.subscriptions.add(this.peer.state$.subscribe(state => {
-      if (state === 'closed' || state === 'idle') this.stopAll('session_closed');
+      if (state === 'closed' || state === 'idle' || state === 'failed') this.stopAll('session_closed');
+    }));
+    this.subscriptions.add(this.pairMediaE2ee.status$.subscribe(status => {
+      if (status.sessionId !== this.currentSessionId || status.state === 'ready') return;
+      if (this.local.size || this.remote.size) {
+        this.stopAll(status.reasonCode || 'public_media_e2ee_not_ready');
+      }
     }));
     this.subscriptions.add(this.mediaSession.remoteTracks$.subscribe(tracks => this.reconcileRemoteTracks(tracks)));
     this.devices.addEventListener?.('devicechange', this.deviceChangeListener);
@@ -118,7 +126,11 @@ export class WebrtcMediaPublicationService implements OnDestroy {
       const track = stream.getVideoTracks()[0];
       if (!track) throw new Error('video_track_missing');
       validateTrackSettings(track, limits);
-      sender = this.peer.addMediaTrack(track, stream);
+      sender = await this.peer.attachMediaTrack(
+        authorization.source === 'camera' ? 'camera-vp8' : 'screen-vp8',
+        track,
+        stream,
+      );
       await applyBitrate(sender, limits.bitrate);
       this.assertOperation(authorization.publicationId, operationId);
       publication.view = Object.freeze({
@@ -353,9 +365,13 @@ export class WebrtcMediaPublicationService implements OnDestroy {
     const activePublicationIds = new Set<string>();
     for (const value of tracks) {
       if (value.track.kind !== 'video' || value.track.readyState === 'ended') continue;
-      const publicationId = `remote-${value.track.id}`;
+      const publicSlot = value.slot === 'camera-vp8' || value.slot === 'screen-vp8'
+        ? value.slot : null;
+      const publicationId = publicSlot ? `remote-${publicSlot}` : `remote-${value.track.id}`;
       activePublicationIds.add(publicationId);
-      const source = value.track.getSettings().displaySurface ? 'screen' : 'camera';
+      const source = publicSlot === 'screen-vp8'
+        ? 'screen' : publicSlot === 'camera-vp8'
+          ? 'camera' : value.track.getSettings().displaySurface ? 'screen' : 'camera';
       this.registerRemote(publicationId, value.track, source);
     }
     for (const [publicationId, publication] of this.remote) {

--- a/frontend-angular/src/app/services/webrtc-media-session.service.spec.ts
+++ b/frontend-angular/src/app/services/webrtc-media-session.service.spec.ts
@@ -3,6 +3,7 @@ import { BehaviorSubject, Subject } from 'rxjs';
 import { WEBRTC_MEDIA_DEVICES, WebrtcMediaSessionService } from './webrtc-media-session.service';
 import { PeerState, WebrtcSessionService } from './webrtc-session.service';
 import { PairOrdinaryMediaPolicy } from './pair-ordinary-media.policy';
+import { PairMediaE2eeCoordinatorService } from './pair-media-e2ee-coordinator.service';
 
 class FakeTrack {
   id: string; kind = 'audio'; label = 'Explicit microphone'; enabled = true; onended: (() => void) | null = null;
@@ -25,6 +26,7 @@ describe('WebrtcMediaSessionService', () => {
   let devices: any;
   let dispatchDeviceChange: () => void;
   const mediaPolicy = { assertAllowed: vi.fn() };
+  const mediaE2eeStatus = new BehaviorSubject({ sessionId: '', state: 'inactive' as const });
 
   beforeEach(() => {
     tracks = [];
@@ -34,6 +36,10 @@ describe('WebrtcMediaSessionService', () => {
       remoteTrack$: new Subject<RTCTrackEvent>(), sender: { track: null }, addMediaTrack: vi.fn((track: MediaStreamTrack) => {
         peer.sender.track = track; return peer.sender;
       }),
+      attachMediaTrack: vi.fn(async (_slot: string, track: MediaStreamTrack) => {
+        peer.sender.track = track; return peer.sender;
+      }),
+      publicMediaSlotForReceiver: vi.fn(() => null),
       replaceMediaTrack: vi.fn(async (sender: any, track: MediaStreamTrack | null) => { sender.track = track; }),
       removeMediaSender: vi.fn(), restartMediaIce: vi.fn(),
     };
@@ -52,6 +58,7 @@ describe('WebrtcMediaSessionService', () => {
       WebrtcMediaSessionService,
       { provide: WebrtcSessionService, useValue: peer },
       { provide: PairOrdinaryMediaPolicy, useValue: mediaPolicy },
+      { provide: PairMediaE2eeCoordinatorService, useValue: { status$: mediaE2eeStatus } },
       { provide: WEBRTC_MEDIA_DEVICES, useValue: devices },
     ] });
     service = TestBed.inject(WebrtcMediaSessionService);
@@ -60,7 +67,7 @@ describe('WebrtcMediaSessionService', () => {
   afterEach(() => service.ngOnDestroy());
 
   it('keeps data-channel-only sessions compatible until explicit microphone permission', () => {
-    expect(peer.addMediaTrack).not.toHaveBeenCalled();
+    expect(peer.attachMediaTrack).not.toHaveBeenCalled();
     expect(service.audioState$.value.status).toBe('idle');
   });
 
@@ -80,7 +87,7 @@ describe('WebrtcMediaSessionService', () => {
 
   it('adds, mutes, replaces and reconnects audio without disturbing control transport', async () => {
     await service.requestMicrophone();
-    expect(peer.addMediaTrack).toHaveBeenCalledTimes(1);
+    expect(peer.attachMediaTrack).toHaveBeenCalledTimes(1);
     service.setMuted(true);
     expect(tracks[0].enabled).toBe(false);
     await service.replaceMicrophone({ deviceId: 'second' });
@@ -144,7 +151,7 @@ describe('WebrtcMediaSessionService', () => {
     resolveCapture(new FakeStream(lateTrack));
     await expect(pending).rejects.toThrow('microphone_capture_superseded');
     expect(lateTrack.stops).toBeGreaterThan(0);
-    expect(peer.addMediaTrack).not.toHaveBeenCalled();
+    expect(peer.attachMediaTrack).not.toHaveBeenCalled();
     expect(service.audioState$.value).toMatchObject({ status: 'idle', reasonCode: 'microphone_user_stop' });
   });
 

--- a/frontend-angular/src/app/services/webrtc-media-session.service.ts
+++ b/frontend-angular/src/app/services/webrtc-media-session.service.ts
@@ -2,6 +2,8 @@ import { Injectable, InjectionToken, OnDestroy, inject } from '@angular/core';
 import { BehaviorSubject, Subject, Subscription } from 'rxjs';
 import { PeerState, WebrtcSessionService } from './webrtc-session.service';
 import { PairOrdinaryMediaPolicy } from './pair-ordinary-media.policy';
+import { PairMediaE2eeCoordinatorService } from './pair-media-e2ee-coordinator.service';
+import type { PublicPairMediaSlot } from './public-pair-media-security-contract';
 
 export const WEBRTC_MEDIA_DEVICES = new InjectionToken<MediaDevices>('WEBRTC_MEDIA_DEVICES', {
   providedIn: 'root',
@@ -26,6 +28,7 @@ export interface OrdinaryAudioState {
 export interface RemoteOrdinaryTrack {
   readonly track: MediaStreamTrack;
   readonly streams: readonly MediaStream[];
+  readonly slot?: PublicPairMediaSlot | null;
 }
 
 interface RemoteTrackRegistration extends RemoteOrdinaryTrack {
@@ -48,6 +51,7 @@ export class WebrtcMediaSessionService implements OnDestroy {
 
   private readonly peer = inject(WebrtcSessionService);
   private readonly mediaPolicy = inject(PairOrdinaryMediaPolicy);
+  private readonly pairMediaE2ee = inject(PairMediaE2eeCoordinatorService);
   private readonly devices = inject(WEBRTC_MEDIA_DEVICES);
   private stream?: MediaStream;
   private track?: MediaStreamTrack;
@@ -78,9 +82,18 @@ export class WebrtcMediaSessionService implements OnDestroy {
         safeStop(event.track);
         return;
       }
-      const value = Object.freeze({ track: event.track, streams: Object.freeze([...event.streams]) });
+      const value = Object.freeze({
+        track: event.track,
+        streams: Object.freeze([...event.streams]),
+        slot: this.peer.publicMediaSlotForReceiver(event.receiver),
+      });
       this.registerRemoteTrack(value);
       this.remoteTrack$.next(value);
+    }));
+    this.subscriptions.add(this.pairMediaE2ee.status$.subscribe(status => {
+      if (status.sessionId !== this.currentSessionId || status.state === 'ready') return;
+      if (this.track || this.sender) this.stopAudio(status.reasonCode || 'public_media_e2ee_not_ready');
+      if (this.remoteTracks.size) this.clearRemoteTracks();
     }));
     this.devices.addEventListener?.('devicechange', this.deviceChangeListener);
   }
@@ -102,7 +115,7 @@ export class WebrtcMediaSessionService implements OnDestroy {
       this.assertCaptureCurrent(generation);
       const track = acquired.getAudioTracks()[0];
       if (!track) throw new Error('microphone_track_missing');
-      const sender = this.peer.addMediaTrack(track, acquired);
+      const sender = await this.peer.attachMediaTrack('microphone-opus', track, acquired);
       this.releaseCurrent();
       this.assertCaptureCurrent(generation);
       this.stream = acquired; this.track = track; this.sender = sender;
@@ -215,7 +228,7 @@ export class WebrtcMediaSessionService implements OnDestroy {
   }
 
   private onPeerState(state: PeerState): void {
-    if (state === 'closed' || state === 'idle') {
+    if (state === 'closed' || state === 'idle' || state === 'failed') {
       this.stopAudio('session_closed');
       this.clearRemoteTracks();
     }
@@ -247,7 +260,7 @@ export class WebrtcMediaSessionService implements OnDestroy {
     this.remoteTrackState.next(Object.freeze(
       [...this.remoteTracks.values()]
         .filter(value => value.track.readyState !== 'ended')
-        .map(value => Object.freeze({ track: value.track, streams: value.streams })),
+        .map(value => Object.freeze({ track: value.track, streams: value.streams, slot: value.slot })),
     ));
   }
 

--- a/frontend-angular/src/app/services/webrtc-peer-key.service.ts
+++ b/frontend-angular/src/app/services/webrtc-peer-key.service.ts
@@ -92,8 +92,12 @@ export class WebrtcPeerKeyService {
   async verifyAndRefreshBinding(
     rawPackage: SignedPeerKeyPackage,
     options: PeerPackageVerificationOptions,
+    isCurrent: () => boolean = () => true,
   ): Promise<Readonly<VerifiedPeerBinding>> {
     const verifiedPackage = await this.verifyPackage(rawPackage, options);
+    // The caller owns the session generation. Check it after every async
+    // verification and immediately before this service may mutate binding.
+    if (!isCurrent()) throw new PeerKeyError('peer_binding_operation_superseded');
     const current = this.binding;
     if (
       !current

--- a/frontend-angular/src/app/services/webrtc-public-media-lifecycle.spec.ts
+++ b/frontend-angular/src/app/services/webrtc-public-media-lifecycle.spec.ts
@@ -1,0 +1,619 @@
+import { TestBed } from '@angular/core/testing';
+import { BehaviorSubject, Subject, of } from 'rxjs';
+
+import { NetworkProfileService } from './network-profile.service';
+import { OidcAuthService } from './oidc-auth.service';
+import { PairMediaE2eeCoordinatorService } from './pair-media-e2ee-coordinator.service';
+import { PairMediaE2eeTransformAdapter } from './pair-media-e2ee-transform.adapter';
+import { PairOrdinaryMediaPolicy } from './pair-ordinary-media.policy';
+import { PairSessionControlPlaneService } from './pair-session-control-plane.service';
+import { PairViewSecurityBootstrapService } from './pair-view-security-bootstrap.service';
+import { PublicPairMediaSecurityContractV1 } from './public-pair-media-security-contract';
+import { WebrtcChunkReassemblyStore } from './webrtc-chunk-reassembly.store';
+import {
+  SEMANTIC_DC_VERSION,
+  semanticDcEncode,
+  type SemanticDataChannelMessage,
+} from './webrtc-datachannel.service';
+import { SignalMessage, WebrtcSignalingService } from './webrtc-signaling.service';
+import { WebrtcSessionService } from './webrtc-session.service';
+
+class PublicPeerConnection {
+  static instances: PublicPeerConnection[] = [];
+  connectionState: RTCPeerConnectionState = 'new';
+  signalingState: RTCSignalingState = 'stable';
+  onicecandidate: ((event: RTCPeerConnectionIceEvent) => void) | null = null;
+  onconnectionstatechange: (() => void) | null = null;
+  ontrack: ((event: RTCTrackEvent) => void) | null = null;
+  ondatachannel: ((event: RTCDataChannelEvent) => void) | null = null;
+  remoteTrackDuringDescription: RTCTrackEvent | null = null;
+  remoteDescriptionGate: ReturnType<typeof deferred<void>> | null = null;
+  remoteOfferTransceivers: Array<{ direction: RTCRtpTransceiverDirection; sender: { replaceTrack: ReturnType<typeof vi.fn> } }> = [];
+  readonly close = vi.fn(() => { this.connectionState = 'closed'; });
+  readonly createAnswer = vi.fn(async () => ({ type: 'answer', sdp: 'data-only-answer' } as RTCSessionDescriptionInit));
+  readonly createOffer = vi.fn(async () => ({ type: 'offer', sdp: 'offer' } as RTCSessionDescriptionInit));
+  readonly setLocalDescription = vi.fn(async () => undefined);
+  readonly setRemoteDescription = vi.fn(async () => {
+    if (this.remoteTrackDuringDescription) this.ontrack?.(this.remoteTrackDuringDescription);
+    await this.remoteDescriptionGate?.promise;
+  });
+  readonly addIceCandidate = vi.fn(async () => undefined);
+  readonly createDataChannel = vi.fn(() => dataChannel());
+  readonly getTransceivers = vi.fn(() => this.remoteOfferTransceivers as unknown as RTCRtpTransceiver[]);
+
+  constructor(readonly configuration?: RTCConfiguration) {
+    PublicPeerConnection.instances.push(this);
+  }
+}
+
+class SessionDescription {
+  constructor(readonly value: RTCSessionDescriptionInit) {}
+  get type(): RTCSdpType { return this.value.type; }
+  get sdp(): string { return this.value.sdp ?? ''; }
+  toJSON(): RTCSessionDescriptionInit { return this.value; }
+}
+
+class IceCandidate {
+  constructor(readonly init: RTCIceCandidateInit) {}
+}
+
+describe('WebrtcSessionService Public media lifecycle', () => {
+  const runtime = globalThis as typeof globalThis & {
+    RTCPeerConnection: typeof RTCPeerConnection;
+    RTCSessionDescription: typeof RTCSessionDescription;
+    RTCIceCandidate: typeof RTCIceCandidate;
+  };
+  const originalPeer = runtime.RTCPeerConnection;
+  const originalDescription = runtime.RTCSessionDescription;
+  const originalCandidate = runtime.RTCIceCandidate;
+  let service: WebrtcSessionService;
+  let signalHandler: ((message: SignalMessage) => Promise<void>) | null;
+  let signaling: any;
+  let transforms: TransformMock;
+  let coordinator: CoordinatorMock;
+  let bootstrap: { mediaContractFor: ReturnType<typeof vi.fn> };
+
+  beforeAll(() => {
+    runtime.RTCPeerConnection = PublicPeerConnection as unknown as typeof RTCPeerConnection;
+    runtime.RTCSessionDescription = SessionDescription as unknown as typeof RTCSessionDescription;
+    runtime.RTCIceCandidate = IceCandidate as unknown as typeof RTCIceCandidate;
+  });
+
+  afterAll(() => {
+    runtime.RTCPeerConnection = originalPeer;
+    runtime.RTCSessionDescription = originalDescription;
+    runtime.RTCIceCandidate = originalCandidate;
+  });
+
+  beforeEach(() => {
+    PublicPeerConnection.instances = [];
+    signalHandler = null;
+    signaling = {
+      status$: new BehaviorSubject('disconnected'),
+      connect: vi.fn(), disconnect: vi.fn(), send: vi.fn(async () => undefined),
+      bindMessageHandler: vi.fn((handler: (message: SignalMessage) => Promise<void>) => {
+        signalHandler = handler;
+        return () => { if (signalHandler === handler) signalHandler = null; };
+      }),
+    };
+    transforms = new TransformMock();
+    coordinator = new CoordinatorMock();
+    bootstrap = { mediaContractFor: vi.fn(() => contract()) };
+    TestBed.configureTestingModule({ providers: [
+      WebrtcSessionService,
+      { provide: NetworkProfileService, useValue: { current: {
+        ice_servers: [], signaling_url: '', require_e2e_payload_encryption: true,
+      } } },
+      { provide: WebrtcSignalingService, useValue: signaling },
+      { provide: OidcAuthService, useValue: { sessionNonce: 'nonce' } },
+      { provide: PairSessionControlPlaneService, useValue: {
+        isPublicSession: () => true, authorityKindForSession: () => 'public',
+        turnCredentials: () => of(null), assertSessionAvailable: vi.fn(),
+      } },
+      { provide: PairOrdinaryMediaPolicy, useValue: {
+        assertAllowed: vi.fn(() => { throw new Error('raw_public_media_forbidden'); }),
+      } },
+      { provide: PairViewSecurityBootstrapService, useValue: bootstrap },
+      { provide: PairMediaE2eeCoordinatorService, useValue: coordinator },
+      { provide: PairMediaE2eeTransformAdapter, useValue: transforms },
+      { provide: WebrtcChunkReassemblyStore, useValue: { clearContext: vi.fn(), accept: vi.fn() } },
+    ] });
+    service = TestBed.inject(WebrtcSessionService);
+  });
+
+  afterEach(() => {
+    service.closeSession();
+    TestBed.resetTestingModule();
+  });
+
+  it('recreates a clean data-only peer when transform preparation fails', async () => {
+    transforms.prepareSession.mockRejectedValueOnce(new Error('media_e2ee_worker_unavailable'));
+
+    await service.startSession('session-a', false, 'peer:remote');
+    expect(PublicPeerConnection.instances).toHaveLength(2);
+    expect(PublicPeerConnection.instances[0].close).toHaveBeenCalledOnce();
+    expect(PublicPeerConnection.instances[1].close).not.toHaveBeenCalled();
+    expect(service.state$.value).toBe('connecting');
+
+    await signalHandler?.(offer());
+    expect(PublicPeerConnection.instances[1].createAnswer).toHaveBeenCalledOnce();
+    expect(signaling.send).toHaveBeenCalledWith(expect.objectContaining({ type: 'answer' }));
+  });
+
+  it('fences an old same-session prepare continuation and fatal callback from its replacement', async () => {
+    const firstPrepare = deferred<number>();
+    let staleFatal: ((reason: string) => void) | null = null;
+    transforms.prepareSession.mockImplementationOnce(async (_pc, _session, _contract, fatal) => {
+      staleFatal = fatal;
+      transforms.activeGeneration = 1;
+      return firstPrepare.promise;
+    }).mockImplementationOnce(async (_pc, _session, _contract, fatal) => {
+      transforms.activeGeneration = 2;
+      transforms.latestFatal = fatal;
+      return 2;
+    });
+
+    const staleStart = service.startSession('session-a', false, 'peer:remote');
+    await settle();
+    await service.startSession('session-a', false, 'peer:remote');
+    const replacement = PublicPeerConnection.instances[1];
+    firstPrepare.resolve(1);
+    await staleStart;
+    staleFatal?.('media_e2ee_worker_failed');
+
+    expect(replacement.close).not.toHaveBeenCalled();
+    expect(coordinator.failMediaExtension).not.toHaveBeenCalled();
+    expect(service.state$.value).toBe('connecting');
+  });
+
+  it('stages ontrack during answer SRD, then disables asymmetric media without closing data-only Pair', async () => {
+    transforms.bindRemoteOfferTopology.mockRejectedValueOnce(new Error('public_media_topology_invalid'));
+    await service.startSession('session-a', false, 'peer:remote');
+    const peer = PublicPeerConnection.instances[0];
+    const track = { stop: vi.fn() } as unknown as MediaStreamTrack;
+    peer.remoteTrackDuringDescription = {
+      track,
+      receiver: transforms.receiver,
+      transceiver: { receiver: transforms.receiver },
+      streams: [],
+    } as unknown as RTCTrackEvent;
+
+    await signalHandler?.(offer());
+
+    expect(track.stop).toHaveBeenCalledOnce();
+    expect(coordinator.failMediaExtension).toHaveBeenCalledWith(
+      'session-a', 'public_media_topology_invalid',
+    );
+    expect(peer.close).not.toHaveBeenCalled();
+    expect(peer.createAnswer).toHaveBeenCalledOnce();
+    expect(service.state$.value).toBe('connecting');
+  });
+
+  it('ignores remote media events after local prepare fallback instead of rejecting the Pair', async () => {
+    transforms.prepareSession.mockRejectedValueOnce(new Error('media_e2ee_worker_unavailable'));
+    await service.startSession('session-a', false, 'peer:remote');
+    const dataOnlyPeer = PublicPeerConnection.instances[1];
+    dataOnlyPeer.remoteOfferTransceivers = [0, 1, 2].map(() => ({
+      direction: 'recvonly', sender: { replaceTrack: vi.fn(async () => undefined) },
+    }));
+    const track = { stop: vi.fn() } as unknown as MediaStreamTrack;
+
+    dataOnlyPeer.ontrack?.({ track, streams: [] } as unknown as RTCTrackEvent);
+    await signalHandler?.(offer());
+
+    expect(track.stop).toHaveBeenCalledOnce();
+    expect(dataOnlyPeer.remoteOfferTransceivers.map(value => value.direction))
+      .toEqual(['inactive', 'inactive', 'inactive']);
+    for (const transceiver of dataOnlyPeer.remoteOfferTransceivers) {
+      expect(transceiver.sender.replaceTrack).toHaveBeenCalledWith(null);
+    }
+    expect(dataOnlyPeer.close).not.toHaveBeenCalled();
+    expect(service.state$.value).toBe('connecting');
+  });
+
+  it('makes Public ICE restart terminal so salts and worker counters cannot be reused', async () => {
+    await service.startSession('session-a', true, 'peer:remote');
+    const peer = PublicPeerConnection.instances[0];
+
+    expect(() => service.restartMediaIce()).toThrow('public_media_fresh_connection_required');
+
+    expect(coordinator.deactivate).toHaveBeenCalledWith(
+      'session-a', 'public_media_fresh_connection_required',
+    );
+    expect(peer.close).toHaveBeenCalledOnce();
+    expect(service.state$.value).toBe('failed');
+  });
+
+  it('fails a data-only Public Pair when its semantic DataChannel closes', async () => {
+    transforms.prepareSession.mockRejectedValueOnce(new Error('media_e2ee_worker_unavailable'));
+    await service.startSession('session-a', false, 'peer:remote');
+    const peer = PublicPeerConnection.instances[1];
+    const channel = dataChannel();
+    peer.ondatachannel?.({ channel } as RTCDataChannelEvent);
+
+    channel.onclose?.(new Event('close'));
+
+    expect(peer.close).toHaveBeenCalledOnce();
+    expect(service.state$.value).toBe('failed');
+  });
+
+  it('rejects role reversal and repeated SDP in one Public connection generation', async () => {
+    await service.startSession('session-a', false, 'peer:remote');
+    const answerer = PublicPeerConnection.instances[0];
+
+    await signalHandler?.({ ...offer(), type: 'answer' });
+    expect(answerer.close).toHaveBeenCalledOnce();
+    expect(service.state$.value).toBe('failed');
+
+    await service.startSession('session-a', false, 'peer:remote');
+    const replacement = PublicPeerConnection.instances[1];
+    await signalHandler?.(offer());
+    expect(replacement.close).not.toHaveBeenCalled();
+    await signalHandler?.(offer());
+    expect(replacement.close).toHaveBeenCalledOnce();
+    expect(service.auditLog).toContainEqual(expect.objectContaining({
+      type: 'public_sdp_rejected', detail: 'unexpected_offer:established',
+    }));
+  });
+
+  it('fences a delayed old answer before it can key or establish a same-session replacement', async () => {
+    await service.startSession('session-a', true, 'peer:remote');
+    const stalePeer = PublicPeerConnection.instances[0];
+    const staleHandler = signalHandler;
+    const remoteDescriptionGate = deferred<void>();
+    stalePeer.remoteDescriptionGate = remoteDescriptionGate;
+    const applyingStaleAnswer = staleHandler?.(answer());
+    await settle();
+
+    await service.startSession('session-a', true, 'peer:remote');
+    const replacement = PublicPeerConnection.instances[1];
+    const replacementHandler = signalHandler;
+    coordinator.markTopologyNegotiated.mockClear();
+    remoteDescriptionGate.resolve(undefined);
+    await applyingStaleAnswer;
+
+    expect(replacement.close).not.toHaveBeenCalled();
+    expect(coordinator.markTopologyNegotiated).not.toHaveBeenCalled();
+    await replacementHandler?.(answer());
+    expect(coordinator.markTopologyNegotiated).toHaveBeenCalledTimes(1);
+    expect(replacement.close).not.toHaveBeenCalled();
+  });
+
+  it('fences delayed answer publication before it can establish a responder replacement', async () => {
+    const answerPublicationGate = deferred<void>();
+    const answerPublicationStarted = deferred<void>();
+    signaling.send.mockImplementation(async (message: SignalMessage) => {
+      if (message.type !== 'answer') return;
+      answerPublicationStarted.resolve(undefined);
+      await answerPublicationGate.promise;
+    });
+    await service.startSession('session-a', false, 'peer:remote');
+    const staleHandler = signalHandler;
+    const publishingStaleAnswer = staleHandler?.(offer());
+    await answerPublicationStarted.promise;
+
+    await service.startSession('session-a', false, 'peer:remote');
+    const replacement = PublicPeerConnection.instances[1];
+    const replacementHandler = signalHandler;
+    coordinator.markTopologyNegotiated.mockClear();
+    answerPublicationGate.resolve(undefined);
+    await publishingStaleAnswer;
+
+    expect(replacement.close).not.toHaveBeenCalled();
+    expect(coordinator.markTopologyNegotiated).not.toHaveBeenCalled();
+    await replacementHandler?.(offer());
+    expect(coordinator.markTopologyNegotiated).toHaveBeenCalledTimes(1);
+    expect(replacement.close).not.toHaveBeenCalled();
+  });
+
+  it('processes delayed media hello and following ACK in exact DataChannel wire order', async () => {
+    await service.startSession('session-a', false, 'peer:remote');
+    const peer = PublicPeerConnection.instances[0];
+    const channel = dataChannel();
+    peer.ondatachannel?.({ channel } as RTCDataChannelEvent);
+    const helloGate = deferred<void>();
+    const seen: string[] = [];
+    coordinator.acceptSemantic.mockImplementationOnce(async message => {
+      seen.push(message.message_id);
+      await helloGate.promise;
+      return true;
+    }).mockImplementationOnce(async message => {
+      seen.push(message.message_id);
+      return true;
+    });
+    const [hello, ack] = await Promise.all([
+      semanticFrame('pair-media-hello-test', 1),
+      semanticFrame('pair-media-hello_ack-test', 2),
+    ]);
+
+    channel.onmessage?.({ data: hello } as MessageEvent);
+    channel.onmessage?.({ data: ack } as MessageEvent);
+    await settleCrypto();
+    expect(seen).toEqual(['pair-media-hello-test']);
+
+    helloGate.resolve(undefined);
+    await settleCrypto(4);
+    expect(seen).toEqual(['pair-media-hello-test', 'pair-media-hello_ack-test']);
+  });
+
+  it('bounds the ordered receive queue while the first semantic message is stalled', async () => {
+    await service.startSession('session-a', false, 'peer:remote');
+    const peer = PublicPeerConnection.instances[0];
+    const channel = dataChannel();
+    peer.ondatachannel?.({ channel } as RTCDataChannelEvent);
+    const firstGate = deferred<void>();
+    const firstEntered = deferred<void>();
+    coordinator.acceptSemantic.mockImplementationOnce(async () => {
+      firstEntered.resolve(undefined);
+      await firstGate.promise;
+      return true;
+    });
+    const frame = await semanticFrame('pair-media-hello-queue', 1);
+    channel.onmessage?.({ data: frame } as MessageEvent);
+    await firstEntered.promise;
+
+    for (let index = 0; index < 128; index += 1) {
+      channel.onmessage?.({ data: frame } as MessageEvent);
+    }
+
+    expect(coordinator.fail).toHaveBeenCalledWith(
+      'session-a', 'public_datachannel_receive_queue_overflow',
+    );
+    expect(peer.close).toHaveBeenCalledOnce();
+    expect(service.state$.value).toBe('failed');
+    firstGate.resolve(undefined);
+  });
+
+  it('does not emit an old semantic frame after coordinator work crosses a same-session replacement', async () => {
+    await service.startSession('session-a', false, 'peer:remote');
+    const stalePeer = PublicPeerConnection.instances[0];
+    const staleChannel = dataChannel();
+    stalePeer.ondatachannel?.({ channel: staleChannel } as RTCDataChannelEvent);
+    const coordinatorGate = deferred<void>();
+    const coordinatorEntered = deferred<void>();
+    coordinator.acceptSemantic.mockImplementationOnce(async () => {
+      coordinatorEntered.resolve(undefined);
+      await coordinatorGate.promise;
+      return false;
+    });
+    const messages: string[] = [];
+    service.semanticMessage$.subscribe(message => messages.push(message.message_id));
+    staleChannel.onmessage?.({
+      data: await semanticFrame('pair-media-old-generation', 1),
+    } as MessageEvent);
+    await coordinatorEntered.promise;
+
+    await service.startSession('session-a', false, 'peer:remote');
+    const replacement = PublicPeerConnection.instances[1];
+    const replacementChannel = dataChannel();
+    replacement.ondatachannel?.({ channel: replacementChannel } as RTCDataChannelEvent);
+    coordinatorGate.resolve(undefined);
+    await settleCrypto(4);
+
+    expect(messages).toEqual([]);
+    replacementChannel.onmessage?.({
+      data: await semanticFrame('pair-media-new-generation', 2),
+    } as MessageEvent);
+    await settleCrypto(4);
+    expect(messages).toEqual(['pair-media-new-generation']);
+    expect(replacement.close).not.toHaveBeenCalled();
+  });
+
+  it('drops semantic decoding that finishes after a same-session DataChannel replacement', async () => {
+    await service.startSession('session-a', false, 'peer:remote');
+    const stalePeer = PublicPeerConnection.instances[0];
+    const staleChannel = dataChannel();
+    stalePeer.ondatachannel?.({ channel: staleChannel } as RTCDataChannelEvent);
+    const frame = await semanticFrame('pair-media-delayed-decode', 3);
+    const expectedDigest = await crypto.subtle.digest('SHA-256', Uint8Array.of(3));
+    const digestGate = deferred<ArrayBuffer>();
+    const digestEntered = deferred<void>();
+    const digestSpy = vi.spyOn(crypto.subtle, 'digest').mockImplementationOnce(async () => {
+      digestEntered.resolve(undefined);
+      return digestGate.promise;
+    });
+
+    try {
+      staleChannel.onmessage?.({ data: frame } as MessageEvent);
+      await digestEntered.promise;
+      await service.startSession('session-a', false, 'peer:remote');
+      const replacement = PublicPeerConnection.instances[1];
+      digestGate.resolve(expectedDigest);
+      await settleCrypto(4);
+
+      expect(coordinator.acceptSemantic).not.toHaveBeenCalled();
+      expect(replacement.close).not.toHaveBeenCalled();
+      expect(service.state$.value).toBe('connecting');
+    } finally {
+      digestSpy.mockRestore();
+    }
+  });
+
+  it('does not enqueue encoded media control into a replacement same-session DataChannel', async () => {
+    const message = await semanticMessage('pair-media-stale-outbound', 4, 9);
+    const expectedPayloadDigest = await crypto.subtle.digest('SHA-256', Uint8Array.of(4));
+    await service.startSession('session-a', true, 'peer:remote');
+    const stalePort = coordinator.port;
+    const digestGate = deferred<ArrayBuffer>();
+    const digestEntered = deferred<void>();
+    const digestSpy = vi.spyOn(crypto.subtle, 'digest').mockImplementationOnce(async () => {
+      digestEntered.resolve(undefined);
+      return digestGate.promise;
+    });
+
+    try {
+      const staleSend = stalePort.send(message) as Promise<void>;
+      await digestEntered.promise;
+      await service.startSession('session-a', true, 'peer:remote');
+      const replacement = PublicPeerConnection.instances[1];
+      const replacementChannel = replacement.createDataChannel.mock.results[0].value as RTCDataChannel;
+      Object.assign(replacementChannel, { readyState: 'open' });
+      replacementChannel.onopen?.(new Event('open'));
+      (replacementChannel.send as ReturnType<typeof vi.fn>).mockClear();
+
+      digestGate.resolve(expectedPayloadDigest);
+      await expect(staleSend).rejects.toThrow('semantic_send_context_superseded');
+      await settleCrypto(3);
+
+      expect(replacementChannel.send).not.toHaveBeenCalled();
+      expect((service as unknown as { activeEpoch: number }).activeEpoch).toBe(1);
+      expect((service as unknown as { pendingSemanticSends: Map<string, unknown> })
+        .pendingSemanticSends.size).toBe(0);
+      expect(replacement.close).not.toHaveBeenCalled();
+    } finally {
+      digestSpy.mockRestore();
+    }
+  });
+
+  it('does not let an older same-digest completion delete the newer pending operation', async () => {
+    await service.startSession('session-a', false, 'peer:remote');
+    const message = await semanticMessage('pair-media-same-digest', 5, 7);
+    const older = await service.sendSemantic(message);
+    const newer = await service.sendSemantic(message);
+    const pending = (service as unknown as {
+      pendingSemanticSends: Map<string, unknown>;
+    }).pendingSemanticSends;
+
+    older.cancel();
+    await older.result;
+    await settle();
+
+    expect(pending.get(newer.messageDigest)).toBe(newer);
+    newer.cancel();
+  });
+});
+
+class TransformMock {
+  activeGeneration: number | null = null;
+  latestFatal: ((reason: string) => void) | null = null;
+  readonly receiver = {} as RTCRtpReceiver;
+  private readonly stagedReceivers = new WeakSet<RTCRtpReceiver>();
+  readonly prepareSession = vi.fn(async (
+    _peer: RTCPeerConnection,
+    _sessionId: string,
+    _contract: unknown,
+    fatal: (reason: string) => void,
+  ) => {
+    this.activeGeneration = (this.activeGeneration ?? 0) + 1;
+    this.latestFatal = fatal;
+    return this.activeGeneration;
+  });
+  readonly releaseSession = vi.fn((_sessionId?: string, generation?: number) => {
+    if (generation === undefined || generation === this.activeGeneration) this.activeGeneration = null;
+  });
+  readonly isPrepared = vi.fn((_session: string, _epoch?: number, _digest?: string, generation?: number) => (
+    this.activeGeneration !== null && (generation === undefined || generation === this.activeGeneration)
+  ));
+  readonly isKeyed = vi.fn(() => false);
+  readonly generationForSession = vi.fn(() => this.activeGeneration);
+  readonly isAwaitingRemoteTopology = vi.fn((_session: string, generation?: number) => (
+    this.activeGeneration !== null && (generation === undefined || generation === this.activeGeneration)
+  ));
+  readonly bindRemoteOfferTopology = vi.fn(async () => undefined);
+  readonly stageRemoteOfferTrack = vi.fn((
+    _session: string, _transceiver: RTCRtpTransceiver, receiver: RTCRtpReceiver,
+  ) => {
+    this.stagedReceivers.add(receiver);
+    return 'microphone-opus';
+  });
+  readonly slotForReceiver = vi.fn((_session: string, receiver: RTCRtpReceiver) => (
+    this.stagedReceivers.has(receiver) ? 'microphone-opus' : null
+  ));
+  readonly validateFinalTopology = vi.fn();
+}
+
+class CoordinatorMock {
+  readonly status$ = new BehaviorSubject<any>({ sessionId: '', state: 'inactive' });
+  port: any = null;
+  readonly bindTransport = vi.fn((_sessionId: string, port: any) => { this.port = port; });
+  readonly unbindTransport = vi.fn(() => { this.port = null; });
+  readonly fail = vi.fn((sessionId: string, reasonCode: string) => {
+    this.status$.next({ sessionId, state: 'failed', reasonCode });
+    this.port?.failClosed(reasonCode);
+  });
+  readonly failMediaExtension = vi.fn((sessionId: string, reasonCode: string) => {
+    this.port?.disableMedia(reasonCode);
+    this.status$.next({ sessionId, state: 'failed', reasonCode });
+  });
+  readonly markDataChannelOpen = vi.fn();
+  readonly markTopologyNegotiated = vi.fn();
+  readonly acceptSemantic = vi.fn(async () => false);
+  readonly deactivate = vi.fn((_sessionId: string, reasonCode: string) => {
+    this.port?.failClosed(reasonCode);
+    this.status$.next({ sessionId: _sessionId, state: 'inactive', reasonCode });
+  });
+  statusFor(sessionId: string): any { return { sessionId, state: 'inactive' }; }
+}
+
+function contract(): PublicPairMediaSecurityContractV1 {
+  return {
+    session_id: 'session-a', epoch: 7, digest: 'a'.repeat(64),
+    expires_at_ms: Date.now() + 60_000, transform: 'RTCRtpScriptTransform',
+  } as PublicPairMediaSecurityContractV1;
+}
+
+function offer(): SignalMessage {
+  return {
+    type: 'offer', session_id: 'session-a', sender_id: 'peer:remote', recipient_id: 'peer:local',
+    payload: { type: 'offer', sdp: 'media-offer' },
+  };
+}
+
+function answer(): SignalMessage {
+  return { ...offer(), type: 'answer', payload: { type: 'answer', sdp: 'media-answer' } };
+}
+
+function dataChannel(): RTCDataChannel {
+  return {
+    readyState: 'connecting', bufferedAmount: 0, bufferedAmountLowThreshold: 0,
+    send: vi.fn(), close: vi.fn(),
+  } as unknown as RTCDataChannel;
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve(value: T): void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(accept => { resolve = accept; });
+  return { promise, resolve };
+}
+
+async function settle(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+async function semanticFrame(messageId: string, sequence: number): Promise<string> {
+  return semanticDcEncode(await semanticMessage(messageId, sequence));
+}
+
+async function semanticMessage(
+  messageId: string,
+  sequence: number,
+  epoch = 7,
+): Promise<SemanticDataChannelMessage> {
+  const ciphertext = Uint8Array.of(sequence);
+  const digest = await crypto.subtle.digest('SHA-256', ciphertext);
+  return {
+    version: SEMANTIC_DC_VERSION,
+    traffic_class: 'control',
+    message_id: messageId,
+    session_id: 'session-a',
+    epoch,
+    sender_id: 'peer:remote',
+    audience_id: 'peer:local',
+    sequence,
+    expires_at_ms: 2_000_000_000_000,
+    compression: 'none',
+    security: { algorithm: 'AES-GCM-256', key_id: 'pair-key-7' },
+    payload_bytes: ciphertext.byteLength,
+    payload_digest: [...new Uint8Array(digest)]
+      .map(byte => byte.toString(16).padStart(2, '0')).join(''),
+    ciphertext: btoa(String.fromCharCode(...ciphertext)),
+  };
+}
+
+async function settleCrypto(turns = 2): Promise<void> {
+  for (let index = 0; index < turns; index += 1) {
+    await crypto.subtle.digest('SHA-256', new Uint8Array(0));
+  }
+}

--- a/frontend-angular/src/app/services/webrtc-session-lifecycle.spec.ts
+++ b/frontend-angular/src/app/services/webrtc-session-lifecycle.spec.ts
@@ -225,7 +225,7 @@ describe('WebrtcSessionService session-bound signaling lifecycle', () => {
     expect(() => service.addMediaTrack(
       { kind: 'audio' } as MediaStreamTrack,
       {} as MediaStream,
-    )).toThrow('public_ordinary_media_e2ee_unavailable');
+    )).toThrow('public_media_contract_missing');
     peer.ontrack?.({ track: remoteTrack, streams: [] } as unknown as RTCTrackEvent);
 
     expect(remoteTrack.stop).toHaveBeenCalledOnce();
@@ -233,7 +233,7 @@ describe('WebrtcSessionService session-bound signaling lifecycle', () => {
     expect(service.state$.value).toBe('failed');
     expect(service.auditLog).toContainEqual(expect.objectContaining({
       type: 'public_media_rejected',
-      detail: 'public_ordinary_media_e2ee_unavailable',
+      detail: 'public_media_contract_missing',
     }));
   });
 

--- a/frontend-angular/src/app/services/webrtc-session.service.ts
+++ b/frontend-angular/src/app/services/webrtc-session.service.ts
@@ -27,9 +27,15 @@ import { WebrtcPrioritySendQueue } from './webrtc-priority-send-queue';
 import { WebrtcSendOperation } from './webrtc-send-operation';
 import { PairSessionControlPlaneService } from './pair-session-control-plane.service';
 import { PairOrdinaryMediaPolicy } from './pair-ordinary-media.policy';
+import { PairViewSecurityBootstrapService } from './pair-view-security-bootstrap.service';
+import { PairMediaE2eeCoordinatorService } from './pair-media-e2ee-coordinator.service';
+import { PairMediaE2eeTransformAdapter } from './pair-media-e2ee-transform.adapter';
+import type { PublicPairMediaSlot } from './public-pair-media-security-contract';
 import { PUBLIC_WEBRTC_STUN_URL } from './public-ananta-endpoints';
 
 export type PeerState = 'idle' | 'connecting' | 'connected' | 'failed' | 'closed';
+type PublicSdpPhase = 'none' | 'awaiting-offer' | 'processing-offer'
+  | 'awaiting-answer' | 'processing-answer' | 'established';
 
 export interface OrdinaryMediaStatsSnapshot {
   readonly connection: RTCPeerConnectionState;
@@ -42,12 +48,36 @@ const ALLOWED_DC_TYPES = new Set([
 const RATE_LIMIT_WINDOW_MS = 1000;
 const RATE_LIMIT_MAX = 300;
 const RATE_LIMIT_BYTES = 4 * 1024 * 1024;
+const DC_RECEIVE_QUEUE_MAX = 128;
+const DC_RECEIVE_QUEUE_BYTES = 4 * 1024 * 1024;
 
 interface AuditEvent {
   ts: number;
   type: string;
   session_id: string;
   detail?: string;
+}
+
+interface ActivePublicMediaContext {
+  readonly sessionId: string;
+  readonly peer: RTCPeerConnection;
+  readonly sessionGeneration: number;
+  readonly adapterGeneration: number;
+  readonly contractDigest: string;
+}
+
+interface DataChannelReceiveContext {
+  readonly peer: RTCPeerConnection;
+  readonly channel: RTCDataChannel;
+  readonly sessionId: string;
+  readonly sessionGeneration: number;
+}
+
+interface SemanticSendContext {
+  readonly peer: RTCPeerConnection | null;
+  readonly sessionId: string;
+  readonly sessionGeneration: number;
+  readonly channel?: RTCDataChannel;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -57,6 +87,9 @@ export class WebrtcSessionService {
   private oidc = inject(OidcAuthService);
   private controlPlane = inject(PairSessionControlPlaneService);
   private mediaPolicy = inject(PairOrdinaryMediaPolicy);
+  private securityBootstrap = inject(PairViewSecurityBootstrapService);
+  private pairMediaE2ee = inject(PairMediaE2eeCoordinatorService);
+  private pairMediaTransforms = inject(PairMediaE2eeTransformAdapter);
 
   readonly state$ = new BehaviorSubject<PeerState>('idle');
   readonly dcMessage$ = new Subject<DcMessage>();
@@ -77,11 +110,25 @@ export class WebrtcSessionService {
   private readonly pendingSemanticSends = new Map<string, WebrtcSendOperation>();
   private activeEpoch = 1;
   private isInitiator = false;
+  private publicSdpPhase: PublicSdpPhase = 'none';
   private releaseSignalingHandler: (() => void) | null = null;
   private signalingStatusSubscription: Subscription | null = null;
   private sessionGeneration = 0;
   private localDescriptionPublicationPending = false;
   private pendingLocalIce: RTCIceCandidateInit[] = [];
+  private readonly pendingPublicMediaTracks = new Map<PublicPairMediaSlot, RTCTrackEvent>();
+  private readonly disabledPublicMediaContracts = new Map<string, string>();
+  private activePublicMediaContext: ActivePublicMediaContext | null = null;
+  private readonly pairMediaStatusSubscription = this.pairMediaE2ee.status$.subscribe(status => {
+    if (!this.sessionId || status.sessionId !== this.sessionId) return;
+    if (status.state === 'ready') {
+      this.releasePendingPublicMediaTracks();
+      return;
+    }
+    if (status.state === 'failed') {
+      this.stopPendingPublicMediaTracks();
+    }
+  });
 
   async startSession(sessionId: string, isInitiator: boolean, remotePeerId?: string): Promise<void> {
     if (this.pc || this.releaseSignalingHandler || this.signalingStatusSubscription || this.connectionTimeout) {
@@ -99,6 +146,9 @@ export class WebrtcSessionService {
 
     const profile = this.profiles.current;
     const publicSession = this.controlPlane.isPublicSession(sessionId);
+    this.publicSdpPhase = publicSession
+      ? isInitiator ? 'awaiting-answer' : 'awaiting-offer'
+      : 'none';
     const iceServers = publicSession
       ? [{ urls: PUBLIC_WEBRTC_STUN_URL }]
       : [...profile.ice_servers];
@@ -131,8 +181,107 @@ export class WebrtcSessionService {
       iceTransportPolicy: profile.require_e2e_payload_encryption ? 'all' : 'all',
     };
 
-    const pc = new RTCPeerConnection(config);
+    let pc = new RTCPeerConnection(config);
     this.pc = pc;
+    const publicMediaContract = publicSession
+      ? this.securityBootstrap.mediaContractFor(sessionId) : null;
+    if (publicMediaContract
+        && this.disabledPublicMediaContracts.get(sessionId) !== publicMediaContract.digest) {
+      let adapterGeneration: number | null = null;
+      try {
+        adapterGeneration = await this.pairMediaTransforms.prepareSession(
+          pc,
+          sessionId,
+          publicMediaContract,
+          reasonCode => {
+            const context = this.activePublicMediaContext;
+            if (
+              adapterGeneration === null
+              || !context
+              || context.peer !== pc
+              || context.sessionId !== sessionId
+              || context.sessionGeneration !== generation
+              || context.adapterGeneration !== adapterGeneration
+              || !this.isCurrentSession(pc, sessionId, generation)
+            ) return;
+            this.pairMediaE2ee.failMediaExtension(sessionId, reasonCode);
+          },
+          isInitiator ? 'offerer' : 'answerer',
+        );
+        if (!this.isCurrentSession(pc, sessionId, generation)) {
+          this.pairMediaTransforms.releaseSession(sessionId, adapterGeneration);
+          pc.close();
+          return;
+        }
+        const preparedPeer = pc;
+        const preparedAdapterGeneration = adapterGeneration;
+        const matchesPreparedContext = (): boolean => {
+          const context = this.activePublicMediaContext;
+          return !!context
+            && context.peer === preparedPeer
+            && context.sessionId === sessionId
+            && context.sessionGeneration === generation
+            && context.adapterGeneration === preparedAdapterGeneration
+            && this.isCurrentSession(preparedPeer, sessionId, generation);
+        };
+        this.pairMediaE2ee.bindTransport(sessionId, {
+          send: async message => {
+            if (!matchesPreparedContext()) throw new Error('public_media_runtime_superseded');
+            const channel = this.dc;
+            if (!channel) throw new Error('public_media_consent_channel_unavailable');
+            const sendContext: SemanticSendContext = Object.freeze({
+              peer: preparedPeer,
+              sessionId,
+              sessionGeneration: generation,
+              channel,
+            });
+            await this.sendSemanticWithContext(message, {}, sendContext);
+            if (!matchesPreparedContext()) throw new Error('public_media_runtime_superseded');
+          },
+          disableMedia: reasonCode => {
+            if (!matchesPreparedContext()) return;
+            this.audit('public_media_disabled', reasonCode);
+            this.disabledPublicMediaContracts.set(sessionId, publicMediaContract.digest);
+            this.activePublicMediaContext = null;
+            this.pairMediaTransforms.releaseSession(sessionId, preparedAdapterGeneration);
+            this.stopPendingPublicMediaTracks();
+          },
+          failClosed: reasonCode => {
+            if (!matchesPreparedContext()) return;
+            this.audit('public_media_fail_closed', reasonCode);
+            this.disabledPublicMediaContracts.set(sessionId, publicMediaContract.digest);
+            this.terminateSession('failed');
+          },
+        });
+        this.activePublicMediaContext = Object.freeze({
+          sessionId,
+          peer: preparedPeer,
+          sessionGeneration: generation,
+          adapterGeneration: preparedAdapterGeneration,
+          contractDigest: publicMediaContract.digest,
+        });
+      } catch (error) {
+        if (!this.isCurrentSession(pc, sessionId, generation)) {
+          if (adapterGeneration !== null) {
+            this.pairMediaTransforms.releaseSession(sessionId, adapterGeneration);
+          }
+          pc.close();
+          return;
+        }
+        this.audit('public_media_prepare_failed', error instanceof Error ? error.message : String(error));
+        this.disabledPublicMediaContracts.set(sessionId, publicMediaContract.digest);
+        this.pairMediaTransforms.releaseSession(sessionId, adapterGeneration ?? undefined);
+        pc.close();
+        // The optional extension failed before any media could leave DROP
+        // mode. Recreate a clean data-only PC so base Pair chat/view remains.
+        pc = new RTCPeerConnection(config);
+        this.pc = pc;
+        this.pairMediaE2ee.fail(
+          sessionId,
+          error instanceof Error ? error.message : 'public_media_transform_prepare_failed',
+        );
+      }
+    }
     this.releaseSignalingHandler = this.signaling.bindMessageHandler(async msg => {
       if (!this.isCurrentSession(pc, sessionId, generation) || msg.session_id !== sessionId) return;
       try {
@@ -159,7 +308,11 @@ export class WebrtcSessionService {
         this.audit('ice_failed', 'timeout after 15s');
         // The transport coordinator decides whether a local legacy session
         // may use Hub relay. Public sessions fail closed after direct/TURN ICE.
-        this.state$.next('failed');
+        if (this.pairMediaTransforms.isPrepared(sessionId)) {
+          this.pairMediaE2ee.fail(sessionId, 'public_media_peer_connection_timeout');
+        } else {
+          this.state$.next('failed');
+        }
       }
     }, 15_000);
   }
@@ -170,6 +323,8 @@ export class WebrtcSessionService {
 
   private terminateSession(finalState: Extract<PeerState, 'failed' | 'closed'>): void {
     const closingSessionId = this.sessionId;
+    const mediaContext = this.activePublicMediaContext;
+    this.activePublicMediaContext = null;
     this.sessionGeneration += 1;
     this.releaseSignalingHandler?.();
     this.releaseSignalingHandler = null;
@@ -177,10 +332,12 @@ export class WebrtcSessionService {
     this.signalingStatusSubscription = null;
     this.localDescriptionPublicationPending = false;
     this.pendingLocalIce = [];
+    this.stopPendingPublicMediaTracks();
     if (this.connectionTimeout) { clearTimeout(this.connectionTimeout); this.connectionTimeout = null; }
-    this.dc?.close();
-    this.pc?.close();
+    const closingDataChannel = this.dc;
     this.dc = null;
+    closingDataChannel?.close();
+    this.pc?.close();
     this.pc = null;
     this.signaling.disconnect();
     this.chunkReassembler.clear();
@@ -188,10 +345,21 @@ export class WebrtcSessionService {
     this.sendQueue.cancelContext(closingSessionId);
     this.sendQueue.unbind();
     this.pendingSemanticSends.clear();
+    if (closingSessionId) {
+      if (mediaContext?.sessionId === closingSessionId) {
+        this.pairMediaTransforms.releaseSession(closingSessionId, mediaContext.adapterGeneration);
+      } else {
+        // Covers cancellation while prepareSession is still awaiting worker
+        // ACKs. This is the current generation and cannot target a replacement.
+        this.pairMediaTransforms.releaseSession(closingSessionId);
+      }
+    }
+    if (closingSessionId) this.pairMediaE2ee.unbindTransport(closingSessionId, `public_media_session_${finalState}`);
     this.state$.next(finalState);
     this.audit(finalState === 'failed' ? 'session_failed' : 'session_closed');
     this.sessionId = '';
     this.isInitiator = false;
+    this.publicSdpPhase = 'none';
   }
 
   sendDc(type: string, payload: Record<string, unknown> = {}): void {
@@ -218,9 +386,26 @@ export class WebrtcSessionService {
     message: SemanticDataChannelMessage,
     options: { signal?: AbortSignal; deadlineMs?: number } = {},
   ): Promise<WebrtcSendOperation> {
-    if (message.session_id !== this.sessionId) throw new Error('semantic_session_mismatch');
-    this.acceptEpoch(message.epoch);
+    const context: SemanticSendContext = Object.freeze({
+      peer: this.pc,
+      sessionId: this.sessionId,
+      sessionGeneration: this.sessionGeneration,
+    });
+    return this.sendSemanticWithContext(message, options, context);
+  }
+
+  private async sendSemanticWithContext(
+    message: SemanticDataChannelMessage,
+    options: { signal?: AbortSignal; deadlineMs?: number },
+    context: SemanticSendContext,
+  ): Promise<WebrtcSendOperation> {
+    this.assertSemanticSendContext(message, context);
     const encoded = await semanticDcEncodePackets(message);
+    // Encoding hashes payloads asynchronously. A same-session replacement
+    // must win before any epoch, pending-operation, or singleton queue state
+    // can be changed by the old continuation.
+    this.assertSemanticSendContext(message, context);
+    this.acceptEpoch(message.epoch, context.sessionId);
     const deadline = Math.min(options.deadlineMs ?? Date.now() + 30_000, message.expires_at_ms);
     const operation = new WebrtcSendOperation(
       message.session_id,
@@ -230,7 +415,11 @@ export class WebrtcSessionService {
       options.signal,
     );
     this.pendingSemanticSends.set(encoded.digest, operation);
-    void operation.result.then(() => this.pendingSemanticSends.delete(encoded.digest));
+    void operation.result.then(() => {
+      if (this.pendingSemanticSends.get(encoded.digest) === operation) {
+        this.pendingSemanticSends.delete(encoded.digest);
+      }
+    });
     for (const packet of encoded.packets) {
       if (!this.sendQueue.enqueue(message.traffic_class, packet, message.expires_at_ms, operation)) {
         operation.cancel();
@@ -247,25 +436,70 @@ export class WebrtcSessionService {
   addMediaTrack(track: MediaStreamTrack, stream: MediaStream): RTCRtpSender {
     this.mediaPolicy.assertAllowed(this.sessionId);
     if (!this.pc || this.pc.connectionState === 'closed') throw new Error('webrtc_session_not_open');
+    if (this.controlPlane.isPublicSession(this.sessionId)) {
+      throw new Error('public_media_slot_required');
+    }
     const sender = this.pc.addTrack(track, stream);
     void this.negotiateMedia();
     return sender;
   }
 
+  async attachMediaTrack(
+    slot: PublicPairMediaSlot,
+    track: MediaStreamTrack,
+    stream: MediaStream,
+  ): Promise<RTCRtpSender> {
+    this.mediaPolicy.assertAllowed(this.sessionId);
+    if (!this.pc || this.pc.connectionState === 'closed') throw new Error('webrtc_session_not_open');
+    if (!this.controlPlane.isPublicSession(this.sessionId)) {
+      const sender = this.pc.addTrack(track, stream);
+      void this.negotiateMedia();
+      return sender;
+    }
+    const status = this.pairMediaE2ee.statusFor(this.sessionId);
+    if (status.state !== 'ready' || !this.pairMediaTransforms.isKeyed(
+      this.sessionId,
+      this.securityBootstrap.mediaContractFor(this.sessionId)?.epoch,
+      status.contractDigest,
+    )) throw new Error(status.reasonCode || 'public_media_e2ee_not_ready');
+    const sender = this.pairMediaTransforms.senderForSlot(this.sessionId, slot);
+    const expectedKind = slot === 'microphone-opus' ? 'audio' : 'video';
+    if (track.kind !== expectedKind) throw new Error('public_media_track_kind_invalid');
+    await sender.replaceTrack(track);
+    return sender;
+  }
+
+  publicMediaSlotForReceiver(receiver: RTCRtpReceiver): PublicPairMediaSlot | null {
+    return this.pairMediaTransforms.slotForReceiver(this.sessionId, receiver);
+  }
+
   async replaceMediaTrack(sender: RTCRtpSender, track: MediaStreamTrack | null): Promise<void> {
     this.mediaPolicy.assertAllowed(this.sessionId);
     if (!this.pc || !this.pc.getSenders().includes(sender)) throw new Error('webrtc_media_sender_stale');
+    if (this.controlPlane.isPublicSession(this.sessionId)
+        && this.pairMediaE2ee.statusFor(this.sessionId).state !== 'ready') {
+      throw new Error('public_media_e2ee_not_ready');
+    }
     await sender.replaceTrack(track);
   }
 
   removeMediaSender(sender: RTCRtpSender): void {
     if (!this.pc || !this.pc.getSenders().includes(sender)) return;
+    if (this.controlPlane.isPublicSession(this.sessionId)) {
+      void sender.replaceTrack(null).catch(() => undefined);
+      return;
+    }
     this.pc.removeTrack(sender);
     void this.negotiateMedia();
   }
 
   restartMediaIce(): void {
     if (!this.pc || this.pc.connectionState === 'closed') throw new Error('webrtc_session_not_open');
+    if (this.controlPlane.isPublicSession(this.sessionId)) {
+      const sessionId = this.sessionId;
+      this.pairMediaE2ee.deactivate(sessionId, 'public_media_fresh_connection_required');
+      throw new Error('public_media_fresh_connection_required');
+    }
     this.pc.restartIce();
     void this.negotiateMedia();
   }
@@ -308,12 +542,61 @@ export class WebrtcSessionService {
         this.state$.next('connected');
       }
       if (s === 'failed' || s === 'disconnected') {
-        this.state$.next('failed');
         this.audit('connection_failed', s);
+        if (this.pairMediaTransforms.isPrepared(sessionId)) {
+          this.pairMediaE2ee.fail(sessionId, 'public_media_peer_connection_lost');
+          return;
+        }
+        this.state$.next('failed');
       }
     };
     pc.ontrack = event => {
       if (!this.isCurrentSession(pc, sessionId, generation)) return;
+      const isPublicSession = this.controlPlane.isPublicSession(sessionId);
+      const currentMediaContract = isPublicSession
+        ? this.securityBootstrap.mediaContractFor(sessionId) : null;
+      if (
+        isPublicSession
+        && currentMediaContract
+        && this.disabledPublicMediaContracts.get(sessionId) === currentMediaContract.digest
+      ) {
+        // The remote SDP may still contain rejected/muted media m-lines after
+        // either peer downgraded the optional extension. Never route those
+        // browser events through the ordinary-media policy or render them.
+        try { event.track.stop(); } catch { /* Browser receiver owns the track. */ }
+        this.audit('public_media_track_ignored', 'public_media_extension_disabled');
+        return;
+      }
+      if (isPublicSession && this.pairMediaTransforms.isPrepared(sessionId)) {
+        let slot = this.pairMediaTransforms.slotForReceiver(sessionId, event.receiver);
+        const adapterGeneration = this.activePublicMediaContext?.adapterGeneration;
+        if (!slot && this.pairMediaTransforms.isAwaitingRemoteTopology(sessionId, adapterGeneration)) {
+          try {
+            if (adapterGeneration === undefined) throw new Error('public_media_topology_invalid');
+            slot = this.pairMediaTransforms.stageRemoteOfferTrack(
+              sessionId, event.transceiver, event.receiver, adapterGeneration,
+            );
+          } catch {
+            try { event.track.stop(); } catch { /* Browser receiver owns the track. */ }
+            this.pairMediaE2ee.failMediaExtension(sessionId, 'public_media_remote_slot_invalid');
+            return;
+          }
+        }
+        if (!slot || this.pendingPublicMediaTracks.has(slot)) {
+          try { event.track.stop(); } catch { /* Browser receiver owns the track. */ }
+          this.audit('public_media_rejected', 'public_media_remote_slot_invalid');
+          this.pairMediaE2ee.failMediaExtension(sessionId, 'public_media_remote_slot_invalid');
+          return;
+        }
+        if (this.pairMediaE2ee.statusFor(sessionId).state === 'ready') {
+          this.remoteTrack$.next(event);
+        } else {
+          // The receiver transform is already DROP-first. Hold the browser
+          // track event until hello/ack, exact topology, and worker key ACK.
+          this.pendingPublicMediaTracks.set(slot, event);
+        }
+        return;
+      }
       try {
         this.mediaPolicy.assertAllowed(sessionId);
       } catch (error) {
@@ -361,7 +644,8 @@ export class WebrtcSessionService {
     const pc = this.pc;
     const sessionId = this.sessionId;
     const generation = this.sessionGeneration;
-    if (!pc || !this.isInitiator || pc.signalingState !== 'stable') return;
+    if (!pc || !this.isInitiator || pc.signalingState !== 'stable'
+        || this.controlPlane.isPublicSession(sessionId)) return;
     try {
       await this.createOffer(pc, sessionId, generation);
     } catch (error) {
@@ -376,14 +660,83 @@ export class WebrtcSessionService {
     generation: number,
   ): Promise<void> {
     if (!this.isCurrentSession(pc, sessionId, generation)) return;
+    if (this.controlPlane.isPublicSession(sessionId)) {
+      const expected = msg.type === 'offer'
+        ? !this.isInitiator && this.publicSdpPhase === 'awaiting-offer'
+        : msg.type === 'answer'
+          ? this.isInitiator && this.publicSdpPhase === 'awaiting-answer'
+          : true;
+      if (!expected) {
+        this.audit('public_sdp_rejected', `unexpected_${msg.type}:${this.publicSdpPhase}`);
+        if (this.pairMediaTransforms.isPrepared(sessionId)) {
+          this.pairMediaE2ee.fail(sessionId, 'public_media_unexpected_sdp');
+        }
+        if (this.isCurrentSession(pc, sessionId, generation)) this.terminateSession('failed');
+        return;
+      }
+      if (msg.type === 'offer') this.publicSdpPhase = 'processing-offer';
+      if (msg.type === 'answer') this.publicSdpPhase = 'processing-answer';
+    }
     if (msg.type === 'offer') {
       await pc.setRemoteDescription(new RTCSessionDescription(msg.payload as RTCSessionDescriptionInit));
       if (!this.isCurrentSession(pc, sessionId, generation)) return;
+      const disabledContract = this.securityBootstrap.mediaContractFor(sessionId);
+      if (
+        this.controlPlane.isPublicSession(sessionId)
+        && disabledContract
+        && this.disabledPublicMediaContracts.get(sessionId) === disabledContract.digest
+      ) {
+        this.rejectOfferedPublicMedia(pc);
+      }
+      const mediaContext = this.activePublicMediaContext;
+      if (
+        this.isActivePublicMediaContext(mediaContext, pc, sessionId, generation)
+        && this.pairMediaTransforms.isAwaitingRemoteTopology(
+          sessionId, mediaContext.adapterGeneration,
+        )
+      ) {
+        try {
+          await this.pairMediaTransforms.bindRemoteOfferTopology(
+            sessionId, mediaContext.adapterGeneration,
+          );
+          if (!this.isCurrentSession(pc, sessionId, generation)) return;
+        } catch (error) {
+          this.audit('public_media_topology_disabled', error instanceof Error ? error.message : String(error));
+          this.pairMediaE2ee.failMediaExtension(
+            sessionId,
+            error instanceof Error ? error.message : 'public_media_topology_invalid',
+          );
+        }
+      }
       const answer = await pc.createAnswer();
       if (!this.isCurrentSession(pc, sessionId, generation)) return;
       await this.publishLocalDescription('answer', answer, pc, sessionId, generation);
+      if (!this.isCurrentSession(pc, sessionId, generation)) return;
+      const currentMediaContext = this.activePublicMediaContext;
+      if (
+        this.isActivePublicMediaContext(currentMediaContext, pc, sessionId, generation)
+        && this.pairMediaTransforms.isPrepared(
+          sessionId, undefined, currentMediaContext.contractDigest,
+          currentMediaContext.adapterGeneration,
+        )
+      ) {
+        this.pairMediaE2ee.markTopologyNegotiated(sessionId);
+      }
+      if (this.controlPlane.isPublicSession(sessionId)) this.publicSdpPhase = 'established';
     } else if (msg.type === 'answer') {
       await pc.setRemoteDescription(new RTCSessionDescription(msg.payload as RTCSessionDescriptionInit));
+      if (!this.isCurrentSession(pc, sessionId, generation)) return;
+      const currentMediaContext = this.activePublicMediaContext;
+      if (
+        this.isActivePublicMediaContext(currentMediaContext, pc, sessionId, generation)
+        && this.pairMediaTransforms.isPrepared(
+          sessionId, undefined, currentMediaContext.contractDigest,
+          currentMediaContext.adapterGeneration,
+        )
+      ) {
+        this.pairMediaE2ee.markTopologyNegotiated(sessionId);
+      }
+      if (this.controlPlane.isPublicSession(sessionId)) this.publicSdpPhase = 'established';
     } else if (msg.type === 'ice_candidate') {
       await pc.addIceCandidate(new RTCIceCandidate(msg.payload as RTCIceCandidateInit));
     }
@@ -409,15 +762,17 @@ export class WebrtcSessionService {
       if (!this.isCurrentSession(pc, sessionId, generation)) return;
       published = true;
     } finally {
-      const bufferedIce = this.pendingLocalIce;
-      this.pendingLocalIce = [];
-      this.localDescriptionPublicationPending = false;
-      if (published && this.isCurrentSession(pc, sessionId, generation)) {
-        for (const candidate of bufferedIce) {
-          await this.signaling.send({
-            type: 'ice_candidate', session_id: sessionId, payload: candidate,
-          });
-          if (!this.isCurrentSession(pc, sessionId, generation)) return;
+      if (this.isCurrentSession(pc, sessionId, generation)) {
+        const bufferedIce = this.pendingLocalIce;
+        this.pendingLocalIce = [];
+        this.localDescriptionPublicationPending = false;
+        if (published) {
+          for (const candidate of bufferedIce) {
+            await this.signaling.send({
+              type: 'ice_candidate', session_id: sessionId, payload: candidate,
+            });
+            if (!this.isCurrentSession(pc, sessionId, generation)) return;
+          }
         }
       }
     }
@@ -429,6 +784,15 @@ export class WebrtcSessionService {
     sessionId: string,
     generation: number,
   ): void {
+    const receiveContext: DataChannelReceiveContext = Object.freeze({
+      peer: pc,
+      channel: dc,
+      sessionId,
+      sessionGeneration: generation,
+    });
+    let receiveChain = Promise.resolve();
+    let queuedMessages = 0;
+    let queuedBytes = 0;
     this.sendQueue.bind(dc);
     dc.onbufferedamountlow = () => {
       if (this.isCurrentSession(pc, sessionId, generation) && this.dc === dc) this.sendQueue.flush();
@@ -437,16 +801,62 @@ export class WebrtcSessionService {
       if (!this.isCurrentSession(pc, sessionId, generation) || this.dc !== dc) return;
       this.audit('datachannel_opened');
       this.sendDc('hello', { version: 1 });
+      if (this.pairMediaTransforms.isPrepared(sessionId)) {
+        this.pairMediaE2ee.markDataChannelOpen(sessionId);
+      }
     };
     dc.onclose = () => {
       if (!this.isCurrentSession(pc, sessionId, generation) || this.dc !== dc) return;
       this.sendQueue.unbind();
       this.audit('datachannel_closed');
+      if (this.pairMediaTransforms.isPrepared(sessionId)) {
+        this.pairMediaE2ee.fail(sessionId, 'public_media_consent_channel_closed');
+      } else if (this.controlPlane.isPublicSession(sessionId)) {
+        this.terminateSession('failed');
+      }
+    };
+    dc.onerror = () => {
+      if (!this.isCurrentSession(pc, sessionId, generation) || this.dc !== dc) return;
+      this.audit('datachannel_error');
+      if (this.pairMediaTransforms.isPrepared(sessionId)) {
+        this.pairMediaE2ee.fail(sessionId, 'public_media_consent_channel_failed');
+      } else if (this.controlPlane.isPublicSession(sessionId)) {
+        this.terminateSession('failed');
+      }
     };
     dc.onmessage = (evt) => {
-      if (this.isCurrentSession(pc, sessionId, generation) && this.dc === dc) {
-        void this.handleDcMessage(evt.data as string);
+      if (!this.isCurrentSession(pc, sessionId, generation) || this.dc !== dc) return;
+      const raw = evt.data as string;
+      const incomingBytes = this.dcMessageBytes(raw);
+      if (!this.admitDcMessage(raw, incomingBytes, Date.now())) return;
+      if (
+        queuedMessages >= DC_RECEIVE_QUEUE_MAX
+        || queuedBytes + incomingBytes > DC_RECEIVE_QUEUE_BYTES
+      ) {
+        this.audit('policy_violation', 'datachannel_receive_queue_overflow');
+        if (this.controlPlane.isPublicSession(sessionId)) {
+          if (this.pairMediaTransforms.isPrepared(sessionId)) {
+            this.pairMediaE2ee.fail(sessionId, 'public_datachannel_receive_queue_overflow');
+          }
+          if (this.isCurrentSession(pc, sessionId, generation)) this.terminateSession('failed');
+        }
+        return;
       }
+      queuedMessages += 1;
+      queuedBytes += incomingBytes;
+      receiveChain = receiveChain.then(async () => {
+        if (!this.isCurrentDataChannel(receiveContext)) return;
+        await this.handleDcMessage(raw, receiveContext);
+      }).catch(error => {
+        // Keep the ordered queue usable after one decoder failure. Security
+        // failures close the current generation through the coordinator.
+        if (this.isCurrentSession(pc, sessionId, generation) && this.dc === dc) {
+          this.audit('decode_error', String(error));
+        }
+      }).finally(() => {
+        queuedMessages -= 1;
+        queuedBytes -= incomingBytes;
+      });
     };
   }
 
@@ -458,43 +868,88 @@ export class WebrtcSessionService {
     return generation === this.sessionGeneration && this.pc === pc && this.sessionId === sessionId;
   }
 
-  private async handleDcMessage(raw: string): Promise<void> {
-    const now = Date.now();
-    this.rateTs = this.rateTs.filter((t) => now - t < RATE_LIMIT_WINDOW_MS);
-    this.rateBytes = this.rateBytes.filter(row => now - row.ts < RATE_LIMIT_WINDOW_MS);
-    const incomingBytes = typeof raw === 'string' ? new TextEncoder().encode(raw).byteLength : RATE_LIMIT_BYTES + 1;
-    const windowBytes = this.rateBytes.reduce((sum, row) => sum + row.bytes, 0);
-    if (this.rateTs.length >= RATE_LIMIT_MAX || windowBytes + incomingBytes > RATE_LIMIT_BYTES) {
-      this.audit('policy_violation', 'rate_limit_exceeded');
-      return;
-    }
-    this.rateTs.push(now);
-    this.rateBytes.push({ ts: now, bytes: incomingBytes });
+  private isCurrentDataChannel(context: DataChannelReceiveContext): boolean {
+    return this.isCurrentSession(
+      context.peer, context.sessionId, context.sessionGeneration,
+    ) && this.dc === context.channel;
+  }
 
+  private assertSemanticSendContext(
+    message: SemanticDataChannelMessage,
+    context: SemanticSendContext,
+  ): void {
+    const current = context.sessionGeneration === this.sessionGeneration
+      && context.peer === this.pc
+      && context.sessionId === this.sessionId
+      && message.session_id === context.sessionId
+      && (context.channel === undefined || context.channel === this.dc);
+    if (!current) throw new Error('semantic_send_context_superseded');
+  }
+
+  private isActivePublicMediaContext(
+    context: ActivePublicMediaContext | null,
+    pc: RTCPeerConnection,
+    sessionId: string,
+    generation: number,
+  ): context is ActivePublicMediaContext {
+    return !!context
+      && context.peer === pc
+      && context.sessionId === sessionId
+      && context.sessionGeneration === generation
+      && this.isCurrentSession(pc, sessionId, generation);
+  }
+
+  private rejectOfferedPublicMedia(pc: RTCPeerConnection): void {
+    for (const transceiver of pc.getTransceivers()) {
+      try { transceiver.direction = 'inactive'; } catch { /* Rejected/closed m-line is already safe. */ }
+      void transceiver.sender.replaceTrack(null).catch(() => undefined);
+    }
+  }
+
+  private async handleDcMessage(
+    raw: string,
+    context: DataChannelReceiveContext,
+  ): Promise<void> {
     try {
       if (raw.startsWith('ANANTA-DC1 ')) {
         const semantic = await semanticDcDecode(raw);
-        this.acceptEpoch(semantic.epoch);
-        if (semantic.expires_at_ms <= now) throw new SemanticDataChannelError('expired');
+        if (!this.isCurrentDataChannel(context)) return;
+        this.assertSemanticSession(semantic.session_id, context);
+        this.acceptEpoch(semantic.epoch, context.sessionId);
+        if (semantic.expires_at_ms <= Date.now()) throw new SemanticDataChannelError('expired');
+        if (!this.isCurrentDataChannel(context)) return;
+        const accepted = await this.pairMediaE2ee.acceptSemantic(semantic);
+        if (!this.isCurrentDataChannel(context)) return;
+        if (accepted) return;
         this.semanticMessage$.next(semantic);
         return;
       }
       if (raw.startsWith('ANANTA-DCCHUNK1 ')) {
         const chunk = semanticDcDecodeChunk(raw);
-        this.acceptEpoch(chunk.epoch);
-        const result = await this.semanticReassembler.accept(chunk, now);
+        if (!this.isCurrentDataChannel(context)) return;
+        this.assertSemanticSession(chunk.session_id, context);
+        this.acceptEpoch(chunk.epoch, context.sessionId);
+        const result = await this.semanticReassembler.accept(chunk, Date.now());
+        if (!this.isCurrentDataChannel(context)) return;
         if (result.status === 'rejected') throw new SemanticDataChannelError(result.reason);
         if (result.status !== 'complete') return;
         const frame = new TextDecoder('utf-8', { fatal: true }).decode(result.value);
         const semantic = await semanticDcDecode(frame);
-        if (semantic.expires_at_ms <= now) throw new SemanticDataChannelError('expired');
+        if (!this.isCurrentDataChannel(context)) return;
+        this.assertSemanticSession(semantic.session_id, context);
+        if (semantic.epoch !== chunk.epoch) throw new SemanticDataChannelError('chunk_context_mismatch');
+        if (semantic.expires_at_ms <= Date.now()) throw new SemanticDataChannelError('expired');
+        const accepted = await this.pairMediaE2ee.acceptSemantic(semantic);
+        if (!this.isCurrentDataChannel(context)) return;
+        if (accepted) return;
         this.semanticMessage$.next(semantic);
         return;
       }
       const parsed = dcDecode(raw);
       const msg = dcTryReassembleChunk(parsed, this.chunkReassembler);
       if (!msg) return;
-      if (msg.type === 'cursor' && this.controlPlane.isPublicSession(this.sessionId)) {
+      if (!this.isCurrentDataChannel(context)) return;
+      if (msg.type === 'cursor' && this.controlPlane.isPublicSession(context.sessionId)) {
         this.audit('policy_violation', 'public_raw_cursor_transport_disabled');
         return;
       }
@@ -502,20 +957,69 @@ export class WebrtcSessionService {
         this.audit('policy_violation', `disallowed_type:${msg.type}`);
         return;
       }
-      if (msg.type === 'ping') { this.sendDc('pong'); return; }
+      if (msg.type === 'ping') {
+        if (this.isCurrentDataChannel(context)) this.sendDc('pong');
+        return;
+      }
+      if (!this.isCurrentDataChannel(context)) return;
       this.dcMessage$.next(msg);
     } catch (e) {
-      this.audit('decode_error', String(e));
+      if (this.isCurrentDataChannel(context)) this.audit('decode_error', String(e));
     }
   }
 
-  private acceptEpoch(epoch: number): void {
+  private assertSemanticSession(
+    semanticSessionId: string,
+    context: DataChannelReceiveContext,
+  ): void {
+    if (semanticSessionId !== context.sessionId) {
+      throw new SemanticDataChannelError('semantic_session_mismatch');
+    }
+  }
+
+  private admitDcMessage(raw: unknown, incomingBytes: number, now: number): raw is string {
+    this.rateTs = this.rateTs.filter(timestamp => now - timestamp < RATE_LIMIT_WINDOW_MS);
+    this.rateBytes = this.rateBytes.filter(row => now - row.ts < RATE_LIMIT_WINDOW_MS);
+    const windowBytes = this.rateBytes.reduce((sum, row) => sum + row.bytes, 0);
+    if (this.rateTs.length >= RATE_LIMIT_MAX || windowBytes + incomingBytes > RATE_LIMIT_BYTES) {
+      this.audit('policy_violation', 'rate_limit_exceeded');
+      return false;
+    }
+    this.rateTs.push(now);
+    this.rateBytes.push({ ts: now, bytes: incomingBytes });
+    return typeof raw === 'string';
+  }
+
+  private dcMessageBytes(raw: unknown): number {
+    return typeof raw === 'string'
+      ? new TextEncoder().encode(raw).byteLength
+      : RATE_LIMIT_BYTES + 1;
+  }
+
+  private acceptEpoch(epoch: number, sessionId = this.sessionId): void {
     if (!Number.isSafeInteger(epoch) || epoch < this.activeEpoch) throw new Error('stale_semantic_epoch');
     if (epoch === this.activeEpoch) return;
     const prior = this.activeEpoch;
     this.activeEpoch = epoch;
-    this.semanticReassembler.clearContext(this.sessionId, prior);
-    this.sendQueue.cancelContext(this.sessionId, prior);
+    this.semanticReassembler.clearContext(sessionId, prior);
+    this.sendQueue.cancelContext(sessionId, prior);
+  }
+
+  private releasePendingPublicMediaTracks(): void {
+    if (!this.sessionId || this.pairMediaE2ee.statusFor(this.sessionId).state !== 'ready') return;
+    for (const definition of ['microphone-opus', 'camera-vp8', 'screen-vp8'] as const) {
+      const event = this.pendingPublicMediaTracks.get(definition);
+      if (!event) continue;
+      this.pendingPublicMediaTracks.delete(definition);
+      this.remoteTrack$.next(event);
+    }
+  }
+
+  private stopPendingPublicMediaTracks(): void {
+    for (const event of this.pendingPublicMediaTracks.values()) {
+      try { event.track.stop(); } catch { /* Deterministic local cleanup. */ }
+    }
+    this.pendingPublicMediaTracks.clear();
   }
 
   private audit(type: string, detail?: string): void {

--- a/frontend-angular/src/app/workers/pair-media-e2ee.worker.spec.ts
+++ b/frontend-angular/src/app/workers/pair-media-e2ee.worker.spec.ts
@@ -1,0 +1,178 @@
+import { PUBLIC_PAIR_MEDIA_SLOTS } from '../services/public-pair-media-security-contract';
+
+interface WorkerHarness {
+  readonly posted: any[];
+  readonly controllers: Map<string, ReadableStreamDefaultController<any>>;
+  readonly output: Map<string, any[]>;
+  transform(id: string, operation: 'encrypt' | 'decrypt'): void;
+  message(value: unknown): void;
+  restore(): void;
+}
+
+describe('pair media E2EE worker', () => {
+  afterEach(() => vi.resetModules());
+
+  it('keeps every transform DROP-first when the final install entry is invalid', async () => {
+    const harness = await createHarness();
+    try {
+      const ids = installTransforms(harness);
+      const entries = await installEntries(ids);
+      entries[5] = {
+        ...entries[5],
+        context: { ...entries[5].context, recipientId: entries[5].context.senderId },
+      };
+
+      harness.message({ version: 1, type: 'install-keys', sessionId: 'session-a', entries });
+      await settle();
+      harness.controllers.get(ids[0])?.enqueue({ data: Uint8Array.of(1, 2, 3).buffer, type: 'audio' });
+      await settle();
+
+      expect(harness.posted).toContainEqual(expect.objectContaining({
+        type: 'fatal', reasonCode: 'media_e2ee_context_invalid',
+      }));
+      expect(harness.posted.some(message => message.type === 'keys-installed')).toBe(false);
+      expect(harness.output.get(ids[0])).toEqual([]);
+    } finally {
+      harness.restore();
+    }
+  });
+
+  it('never permits a second installation in one worker generation', async () => {
+    const harness = await createHarness();
+    try {
+      const ids = installTransforms(harness);
+      const entries = await installEntries(ids);
+      const message = { version: 1, type: 'install-keys', sessionId: 'session-a', entries };
+      harness.message(message);
+      await settle();
+      expect(harness.posted).toContainEqual(expect.objectContaining({ type: 'keys-installed' }));
+
+      harness.message(message);
+      await settle();
+      expect(harness.posted).toContainEqual(expect.objectContaining({
+        type: 'fatal', reasonCode: 'media_e2ee_key_reinstall_forbidden',
+      }));
+    } finally {
+      harness.restore();
+    }
+  });
+
+  it('poisons every keyed slot before reporting one transform authentication fatal', async () => {
+    const harness = await createHarness();
+    const encryptGate = deferred<void>();
+    const originalEncrypt = crypto.subtle.encrypt.bind(crypto.subtle);
+    const encryptSpy = vi.spyOn(crypto.subtle, 'encrypt').mockImplementationOnce(async (...args) => {
+      await encryptGate.promise;
+      return originalEncrypt(...args);
+    });
+    try {
+      const ids = installTransforms(harness);
+      harness.message({
+        version: 1, type: 'install-keys', sessionId: 'session-a',
+        entries: await installEntries(ids),
+      });
+      await settle();
+
+      harness.controllers.get(ids[0])?.enqueue({
+        data: Uint8Array.of(1, 2, 3).buffer, type: 'audio',
+      });
+      await settle(5);
+      expect(encryptSpy).toHaveBeenCalledOnce();
+
+      harness.controllers.get(ids[1])?.enqueue({
+        data: new Uint8Array(64).buffer, type: 'audio',
+      });
+      await settle(10);
+      expect(harness.posted).toContainEqual(expect.objectContaining({
+        type: 'fatal', transformId: ids[1], reasonCode: 'media_e2ee_header_invalid',
+      }));
+
+      encryptGate.resolve(undefined);
+      harness.controllers.get(ids[2])?.enqueue({
+        data: Uint8Array.of(7, 8, 9).buffer, type: 'delta',
+      });
+      await settle(10);
+      expect(harness.output.get(ids[0])).toEqual([]);
+      expect(harness.output.get(ids[2])).toEqual([]);
+      expect(harness.posted.filter(message => message.type === 'fatal')).toHaveLength(1);
+    } finally {
+      encryptSpy.mockRestore();
+      harness.restore();
+    }
+  });
+});
+
+async function createHarness(): Promise<WorkerHarness> {
+  vi.resetModules();
+  const scope = globalThis as any;
+  const previous = {
+    postMessage: scope.postMessage,
+    onmessage: scope.onmessage,
+    onrtctransform: scope.onrtctransform,
+  };
+  const posted: any[] = [];
+  const controllers = new Map<string, ReadableStreamDefaultController<any>>();
+  const output = new Map<string, any[]>();
+  scope.postMessage = (message: unknown) => posted.push(message);
+  await import('./pair-media-e2ee.worker');
+  return {
+    posted,
+    controllers,
+    output,
+    transform(id, operation) {
+      const frames: any[] = [];
+      output.set(id, frames);
+      const readable = new ReadableStream({ start(controller) { controllers.set(id, controller); } });
+      const writable = new WritableStream({ write(frame) { frames.push(frame); } });
+      scope.onrtctransform({ transformer: {
+        options: { version: 1, transformId: id, operation }, readable, writable,
+      } });
+    },
+    message(value) { scope.onmessage({ data: value }); },
+    restore() {
+      scope.postMessage = previous.postMessage;
+      scope.onmessage = previous.onmessage;
+      scope.onrtctransform = previous.onrtctransform;
+    },
+  };
+}
+
+function installTransforms(harness: WorkerHarness): string[] {
+  const ids = PUBLIC_PAIR_MEDIA_SLOTS.flatMap(definition => [
+    `session-a:${definition.slot}:send`, `session-a:${definition.slot}:receive`,
+  ]);
+  ids.forEach((id, index) => harness.transform(id, index % 2 === 0 ? 'encrypt' : 'decrypt'));
+  return ids;
+}
+
+async function installEntries(ids: readonly string[]): Promise<any[]> {
+  const entries: any[] = [];
+  for (const [index, id] of ids.entries()) {
+    const definition = PUBLIC_PAIR_MEDIA_SLOTS[Math.floor(index / 2)];
+    const sending = index % 2 === 0;
+    entries.push({
+      transformId: id,
+      key: await crypto.subtle.generateKey(
+        { name: 'AES-GCM', length: 256 }, false, ['encrypt', 'decrypt'],
+      ),
+      context: {
+        sessionId: 'session-a', mediaContractDigest: 'a'.repeat(64), connectionId: 'b'.repeat(64),
+        senderId: sending ? 'peer:local' : 'peer:remote',
+        recipientId: sending ? 'peer:remote' : 'peer:local',
+        slot: definition.slot, codec: definition.codec, kind: definition.kind, keyEpoch: 7,
+        contractExpiresAtMs: 2_000_000_000_000,
+      },
+    });
+  }
+  return entries;
+}
+
+async function settle(turns = 3): Promise<void> {
+  for (let index = 0; index < turns; index += 1) await Promise.resolve();
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve(value: T): void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(accept => { resolve = accept; });
+  return { promise, resolve };
+}

--- a/frontend-angular/src/app/workers/pair-media-e2ee.worker.ts
+++ b/frontend-angular/src/app/workers/pair-media-e2ee.worker.ts
@@ -1,0 +1,247 @@
+import {
+  PairMediaE2eeFrameCipher,
+  PairMediaE2eeFrameContext,
+} from '../services/pair-media-e2ee-frame-codec';
+
+type TransformOperation = 'encrypt' | 'decrypt';
+
+interface EncodedFrame {
+  data: ArrayBuffer;
+  readonly type?: string;
+}
+
+interface TransformOptions {
+  readonly version: 1;
+  readonly transformId: string;
+  readonly operation: TransformOperation;
+}
+
+interface TransformState extends TransformOptions {
+  key: CryptoKey | null;
+  cipher: PairMediaE2eeFrameCipher | null;
+  failed: boolean;
+}
+
+interface InstallEntry {
+  readonly transformId: string;
+  readonly context: PairMediaE2eeFrameContext;
+  readonly key: CryptoKey;
+}
+
+interface PreparedInstall {
+  readonly state: TransformState;
+  readonly key: CryptoKey;
+  readonly cipher: PairMediaE2eeFrameCipher;
+}
+
+interface WorkerTransformEvent {
+  readonly transformer: {
+    readonly options: unknown;
+    readonly readable: ReadableStream<EncodedFrame>;
+    readonly writable: WritableStream<EncodedFrame>;
+  };
+}
+
+interface EncodedTransformWorkerScope {
+  onrtctransform: ((event: WorkerTransformEvent) => void) | null;
+  onmessage: ((event: MessageEvent<unknown>) => void) | null;
+  postMessage(message: unknown): void;
+}
+
+const workerScope = globalThis as unknown as EncodedTransformWorkerScope;
+const transforms = new Map<string, TransformState>();
+let installedOnce = false;
+let poisoned = false;
+
+workerScope.onrtctransform = event => {
+  let options: TransformOptions;
+  try {
+    if (poisoned) throw new Error('media_e2ee_worker_poisoned');
+    options = parseTransformOptions(event.transformer.options);
+    if (transforms.has(options.transformId)) throw new Error('media_e2ee_transform_duplicate');
+  } catch (error) {
+    postFatal('', reason(error, 'media_e2ee_transform_options_invalid'));
+    return;
+  }
+  const state: TransformState = { ...options, key: null, cipher: null, failed: false };
+  transforms.set(options.transformId, state);
+  const transform = new TransformStream<EncodedFrame, EncodedFrame>({
+    transform: async (frame, controller) => {
+      // DROP-first: not one encoded byte leaves the transform before a
+      // direction/slot/connection key is installed and acknowledged.
+      if (!state.key || !state.cipher || state.failed) return;
+      try {
+        const key = state.key;
+        const cipher = state.cipher;
+        const frameType = frame.type ?? (cipher.context.kind === 'audio' ? 'audio' : 'delta');
+        const transformed = state.operation === 'encrypt'
+          ? await cipher.seal(key, copyBuffer(frame.data), frameType)
+          : await cipher.open(key, copyBuffer(frame.data), frameType);
+        // Another slot can poison the worker while WebCrypto is in flight.
+        // Recheck the global and exact local generation before publication.
+        if (poisoned || state.failed || state.key !== key || state.cipher !== cipher) return;
+        frame.data = transformed;
+        controller.enqueue(frame);
+      } catch (error) {
+        state.failed = true;
+        postFatal(state.transformId, reason(error, 'media_e2ee_transform_failed'));
+        throw error;
+      }
+    },
+  });
+  event.transformer.readable
+    .pipeThrough(transform)
+    .pipeTo(event.transformer.writable)
+    .catch(error => {
+      if (state.failed) return;
+      state.failed = true;
+      postFatal(state.transformId, reason(error, 'media_e2ee_pipeline_failed'));
+    });
+  workerScope.postMessage({ version: 1, type: 'transform-ready', transformId: state.transformId });
+};
+
+workerScope.onmessage = event => {
+  try {
+    const message = parseWorkerMessage(event.data);
+    if (message.type === 'install-keys') {
+      // Validate and construct the complete six-transform key set before
+      // mutating any live transform. A bad final entry cannot partially open
+      // earlier DROP-first slots.
+      if (installedOnce) throw new Error('media_e2ee_key_reinstall_forbidden');
+      const ids = new Set(message.entries.map(entry => entry.transformId));
+      if (
+        ids.size !== message.entries.length
+        || transforms.size !== message.entries.length
+        || [...transforms.keys()].some(transformId => !ids.has(transformId))
+      ) throw new Error('media_e2ee_key_set_invalid');
+      const prepared = message.entries.map(entry => prepareInstall(entry));
+      // One-shot before the first mutation. Even an unexpected commit error
+      // cannot make the worker reusable with reset counters under this key.
+      installedOnce = true;
+      for (const install of prepared) commitInstall(install);
+      workerScope.postMessage({
+        version: 1,
+        type: 'keys-installed',
+        sessionId: message.sessionId,
+        transformIds: message.entries.map(entry => entry.transformId),
+      });
+      return;
+    }
+    if (message.type === 'clear-keys') {
+      for (const state of transforms.values()) {
+        state.key = null;
+        state.cipher?.clear();
+        state.cipher = null;
+      }
+      workerScope.postMessage({ version: 1, type: 'keys-cleared', sessionId: message.sessionId });
+    }
+  } catch (error) {
+    postFatal('', reason(error, 'media_e2ee_worker_message_invalid'));
+  }
+};
+
+function prepareInstall(entry: InstallEntry): PreparedInstall {
+  const state = transforms.get(entry.transformId);
+  if (!state || state.failed) throw new Error('media_e2ee_transform_missing');
+  validateKey(entry.key);
+  const cipher = new PairMediaE2eeFrameCipher(entry.context);
+  if (cipher.context.senderId === cipher.context.recipientId) {
+    throw new Error('media_e2ee_transform_direction_invalid');
+  }
+  return { state, key: entry.key, cipher };
+}
+
+function commitInstall(value: PreparedInstall): void {
+  value.state.cipher?.clear();
+  value.state.key = value.key;
+  value.state.cipher = value.cipher;
+}
+
+function parseTransformOptions(raw: unknown): TransformOptions {
+  const value = closedObject(raw, ['version', 'transformId', 'operation']);
+  if (
+    value['version'] !== 1
+    || (value['operation'] !== 'encrypt' && value['operation'] !== 'decrypt')
+    || typeof value['transformId'] !== 'string'
+    || !/^[A-Za-z0-9][A-Za-z0-9._:@-]{0,127}$/.test(value['transformId'])
+  ) throw new Error('media_e2ee_transform_options_invalid');
+  return value as unknown as TransformOptions;
+}
+
+function parseWorkerMessage(raw: unknown):
+  | { type: 'install-keys'; sessionId: string; entries: InstallEntry[] }
+  | { type: 'clear-keys'; sessionId: string } {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error('media_e2ee_worker_message_invalid');
+  }
+  const value = raw as Record<string, unknown>;
+  if (value['version'] !== 1 || typeof value['sessionId'] !== 'string') {
+    throw new Error('media_e2ee_worker_message_invalid');
+  }
+  if (value['type'] === 'clear-keys') {
+    closedObject(value, ['version', 'type', 'sessionId']);
+    return { type: 'clear-keys', sessionId: value['sessionId'] };
+  }
+  if (value['type'] !== 'install-keys') throw new Error('media_e2ee_worker_message_invalid');
+  closedObject(value, ['version', 'type', 'sessionId', 'entries']);
+  if (!Array.isArray(value['entries']) || value['entries'].length !== 6) {
+    throw new Error('media_e2ee_worker_message_invalid');
+  }
+  const entries = value['entries'].map(item => {
+    const entry = closedObject(item, ['transformId', 'context', 'key']);
+    if (typeof entry['transformId'] !== 'string') throw new Error('media_e2ee_worker_message_invalid');
+    return entry as unknown as InstallEntry;
+  });
+  return { type: 'install-keys', sessionId: value['sessionId'], entries };
+}
+
+function closedObject(raw: unknown, fields: readonly string[]): Record<string, unknown> {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error('media_e2ee_worker_message_invalid');
+  }
+  const value = raw as Record<string, unknown>;
+  const keys = Object.keys(value);
+  if (keys.length !== fields.length || fields.some(field => !(field in value))) {
+    throw new Error('media_e2ee_worker_message_invalid');
+  }
+  return value;
+}
+
+function validateKey(value: CryptoKey): void {
+  if (
+    !value
+    || value.type !== 'secret'
+    || value.algorithm.name !== 'AES-GCM'
+    || value.extractable
+    || !value.usages.includes('encrypt')
+    || !value.usages.includes('decrypt')
+  ) throw new Error('media_e2ee_key_invalid');
+}
+
+function copyBuffer(value: ArrayBuffer): ArrayBuffer {
+  if (Object.prototype.toString.call(value) !== '[object ArrayBuffer]') {
+    throw new Error('media_e2ee_frame_size_invalid');
+  }
+  return value.slice(0);
+}
+
+function postFatal(transformId: string, reasonCode: string): void {
+  if (poisoned) return;
+  poisoned = true;
+  // Worker-global fail boundary: one authenticated-frame failure closes all
+  // slots synchronously, before the main thread receives the fatal event.
+  for (const state of transforms.values()) {
+    state.failed = true;
+    state.key = null;
+    state.cipher?.clear();
+    state.cipher = null;
+  }
+  workerScope.postMessage({ version: 1, type: 'fatal', transformId, reasonCode });
+}
+
+function reason(error: unknown, fallback: string): string {
+  return error instanceof Error && /^media_e2ee_[a-z0-9_]{2,96}$/.test(error.message)
+    ? error.message : fallback;
+}
+
+export {};

--- a/public-rendezvous/rendezvous/app.py
+++ b/public-rendezvous/rendezvous/app.py
@@ -170,6 +170,7 @@ def info():
             "turn_urls": cfg.TURN_URLS,
             "session_max_minutes": cfg.SESSION_MAX_DURATION_SECONDS // 60,
             "supported_identity_binding_versions": [1, 2],
+            "supported_public_media_e2ee_versions": [1],
         }
     ), 200
 
@@ -198,6 +199,8 @@ def create_session():
             "owner_device_id",
             "owner_device_fingerprint",
             "identity_binding_version",
+            "public_media_e2ee_version",
+            "public_media_capabilities",
         }
     )
     if body_error:
@@ -217,6 +220,15 @@ def create_session():
         or identity_binding_version not in {1, 2}
     ):
         return jsonify({"error": "identity_binding_version_unsupported"}), 400
+    try:
+        public_media_e2ee_version = svc.normalize_public_media_advertisement(
+            body.get("public_media_e2ee_version"),
+            body.get("public_media_capabilities"),
+        )
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
+    if public_media_e2ee_version and identity_binding_version != 2:
+        return jsonify({"error": "public_media_identity_binding_v2_required"}), 400
     device_fp = str(body.get("owner_device_fingerprint") or "").strip()
     device_id = str(body.get("owner_device_id") or "").strip()
     public_key = str(body.get("public_key_spki_b64") or "").strip()
@@ -231,6 +243,7 @@ def create_session():
             account_id=ctx.account_id,
             device_fingerprint=device_fp,
             membership_capability=membership_capability,
+            public_media_e2ee_version=public_media_e2ee_version,
         )
     if not is_recovery and not svc._rate_check(
         "create",
@@ -259,6 +272,8 @@ def create_session():
             requested_expires_at=requested_expires_at,
             identity_binding_version=identity_binding_version,
             membership_capability=membership_capability,
+            public_media_e2ee_version=public_media_e2ee_version,
+            public_media_capabilities=body.get("public_media_capabilities"),
         )
     except ValueError as exc:
         return jsonify({"error": str(exc)}), 400
@@ -326,6 +341,8 @@ def _join_session_by_invite(*, expected_session_id: str):
             "device_id",
             "device_fingerprint",
             "identity_binding_version",
+            "public_media_e2ee_version",
+            "public_media_capabilities",
         }
     )
     if body_error:
@@ -340,6 +357,15 @@ def _join_session_by_invite(*, expected_session_id: str):
         or expected_identity_binding_version not in {1, 2}
     ):
         return jsonify({"error": "identity_binding_version_unsupported"}), 400
+    try:
+        public_media_e2ee_version = svc.normalize_public_media_advertisement(
+            body.get("public_media_e2ee_version"),
+            body.get("public_media_capabilities"),
+        )
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
+    if public_media_e2ee_version and expected_identity_binding_version != 2:
+        return jsonify({"error": "public_media_identity_binding_v2_required"}), 400
     invite_code = str(body.get("invite_code") or "").strip()
     membership_capability = _membership_capability()
     is_recovery = False
@@ -351,6 +377,7 @@ def _join_session_by_invite(*, expected_session_id: str):
             account_id=ctx.account_id,
             device_fingerprint=str(body.get("device_fingerprint") or "").strip(),
             membership_capability=membership_capability,
+            public_media_e2ee_version=public_media_e2ee_version,
         )
     # OIDC account identity, never forwarding headers, owns the abuse bucket.
     if not is_recovery and not svc._rate_check(
@@ -373,6 +400,8 @@ def _join_session_by_invite(*, expected_session_id: str):
         expected_session_id=expected_session_id,
         membership_capability=membership_capability,
         expected_identity_binding_version=expected_identity_binding_version,
+        public_media_e2ee_version=public_media_e2ee_version,
+        public_media_capabilities=body.get("public_media_capabilities"),
     )
     if not result.get("ok"):
         reason = result["reason"]

--- a/public-rendezvous/rendezvous/pair_security.py
+++ b/public-rendezvous/rendezvous/pair_security.py
@@ -2,8 +2,8 @@
 
 The service authenticates membership and device public keys.  It never sees
 the derived ECDH secret or encrypted application payloads. Public audio/video
-publication remains disabled until the Pair key is wired to browser media
-insertable-stream transforms.
+remains disabled unless both peers negotiate the separately signed media-v1
+contract and enforce it through browser encoded-media transforms.
 """
 
 from __future__ import annotations
@@ -20,6 +20,60 @@ from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 TENANT_ID = "public-ananta"
+PUBLIC_MEDIA_E2EE_VERSION = 1
+PUBLIC_MEDIA_TRANSFORM = "RTCRtpScriptTransform"
+PUBLIC_MEDIA_GRANTS = (
+    "microphone-opus",
+    "camera-vp8",
+    "screen-vp8",
+)
+PUBLIC_MEDIA_SLOTS = (
+    {"slot": "microphone-opus", "kind": "audio", "codec": "opus"},
+    {"slot": "camera-vp8", "kind": "video", "codec": "vp8"},
+    {"slot": "screen-vp8", "kind": "video", "codec": "vp8"},
+)
+
+
+def public_media_capabilities_v1() -> dict[str, Any]:
+    """Return the one closed capability advertisement supported by v1."""
+    return {
+        "version": PUBLIC_MEDIA_E2EE_VERSION,
+        "transform": PUBLIC_MEDIA_TRANSFORM,
+        "grants": list(PUBLIC_MEDIA_GRANTS),
+    }
+
+
+def normalize_public_media_advertisement(version: Any, capabilities: Any) -> int:
+    """Validate an optional, fail-closed Public Pair media advertisement.
+
+    Version zero is the backward-compatible data-only state. Version one is
+    accepted only together with the complete closed capability object, so a
+    partial or future-shaped request can never accidentally broaden a grant.
+    """
+    normalized_version = 0 if version is None else version
+    if (
+        isinstance(normalized_version, bool)
+        or not isinstance(normalized_version, int)
+        or normalized_version not in {0, PUBLIC_MEDIA_E2EE_VERSION}
+    ):
+        raise ValueError("public_media_e2ee_version_unsupported")
+    if normalized_version == 0:
+        if capabilities is not None:
+            raise ValueError("public_media_capabilities_without_version")
+        return 0
+    if (
+        not isinstance(capabilities, dict)
+        or set(capabilities) != {"version", "transform", "grants"}
+        or type(capabilities.get("version")) is not int
+        or capabilities.get("version") != PUBLIC_MEDIA_E2EE_VERSION
+        or type(capabilities.get("transform")) is not str
+        or capabilities.get("transform") != PUBLIC_MEDIA_TRANSFORM
+        or not isinstance(capabilities.get("grants"), list)
+        or any(type(grant) is not str for grant in capabilities["grants"])
+        or capabilities["grants"] != list(PUBLIC_MEDIA_GRANTS)
+    ):
+        raise ValueError("public_media_capabilities_invalid")
+    return PUBLIC_MEDIA_E2EE_VERSION
 
 
 def canonical(value: Any) -> bytes:
@@ -107,6 +161,53 @@ class PairSecurityAuthority:
             "digest": digest,
             "signature": signature,
             "signature_algorithm": "HMAC-SHA256",
+        }
+
+    def public_media_contract(
+        self,
+        *,
+        session: dict[str, Any],
+        owner: dict[str, Any],
+        guest: dict[str, Any],
+        base_security_contract_digest: str,
+    ) -> dict[str, Any]:
+        """Issue the stable, separately signed Public Pair media contract."""
+        unsigned = {
+            "domain": "ananta.public-pair.media-security-contract.v1",
+            "version": PUBLIC_MEDIA_E2EE_VERSION,
+            "session_id": session["id"],
+            "epoch": int(session["security_epoch"]),
+            "identity_binding_version": 2,
+            "base_security_contract_digest": base_security_contract_digest,
+            "memberships": [
+                {
+                    "membership_id": member["membership_id"],
+                    "membership_version": int(member["membership_version"]),
+                    "peer_id": member["peer_id"],
+                    "device_key_fingerprint": member["fingerprint"],
+                    "public_media_e2ee_version": int(member["public_media_e2ee_version"]),
+                }
+                for member in (owner, guest)
+            ],
+            "grants": list(PUBLIC_MEDIA_GRANTS),
+            "slots": [dict(slot) for slot in PUBLIC_MEDIA_SLOTS],
+            "transform": PUBLIC_MEDIA_TRANSFORM,
+            "algorithms": {
+                "aead": "AES-256-GCM",
+                "kdf": "HKDF-SHA-256",
+            },
+            "expires_at_ms": int(float(session["expires_at"]) * 1000),
+            "authority_key_id": self.key_id,
+        }
+        digest = hashlib.sha256(canonical(unsigned)).hexdigest()
+        signed = {
+            **unsigned,
+            "digest": digest,
+            "signature_algorithm": "Ed25519",
+        }
+        return {
+            **signed,
+            "signature_b64": base64.b64encode(self._private_key.sign(canonical(signed))).decode("ascii"),
         }
 
     def key_package(

--- a/public-rendezvous/rendezvous/service.py
+++ b/public-rendezvous/rendezvous/service.py
@@ -20,7 +20,14 @@ from collections import defaultdict
 from contextlib import contextmanager
 from typing import Any
 
-from pair_security import TENANT_ID, PairSecurityAuthority, spki_fingerprint
+from pair_security import (
+    PUBLIC_MEDIA_E2EE_VERSION,
+    TENANT_ID,
+    PairSecurityAuthority,
+    normalize_public_media_advertisement,
+    public_media_capabilities_v1,
+    spki_fingerprint,
+)
 from peer_identity import (
     canonical_device_peer_id,
     is_canonical_account_id,
@@ -83,6 +90,7 @@ def _owner_create_request_digest(
     title: str,
     permissions: dict[str, bool],
     requested_expires_at: float | None,
+    public_media_e2ee_version: int,
 ) -> str:
     payload = {
         "account_id": account_id,
@@ -97,6 +105,12 @@ def _owner_create_request_digest(
         "subject_hash": subject_hash,
         "title": title,
     }
+    # Preserve the byte-for-byte v2 digest for pre-media clients and already
+    # persisted idempotency records. The media fields are bound only when the
+    # owner explicitly opts into the closed v1 capability set.
+    if public_media_e2ee_version == PUBLIC_MEDIA_E2EE_VERSION:
+        payload["public_media_e2ee_version"] = public_media_e2ee_version
+        payload["public_media_capabilities"] = public_media_capabilities_v1()
     material = b"ananta.public-rendezvous.owner-create-request.v2\0" + json.dumps(
         payload,
         sort_keys=True,
@@ -167,10 +181,12 @@ def _migrate_database(conn: sqlite3.Connection) -> None:
         _add_column(conn, "sessions", "owner_membership_capability_hash TEXT NOT NULL DEFAULT ''")
         _add_column(conn, "sessions", "owner_capability_lookup_hash TEXT NOT NULL DEFAULT ''")
         _add_column(conn, "sessions", "owner_create_request_hash TEXT NOT NULL DEFAULT ''")
+        _add_column(conn, "sessions", "public_media_e2ee_version INTEGER NOT NULL DEFAULT 0")
         _add_column(conn, "participants", "public_key_spki_b64 TEXT NOT NULL DEFAULT ''")
         _add_column(conn, "participants", "account_id TEXT NOT NULL DEFAULT ''")
         _add_column(conn, "participants", "peer_id TEXT NOT NULL DEFAULT ''")
         _add_column(conn, "participants", "membership_capability_hash TEXT NOT NULL DEFAULT ''")
+        _add_column(conn, "participants", "public_media_e2ee_version INTEGER NOT NULL DEFAULT 0")
         _add_column(conn, "signals", "sequence INTEGER NOT NULL DEFAULT 0")
         _add_column(conn, "key_confirmations", "expires_at REAL NOT NULL DEFAULT 0")
         _backfill_v1_identity_columns(conn)
@@ -358,6 +374,12 @@ def _row_to_session(row: sqlite3.Row) -> dict[str, Any]:
         "security_epoch": row["security_epoch"],
         "security_contract_version": row["security_contract_version"],
         "identity_binding_version": row["identity_binding_version"],
+        "public_media_e2ee_version": row["public_media_e2ee_version"],
+        "public_media_capabilities": (
+            public_media_capabilities_v1()
+            if int(row["public_media_e2ee_version"] or 0) == PUBLIC_MEDIA_E2EE_VERSION
+            else None
+        ),
         "security_mode": row["security_mode"],
         "mode": "p2p",
         "transport": "webrtc",
@@ -377,7 +399,7 @@ def _list_participants(
         SELECT id, session_id, user_id, user_sub_hash, device_id,
                device_fingerprint, public_key_spki_b64, permissions,
                joined_at, last_seen, revoked_at, account_id, peer_id,
-               membership_capability_hash
+               membership_capability_hash, public_media_e2ee_version
         FROM participants
         WHERE session_id = ? {where_clause}
         ORDER BY joined_at ASC
@@ -402,6 +424,12 @@ def _list_participants(
                 "account_id": row["account_id"],
                 "peer_id": row["peer_id"],
                 "_membership_capability_hash": row["membership_capability_hash"],
+                "public_media_e2ee_version": row["public_media_e2ee_version"],
+                "public_media_capabilities": (
+                    public_media_capabilities_v1()
+                    if int(row["public_media_e2ee_version"] or 0) == PUBLIC_MEDIA_E2EE_VERSION
+                    else None
+                ),
             }
         )
     return out
@@ -526,6 +554,8 @@ def create_session(
     requested_expires_at: float | None = None,
     identity_binding_version: int = 1,
     membership_capability: str = "",
+    public_media_e2ee_version: int | None = None,
+    public_media_capabilities: Any = None,
 ) -> dict[str, Any]:
     _ensure_db_initialized()
     _cleanup_expired()
@@ -538,6 +568,12 @@ def create_session(
         raise ValueError("oidc_identity_required")
     if identity_binding_version not in {1, 2}:
         raise ValueError("identity_binding_version_unsupported")
+    normalized_media_version = normalize_public_media_advertisement(
+        public_media_e2ee_version,
+        public_media_capabilities,
+    )
+    if normalized_media_version and identity_binding_version != 2:
+        raise ValueError("public_media_identity_binding_v2_required")
     membership_capability = str(membership_capability or "").strip()
     if identity_binding_version == 2:
         if not membership_capability:
@@ -598,6 +634,7 @@ def create_session(
             title=normalized_title,
             permissions=perms,
             requested_expires_at=(float(requested_expires_at) if requested_expires_at is not None else None),
+            public_media_e2ee_version=normalized_media_version,
         )
         if identity_binding_version == 2
         else ""
@@ -649,6 +686,7 @@ def create_session(
                                 create_request_hash,
                             )
                             and int(existing.get("identity_binding_version") or 0) == 2
+                            and int(existing.get("public_media_e2ee_version") or 0) == normalized_media_version
                             and secrets.compare_digest(
                                 str(existing.get("_owner_membership_capability_hash") or ""),
                                 expected_hash,
@@ -669,8 +707,9 @@ def create_session(
                         owner_device_id, owner_public_key_spki_b64, security_epoch,
                         security_mode, security_contract_version, identity_binding_version,
                         owner_account_id, owner_peer_id, owner_membership_capability_hash,
-                        owner_capability_lookup_hash, owner_create_request_hash
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?)
+                        owner_capability_lookup_hash, owner_create_request_hash,
+                        public_media_e2ee_version
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         sid,
@@ -693,6 +732,7 @@ def create_session(
                         capability_hash,
                         capability_lookup_hash,
                         create_request_hash,
+                        normalized_media_version,
                     ),
                 )
                 conn.execute("COMMIT")
@@ -776,6 +816,7 @@ def is_owner_create_recovery(
     account_id: str,
     device_fingerprint: str,
     membership_capability: str,
+    public_media_e2ee_version: int = 0,
 ) -> bool:
     """Recognize a v2 create retry so rate limiting does not orphan it."""
     try:
@@ -790,7 +831,7 @@ def is_owner_create_recovery(
     _ensure_db_initialized()
     with _db() as conn:
         row = conn.execute(
-            """SELECT id, owner_membership_capability_hash
+            """SELECT id, owner_membership_capability_hash, public_media_e2ee_version
                FROM sessions
                WHERE owner_capability_lookup_hash = ?
                  AND owner_account_id = ?
@@ -801,6 +842,8 @@ def is_owner_create_recovery(
             (lookup_hash, account_id, peer_id, _now()),
         ).fetchone()
         if not row:
+            return False
+        if int(row["public_media_e2ee_version"] or 0) != public_media_e2ee_version:
             return False
         expected_hash = membership_capability_digest(
             str(row["id"]),
@@ -820,6 +863,7 @@ def is_join_recovery(
     account_id: str,
     device_fingerprint: str,
     membership_capability: str,
+    public_media_e2ee_version: int = 0,
 ) -> bool:
     """Recognize an already committed v2 join using its original capability."""
     try:
@@ -829,7 +873,8 @@ def is_join_recovery(
     _ensure_db_initialized()
     with _db() as conn:
         row = conn.execute(
-            """SELECT p.session_id, p.membership_capability_hash
+            """SELECT p.session_id, p.membership_capability_hash,
+                      p.public_media_e2ee_version
                FROM participants p
                JOIN sessions s ON s.id = p.session_id
                WHERE s.invite_code = ?
@@ -843,6 +888,8 @@ def is_join_recovery(
             (str(invite_code or "").strip().upper(), _now(), account_id, peer_id),
         ).fetchone()
         if not row:
+            return False
+        if int(row["public_media_e2ee_version"] or 0) != public_media_e2ee_version:
             return False
         try:
             expected_hash = membership_capability_digest(
@@ -871,6 +918,8 @@ def join_session(
     expected_session_id: str = "",
     membership_capability: str = "",
     expected_identity_binding_version: int | None = None,
+    public_media_e2ee_version: int | None = None,
+    public_media_capabilities: Any = None,
 ) -> dict[str, Any]:
     _ensure_db_initialized()
     _cleanup_expired()
@@ -884,6 +933,15 @@ def join_session(
     negotiated_identity_binding_version = (
         1 if expected_identity_binding_version is None else expected_identity_binding_version
     )
+    try:
+        normalized_media_version = normalize_public_media_advertisement(
+            public_media_e2ee_version,
+            public_media_capabilities,
+        )
+    except ValueError as exc:
+        return {"ok": False, "reason": str(exc)}
+    if normalized_media_version and negotiated_identity_binding_version != 2:
+        return {"ok": False, "reason": "public_media_identity_binding_v2_required"}
     if not is_canonical_account_id(user_id) or not user_sub or not oidc_issuer:
         return {"ok": False, "reason": "oidc_identity_required"}
     if not device_id or not device_fingerprint or not public_key_spki_b64:
@@ -950,7 +1008,7 @@ def join_session(
             SELECT id, session_id, user_id, user_sub_hash, device_id,
                    device_fingerprint, public_key_spki_b64, permissions,
                    joined_at, last_seen, revoked_at, account_id, peer_id,
-                   membership_capability_hash
+                   membership_capability_hash, public_media_e2ee_version
             FROM participants
             WHERE session_id = ?
               AND ((? = 2 AND peer_id = ?) OR (? = 1 AND user_id = ? AND device_id = ?))
@@ -990,6 +1048,9 @@ def join_session(
                 ):
                     conn.execute("ROLLBACK")
                     return {"ok": False, "reason": "membership_capability_invalid"}
+            if int(existing["public_media_e2ee_version"] or 0) != normalized_media_version:
+                conn.execute("ROLLBACK")
+                return {"ok": False, "reason": "public_media_capability_conflict"}
             participant = {
                 "id": existing["id"],
                 "session_id": existing["session_id"],
@@ -1004,6 +1065,12 @@ def join_session(
                 "public_key_spki_b64": existing["public_key_spki_b64"],
                 "account_id": existing["account_id"] or existing["user_id"],
                 "peer_id": existing["peer_id"] or existing["user_id"],
+                "public_media_e2ee_version": int(existing["public_media_e2ee_version"] or 0),
+                "public_media_capabilities": (
+                    public_media_capabilities_v1()
+                    if int(existing["public_media_e2ee_version"] or 0) == PUBLIC_MEDIA_E2EE_VERSION
+                    else None
+                ),
             }
             conn.execute("COMMIT")
             return {
@@ -1035,6 +1102,10 @@ def join_session(
             "public_key_spki_b64": public_key_spki_b64,
             "account_id": user_id,
             "peer_id": peer_id,
+            "public_media_e2ee_version": normalized_media_version,
+            "public_media_capabilities": (
+                public_media_capabilities_v1() if normalized_media_version == PUBLIC_MEDIA_E2EE_VERSION else None
+            ),
         }
         if identity_binding_version == 2:
             if not membership_capability:
@@ -1050,8 +1121,9 @@ def join_session(
             INSERT INTO participants (
                 id, session_id, user_id, user_sub_hash, device_id, device_fingerprint,
                 public_key_spki_b64, permissions, joined_at, last_seen, revoked_at,
-                account_id, peer_id, membership_capability_hash
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?)
+                account_id, peer_id, membership_capability_hash,
+                public_media_e2ee_version
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?)
             """,
             (
                 participant["id"],
@@ -1067,6 +1139,7 @@ def join_session(
                 participant["account_id"],
                 participant["peer_id"],
                 capability_hash,
+                normalized_media_version,
             ),
         )
         conn.execute("UPDATE sessions SET security_epoch = security_epoch + 1 WHERE id = ?", (sid,))
@@ -1156,6 +1229,8 @@ def get_participants(
                 "last_seen": _now(),
                 "last_seen_at": _now(),
                 "revoked_at": session.get("revoked_at"),
+                "public_media_e2ee_version": int(session.get("public_media_e2ee_version") or 0),
+                "public_media_capabilities": session.get("public_media_capabilities"),
             }
         ] + [
             {
@@ -1172,6 +1247,8 @@ def get_participants(
                 "last_seen": p.get("last_seen"),
                 "last_seen_at": p.get("last_seen"),
                 "revoked_at": p.get("revoked_at"),
+                "public_media_e2ee_version": int(p.get("public_media_e2ee_version") or 0),
+                "public_media_capabilities": p.get("public_media_capabilities"),
             }
             for p in _list_participants(conn, session_id, include_revoked=True)
         ]
@@ -1234,6 +1311,7 @@ def _memberships(conn: sqlite3.Connection, session: dict[str, Any]) -> list[dict
         "fingerprint": session["owner_device_fingerprint"],
         "public_key_spki_b64": session["owner_public_key_spki_b64"],
         "_membership_capability_hash": session.get("_owner_membership_capability_hash") or "",
+        "public_media_e2ee_version": int(session.get("public_media_e2ee_version") or 0),
         "owner": True,
     }
     members = [owner]
@@ -1250,6 +1328,7 @@ def _memberships(conn: sqlite3.Connection, session: dict[str, Any]) -> list[dict
                 "fingerprint": participant["device_fingerprint"],
                 "public_key_spki_b64": participant["public_key_spki_b64"],
                 "_membership_capability_hash": participant.get("_membership_capability_hash") or "",
+                "public_media_e2ee_version": int(participant.get("public_media_e2ee_version") or 0),
                 "owner": False,
             }
         )
@@ -1411,6 +1490,28 @@ def _strict_pair_material(
     return members, authority, authority.contract(session, owner, guest)
 
 
+def _public_media_contract_v1(
+    *,
+    session: dict[str, Any],
+    members: list[dict[str, Any]],
+    authority: PairSecurityAuthority,
+    base_contract: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Negotiate media only for an exact v2 pair with two v1 adverts."""
+    if int(session.get("identity_binding_version") or 0) != 2 or len(members) != 2:
+        return None
+    if any(int(member.get("public_media_e2ee_version") or 0) != PUBLIC_MEDIA_E2EE_VERSION for member in members):
+        return None
+    owner = next(member for member in members if member["owner"])
+    guest = next(member for member in members if not member["owner"])
+    return authority.public_media_contract(
+        session=session,
+        owner=owner,
+        guest=guest,
+        base_security_contract_digest=str(base_contract["digest"]),
+    )
+
+
 def _expected_key_package(
     *,
     members: list[dict[str, Any]],
@@ -1469,6 +1570,7 @@ def get_key_packages(
                 "tenant_id": TENANT_ID,
                 "security_contract_digest": None,
                 "security_contract": None,
+                "public_media_security_contract_v1": None,
                 "hub_key_id": authority.key_id,
                 "hub_public_key_b64": authority.public_key_b64,
                 "packages": [],
@@ -1496,12 +1598,19 @@ def get_key_packages(
             sender_peer_id=remote["peer_id"],
             recipient_peer_id=requester["peer_id"],
         )
+        public_media_contract = _public_media_contract_v1(
+            session=session,
+            members=members,
+            authority=authority,
+            base_contract=contract,
+        )
         return {
             "ok": True,
             "epoch": session["security_epoch"],
             "tenant_id": TENANT_ID,
             "security_contract_digest": contract["digest"],
             "security_contract": contract,
+            "public_media_security_contract_v1": public_media_contract,
             "hub_key_id": authority.key_id,
             "hub_public_key_b64": authority.public_key_b64,
             "packages": [package],

--- a/tests/contracts/test_public_rendezvous_compose.py
+++ b/tests/contracts/test_public_rendezvous_compose.py
@@ -128,11 +128,14 @@ def test_public_tui_client_explicitly_allows_pair_dev_origins():
         assert setup.count(redirect_uri) == 2
 
 
-def test_local_https_edge_pins_the_supported_public_oidc_issuer():
+def test_local_https_edge_pins_the_supported_public_authorities():
     nginx = NGINX_CONFIG.read_text(encoding="utf-8")
     csp = next(line for line in nginx.splitlines() if "Content-Security-Policy" in line)
 
-    assert "connect-src 'self' https://keycloak.ananta.de ws: wss:;" in csp
+    assert (
+        "connect-src 'self' https://keycloak.ananta.de "
+        "https://webrtc.ananta.de ws: wss:;"
+    ) in csp
     assert "connect-src 'self' https: " not in csp
 
 

--- a/tests/contracts/test_public_rendezvous_image.py
+++ b/tests/contracts/test_public_rendezvous_image.py
@@ -104,6 +104,9 @@ response = client.get('/health', headers={'Origin': 'https://localhost'})
 assert response.status_code == 200
 assert response.get_json() == {'ok': True, 'service': 'ananta-rendezvous'}
 assert response.headers['Access-Control-Allow-Origin'] == 'https://localhost'
+info = client.get('/info')
+assert info.status_code == 200
+assert info.get_json()['supported_public_media_e2ee_versions'] == [1]
 preflight = client.options('/rendezvous/sessions', headers={
     'Origin': 'http://localhost:4200',
     'Access-Control-Request-Method': 'GET',

--- a/tests/test_public_rendezvous_service_contract.py
+++ b/tests/test_public_rendezvous_service_contract.py
@@ -308,7 +308,8 @@ def test_v2_same_account_pair_is_device_addressed_and_capability_isolated(public
     assert wrong_device["local_peer_id"] is None
     assert set(unselected["local_peer_ids"]) == {owner_peer_id, guest_peer_id}
     assert guest_selected["local_peer_id"] == guest_peer_id
-    assert "capability" not in json.dumps(unselected)
+    assert owner_capability not in json.dumps(unselected)
+    assert guest_capability not in json.dumps(unselected)
     with public_service._db() as conn:
         stored_session = conn.execute(
             """SELECT owner_membership_capability_hash,
@@ -502,6 +503,228 @@ def test_v2_create_and_join_retries_require_the_original_capability(public_servi
     )
     with pytest.raises(ValueError, match="membership_capability_retired"):
         public_service.create_session(**create_kwargs)
+
+
+def test_public_media_v1_requires_the_exact_closed_capability_advertisement(public_service):
+    base_kwargs = {
+        "subject": "media-owner-sub",
+        "identity_binding_version": 2,
+        "membership_capability": "M" * 43,
+    }
+    exact = _public_media_capabilities_v1()
+
+    session = _create_session(
+        public_service,
+        **base_kwargs,
+        public_media_e2ee_version=1,
+        public_media_capabilities=exact,
+    )
+
+    assert session["public_media_e2ee_version"] == 1
+    assert session["public_media_capabilities"] == exact
+    with pytest.raises(ValueError, match="public_media_capabilities_without_version"):
+        _create_session(
+            public_service,
+            **{**base_kwargs, "membership_capability": "N" * 43},
+            public_media_capabilities=exact,
+        )
+    with pytest.raises(ValueError, match="public_media_capabilities_invalid"):
+        _create_session(
+            public_service,
+            **{**base_kwargs, "membership_capability": "P" * 43},
+            public_media_e2ee_version=1,
+            public_media_capabilities={**exact, "grants": list(reversed(exact["grants"]))},
+        )
+    with pytest.raises(ValueError, match="public_media_capabilities_invalid"):
+        _create_session(
+            public_service,
+            **{**base_kwargs, "membership_capability": "Q" * 43},
+            public_media_e2ee_version=1,
+            public_media_capabilities={**exact, "future": True},
+        )
+    with pytest.raises(ValueError, match="public_media_capabilities_invalid"):
+        _create_session(
+            public_service,
+            **{**base_kwargs, "membership_capability": "T" * 43},
+            public_media_e2ee_version=1,
+            public_media_capabilities={**exact, "version": True},
+        )
+    with pytest.raises(ValueError, match="public_media_capabilities_invalid"):
+        _create_session(
+            public_service,
+            **{**base_kwargs, "membership_capability": "V" * 43},
+            public_media_e2ee_version=1,
+            public_media_capabilities={
+                **exact,
+                "grants": ["microphone-opus", "camera-vp8", "camera-vp8"],
+            },
+        )
+    with pytest.raises(ValueError, match="public_media_e2ee_version_unsupported"):
+        _create_session(
+            public_service,
+            **{**base_kwargs, "membership_capability": "U" * 43},
+            public_media_e2ee_version=True,
+            public_media_capabilities=exact,
+        )
+    with pytest.raises(ValueError, match="public_media_identity_binding_v2_required"):
+        _create_session(
+            public_service,
+            subject="media-v1-owner-sub",
+            public_media_e2ee_version=1,
+            public_media_capabilities=exact,
+        )
+
+
+def test_public_media_v1_contract_is_stable_exact_and_ed25519_signed(public_service):
+    pair = _public_media_pair(public_service, owner_media_version=1, guest_media_version=1)
+    owner_response = pair["owner_packages"]
+    guest_response = pair["guest_packages"]
+    contract = owner_response["public_media_security_contract_v1"]
+
+    assert contract == guest_response["public_media_security_contract_v1"]
+    repeated = public_service.get_key_packages(
+        session_id=pair["session"]["id"],
+        requester_user_id=pair["account_id"],
+        requester_peer_id=pair["owner_peer_id"],
+        membership_capability=pair["owner_capability"],
+    )
+    assert repeated["public_media_security_contract_v1"] == contract
+    assert set(contract) == {
+        "domain",
+        "version",
+        "session_id",
+        "epoch",
+        "identity_binding_version",
+        "base_security_contract_digest",
+        "memberships",
+        "grants",
+        "slots",
+        "transform",
+        "algorithms",
+        "expires_at_ms",
+        "authority_key_id",
+        "digest",
+        "signature_algorithm",
+        "signature_b64",
+    }
+    assert contract["domain"] == "ananta.public-pair.media-security-contract.v1"
+    assert contract["version"] == 1
+    assert contract["session_id"] == pair["session"]["id"]
+    assert contract["epoch"] == 2
+    assert contract["identity_binding_version"] == 2
+    assert contract["base_security_contract_digest"] == owner_response["security_contract_digest"]
+    assert [member["peer_id"] for member in contract["memberships"]] == [
+        pair["owner_peer_id"],
+        pair["guest_peer_id"],
+    ]
+    assert all(
+        set(member)
+        == {
+            "membership_id",
+            "membership_version",
+            "peer_id",
+            "device_key_fingerprint",
+            "public_media_e2ee_version",
+        }
+        for member in contract["memberships"]
+    )
+    assert all(member["public_media_e2ee_version"] == 1 for member in contract["memberships"])
+    assert contract["grants"] == ["microphone-opus", "camera-vp8", "screen-vp8"]
+    assert contract["slots"] == [
+        {"slot": "microphone-opus", "kind": "audio", "codec": "opus"},
+        {"slot": "camera-vp8", "kind": "video", "codec": "vp8"},
+        {"slot": "screen-vp8", "kind": "video", "codec": "vp8"},
+    ]
+    assert contract["transform"] == "RTCRtpScriptTransform"
+    assert contract["algorithms"] == {"aead": "AES-256-GCM", "kdf": "HKDF-SHA-256"}
+    assert contract["expires_at_ms"] == int(pair["session"]["expires_at"] * 1000)
+    assert contract["authority_key_id"] == owner_response["hub_key_id"]
+    _verify_public_media_contract(contract, owner_response["hub_public_key_b64"])
+
+    from cryptography.exceptions import InvalidSignature
+
+    tampered_contracts = []
+    for path, value in (
+        (("base_security_contract_digest",), "0" * 64),
+        (("epoch",), contract["epoch"] + 1),
+        (("memberships", 0, "peer_id"), pair["guest_peer_id"]),
+        (("memberships", 1, "device_key_fingerprint"), pair["owner_fingerprint"]),
+        (("slots", 0, "codec"), "pcmu"),
+    ):
+        tampered = json.loads(json.dumps(contract))
+        cursor = tampered
+        for key in path[:-1]:
+            cursor = cursor[key]
+        cursor[path[-1]] = value
+        tampered_contracts.append(tampered)
+
+    for tampered in tampered_contracts:
+        with pytest.raises(InvalidSignature):
+            _verify_public_media_contract(tampered, owner_response["hub_public_key_b64"], check_digest=False)
+        with pytest.raises(AssertionError):
+            _verify_public_media_contract(tampered, owner_response["hub_public_key_b64"])
+
+
+@pytest.mark.parametrize(("owner_version", "guest_version"), [(1, 0), (0, 1), (0, 0)])
+def test_public_media_contract_is_null_unless_both_v2_members_advertise_v1(
+    public_service,
+    owner_version,
+    guest_version,
+):
+    pair = _public_media_pair(
+        public_service,
+        owner_media_version=owner_version,
+        guest_media_version=guest_version,
+    )
+
+    assert pair["owner_packages"]["public_media_security_contract_v1"] is None
+    assert pair["guest_packages"]["public_media_security_contract_v1"] is None
+
+
+def test_public_media_version_is_bound_to_create_and_join_idempotency(public_service):
+    pair = _public_media_pair(public_service, owner_media_version=1, guest_media_version=1)
+    exact = _public_media_capabilities_v1()
+
+    recovered_owner = public_service.create_session(**pair["create_kwargs"])
+    recovered_guest = public_service.join_session(**pair["join_kwargs"])
+    assert recovered_owner["_idempotent"] is True
+    assert recovered_guest["idempotent"] is True
+    with pytest.raises(ValueError, match="membership_capability_conflict"):
+        public_service.create_session(
+            **{
+                **pair["create_kwargs"],
+                "public_media_e2ee_version": 0,
+                "public_media_capabilities": None,
+            }
+        )
+    conflicting_join = public_service.join_session(
+        **{
+            **pair["join_kwargs"],
+            "public_media_e2ee_version": 0,
+            "public_media_capabilities": None,
+        }
+    )
+    assert conflicting_join == {"ok": False, "reason": "public_media_capability_conflict"}
+    assert (
+        public_service.is_owner_create_recovery(
+            account_id=pair["account_id"],
+            device_fingerprint=pair["owner_fingerprint"],
+            membership_capability=pair["owner_capability"],
+            public_media_e2ee_version=0,
+        )
+        is False
+    )
+    assert (
+        public_service.is_join_recovery(
+            invite_code=pair["session"]["invite_code"],
+            account_id=pair["account_id"],
+            device_fingerprint=pair["guest_fingerprint"],
+            membership_capability=pair["guest_capability"],
+            public_media_e2ee_version=0,
+        )
+        is False
+    )
+    assert exact == pair["create_kwargs"]["public_media_capabilities"]
 
 
 def test_v2_rejects_cloned_device_key_and_version_downgrade(public_service):
@@ -999,6 +1222,10 @@ def test_legacy_sqlite_schema_migrates_additively_and_fails_closed(monkeypatch, 
                          'legacy-guest', 'offer', '{}', 4)"""
         )
         session_columns = {row[1] for row in conn.execute("PRAGMA table_info(sessions)")}
+        participant_info = {row[1]: row for row in conn.execute("PRAGMA table_info(participants)")}
+        session_media_default = conn.execute(
+            "SELECT public_media_e2ee_version FROM sessions WHERE id = 'legacy-session'"
+        ).fetchone()[0]
         migrated_signal_rows = conn.execute(
             "SELECT sequence FROM signals WHERE id IN ('signal-a', 'signal-b') ORDER BY sent_at, rowid"
         ).fetchall()
@@ -1009,6 +1236,10 @@ def test_legacy_sqlite_schema_migrates_additively_and_fails_closed(monkeypatch, 
         confirmation_expiry = conn.execute("SELECT expires_at FROM key_confirmations").fetchone()[0]
 
     assert "identity_binding_version" in session_columns
+    assert "public_media_e2ee_version" in session_columns
+    assert "public_media_e2ee_version" in participant_info
+    assert session_media_default == 0
+    assert participant_info["public_media_e2ee_version"][4] == "0"
     assert migrated_signal_rows == [(1,), (2,)]
     assert rollback_signal_rows == [(0,), (0,)]
     assert "idx_signals_recipient_sequence" not in signal_indexes
@@ -1074,9 +1305,12 @@ def test_migration_rolls_back_schema_and_cursor_changes_together(public_service,
             public_service._migrate_database(conn)
         assert conn.in_transaction is False
         session_columns = {str(row["name"]) for row in conn.execute("PRAGMA table_info(sessions)")}
+        participant_columns = {str(row["name"]) for row in conn.execute("PRAGMA table_info(participants)")}
         signal_columns = {str(row["name"]) for row in conn.execute("PRAGMA table_info(signals)")}
 
     assert "identity_binding_version" not in session_columns
+    assert "public_media_e2ee_version" not in session_columns
+    assert "public_media_e2ee_version" not in participant_columns
     assert "sequence" not in signal_columns
 
 
@@ -1319,6 +1553,7 @@ def test_http_v2_same_account_pair_requires_membership_capabilities(monkeypatch,
     guest_spki, guest_fp = _device_key()
     owner_capability = "H" * 43
     guest_capability = "I" * 43
+    media_capabilities = _public_media_capabilities_v1()
     expires_at = public_app.svc._now() + 600
     client = public_app.app.test_client()
     auth = {"Authorization": "Bearer shared"}
@@ -1338,8 +1573,27 @@ def test_http_v2_same_account_pair_requires_membership_capabilities(monkeypatch,
         "owner_device_id": "owner-device",
         "owner_device_fingerprint": owner_fp,
         "public_key_spki_b64": owner_spki,
+        "public_media_e2ee_version": 1,
+        "public_media_capabilities": media_capabilities,
     }
 
+    info = client.get("/info")
+    missing_media_capabilities = client.post(
+        "/rendezvous/sessions",
+        headers=owner_headers,
+        json={key: value for key, value in create_body.items() if key != "public_media_capabilities"},
+    )
+    reordered_media_grants = client.post(
+        "/rendezvous/sessions",
+        headers=owner_headers,
+        json={
+            **create_body,
+            "public_media_capabilities": {
+                **media_capabilities,
+                "grants": list(reversed(media_capabilities["grants"])),
+            },
+        },
+    )
     created = client.post("/rendezvous/sessions", headers=owner_headers, json=create_body)
     recovered_create = client.post(
         "/rendezvous/sessions",
@@ -1351,11 +1605,20 @@ def test_http_v2_same_account_pair_requires_membership_capabilities(monkeypatch,
     invite_code = created_payload["session"]["invite_code"]
     owner_peer_id = created_payload["local_peer_id"]
     assert created.status_code == 201
+    assert info.get_json()["supported_public_media_e2ee_versions"] == [1]
+    assert (missing_media_capabilities.status_code, missing_media_capabilities.get_json()) == (
+        400,
+        {"error": "public_media_capabilities_invalid"},
+    )
+    assert (reordered_media_grants.status_code, reordered_media_grants.get_json()) == (
+        400,
+        {"error": "public_media_capabilities_invalid"},
+    )
     assert recovered_create.status_code == 200
     assert recovered_create.get_json()["session"]["id"] == session_id
     assert created.headers["Cache-Control"] == "no-store"
     assert "X-Ananta-Membership-Capability" in created.headers["Access-Control-Allow-Headers"]
-    assert "capability" not in json.dumps(created_payload)
+    assert owner_capability not in json.dumps(created_payload)
 
     join_body = {
         "invite_code": invite_code,
@@ -1364,6 +1627,8 @@ def test_http_v2_same_account_pair_requires_membership_capabilities(monkeypatch,
         "device_id": "guest-device",
         "device_fingerprint": guest_fp,
         "public_key_spki_b64": guest_spki,
+        "public_media_e2ee_version": 1,
+        "public_media_capabilities": media_capabilities,
     }
     guest_capability_header = {"X-Ananta-Membership-Capability": guest_capability}
     joined = client.post(
@@ -1382,7 +1647,7 @@ def test_http_v2_same_account_pair_requires_membership_capabilities(monkeypatch,
     assert recovered_join.status_code == 200
     assert joined.headers["Cache-Control"] == "no-store"
     assert guest_peer_id != owner_peer_id
-    assert "capability" not in json.dumps(joined_payload)
+    assert guest_capability not in json.dumps(joined_payload)
 
     guest_headers = {
         **auth,
@@ -1414,6 +1679,14 @@ def test_http_v2_same_account_pair_requires_membership_capabilities(monkeypatch,
         "X-Ananta-Peer-Id": owner_peer_id,
         "X-Ananta-Membership-Capability": owner_capability,
     }
+    owner_packages = client.get(
+        f"/rendezvous/sessions/{session_id}/security/key-packages",
+        headers=owner_bound_headers,
+    )
+    assert owner_packages.status_code == 200
+    media_contract = owner_packages.get_json()["public_media_security_contract_v1"]
+    assert media_contract["base_security_contract_digest"] == owner_packages.get_json()["security_contract_digest"]
+    _verify_public_media_contract(media_contract, owner_packages.get_json()["hub_public_key_b64"])
     owner_signal = client.post(
         f"/webrtc/sessions/{session_id}/signal",
         headers=owner_bound_headers,
@@ -1511,7 +1784,8 @@ def test_http_v2_same_account_pair_requires_membership_capabilities(monkeypatch,
     assert legacy_payload["data"]["local_peer_id"] == context.account_id
     v2_item = next(item for item in guest_list.get_json()["data"]["items"] if item["identity_binding_version"] == 2)
     assert v2_item["local_peer_id"] == guest_peer_id
-    assert "capability" not in json.dumps(guest_list.get_json())
+    assert owner_capability not in json.dumps(guest_list.get_json())
+    assert guest_capability not in json.dumps(guest_list.get_json())
 
 
 def test_create_recovery_probe_is_rate_limited_before_lookup(monkeypatch, tmp_path):
@@ -2073,6 +2347,104 @@ def _device_key() -> tuple[str, str]:
         )
     )
     return base64.b64encode(raw).decode("ascii"), hashlib.sha256(raw).hexdigest()
+
+
+def _public_media_capabilities_v1() -> dict:
+    return {
+        "version": 1,
+        "transform": "RTCRtpScriptTransform",
+        "grants": ["microphone-opus", "camera-vp8", "screen-vp8"],
+    }
+
+
+def _public_media_pair(public_service, *, owner_media_version: int, guest_media_version: int) -> dict:
+    subject = f"media-pair-{owner_media_version}-{guest_media_version}"
+    account_id = _peer_id(subject)
+    owner_spki, owner_fp = _device_key()
+    guest_spki, guest_fp = _device_key()
+    owner_capability = "R" * 43
+    guest_capability = "S" * 43
+    exact = _public_media_capabilities_v1()
+    create_kwargs = {
+        "owner_user_id": account_id,
+        "owner_user_sub": subject,
+        "owner_device_id": "media-owner-device",
+        "owner_device_fingerprint": owner_fp,
+        "owner_public_key_spki_b64": owner_spki,
+        "oidc_issuer": "https://issuer",
+        "identity_binding_version": 2,
+        "membership_capability": owner_capability,
+        "public_media_e2ee_version": owner_media_version,
+        "public_media_capabilities": exact if owner_media_version == 1 else None,
+    }
+    session = public_service.create_session(**create_kwargs)
+    join_kwargs = {
+        "invite_code": session["invite_code"],
+        "user_id": account_id,
+        "user_sub": subject,
+        "device_id": "media-guest-device",
+        "device_fingerprint": guest_fp,
+        "public_key_spki_b64": guest_spki,
+        "oidc_issuer": "https://issuer",
+        "expected_identity_binding_version": 2,
+        "membership_capability": guest_capability,
+        "public_media_e2ee_version": guest_media_version,
+        "public_media_capabilities": exact if guest_media_version == 1 else None,
+    }
+    joined = public_service.join_session(**join_kwargs)
+    assert joined["ok"] is True
+    owner_peer_id = session["owner_peer_id"]
+    guest_peer_id = joined["participant"]["peer_id"]
+    owner_packages = public_service.get_key_packages(
+        session_id=session["id"],
+        requester_user_id=account_id,
+        requester_peer_id=owner_peer_id,
+        membership_capability=owner_capability,
+    )
+    guest_packages = public_service.get_key_packages(
+        session_id=session["id"],
+        requester_user_id=account_id,
+        requester_peer_id=guest_peer_id,
+        membership_capability=guest_capability,
+    )
+    return {
+        "account_id": account_id,
+        "session": session,
+        "joined": joined,
+        "owner_peer_id": owner_peer_id,
+        "guest_peer_id": guest_peer_id,
+        "owner_fingerprint": owner_fp,
+        "guest_fingerprint": guest_fp,
+        "owner_capability": owner_capability,
+        "guest_capability": guest_capability,
+        "create_kwargs": create_kwargs,
+        "join_kwargs": join_kwargs,
+        "owner_packages": owner_packages,
+        "guest_packages": guest_packages,
+    }
+
+
+def _verify_public_media_contract(contract: dict, public_key_b64: str, *, check_digest: bool = True) -> None:
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+    signed = dict(contract)
+    signature = base64.b64decode(signed.pop("signature_b64"), validate=True)
+    digest_projection = dict(signed)
+    digest_projection.pop("digest")
+    digest_projection.pop("signature_algorithm")
+    expected_digest = hashlib.sha256(
+        json.dumps(
+            digest_projection,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode()
+    ).hexdigest()
+    if check_digest:
+        assert signed["digest"] == expected_digest
+    canonical = json.dumps(signed, sort_keys=True, separators=(",", ":"), allow_nan=False).encode()
+    public_key = Ed25519PublicKey.from_public_bytes(base64.b64decode(public_key_b64, validate=True))
+    public_key.verify(signature, canonical)
 
 
 def _verify_package_signature(response: dict) -> None:


### PR DESCRIPTION
## Summary

- add an additive, separately signed Public Pair media-v1 contract for new v2 sessions
- encrypt fixed microphone, camera, and screen WebRTC slots with DROP-first RTCRtpScriptTransform workers bound to the confirmed Pair context
- preserve data-only behavior for old, asymmetric, or unsupported clients
- enable the Public Pair media UI without depending on Hub availability or Hub media flags
- allow only the pinned `https://webrtc.ananta.de` REST origin in the frontend CSP
- document security, operation, failure, and terminal reconnect behavior

## Architecture and security

The Hub remains the control plane; no worker-to-worker orchestration is introduced. The browser WebWorker is only an encoded-media cryptographic adapter. The change is additive and keeps the existing Public Pair base contract unchanged. Media keys are installed only after authority signature verification, exact peer/epoch/contract binding, bilateral encrypted consent, and fixed-topology validation.

## Validation

- backend and CSP contracts: 89 passed
- focused media Core/UI: 191 passed
- adjacent crypto/DataChannel: 65 passed
- Angular app/spec TypeScript: passed
- focused ESLint and Python Ruff/format: passed
- production `npm run build`: passed; media worker emitted and referenced
- diff and high-entropy secret scans: passed
- independent security review: P0=0, P1=0

A real two-browser Public Pair canary remains the release gate. Rollout order is backend, edge/CSP, then frontend; old clients remain data-only.