### PR TITLE
feat(pair-media): add interoperable public media v2

### DIFF
--- a/docs/ops/public-ananta-test-rendezvous.md
+++ b/docs/ops/public-ananta-test-rendezvous.md
@@ -13,8 +13,9 @@ The public test profile supports early Angular Pair-Dev collaboration tests:
 This infrastructure is provided as a limited free test service by Peter Stuiber/ananta.de. It is not a production service, has no SLA, may be reset, rate-limited or disabled, and must not be used for confidential production workloads.
 
 The strict public adapter always protects supported DataChannel payloads with
-Pair E2EE. Public audio/video is an additive v1 extension for newly created v2
-sessions: both browsers must advertise the exact standard transform capability,
+Pair E2EE. Public audio/video is an additive media-v2 extension for newly
+created v2 sessions: both browsers must advertise the exact standard transform
+capability,
 verify the separately signed media contract and complete bilateral consent
 before DROP-first encoded-media transforms receive keys. Old, asymmetric or
 unsupported clients remain data-only. DTLS-SRTP alone is never represented as
@@ -121,7 +122,7 @@ The rendezvous service (`public-rendezvous/rendezvous/`) is a standalone Flask/G
 | `POST /rendezvous/sessions/join` | Beitreten per Invite-Code ohne bekannte Session-ID |
 | `POST /rendezvous/sessions/<id>/join` | Beitreten per Invite-Code |
 | `GET /rendezvous/sessions/<id>/participants` | Presence für berechtigte Teilnehmer |
-| `GET /rendezvous/sessions/<id>/security/key-packages` | Adressiertes, kurzlebiges Peer-Key-Paket, strikter Basisvertrag und gegebenenfalls separat signierter Media-v1-Vertrag |
+| `GET /rendezvous/sessions/<id>/security/key-packages` | Adressiertes, kurzlebiges Peer-Key-Paket, strikter Basisvertrag und gegebenenfalls separat signierter Media-v2-Vertrag |
 | `GET/POST /rendezvous/sessions/<id>/security/key-confirmations` | Undurchsichtige bilaterale Schlüsselbestätigung |
 | `PATCH /rendezvous/sessions/<id>/permissions` | Fail-closed mit HTTP 409 `permission_update_rekey_required` |
 | `DELETE /rendezvous/sessions/<id>` | Session widerrufen (Owner) |
@@ -154,14 +155,19 @@ uses OIDC-authenticated HTTP polling at the public `/webrtc/sessions/<id>/signal
 boundary. Only SDP/ICE metadata passes through that boundary. Chat, view deltas
 and artifacts use the peer-to-peer encrypted DataChannel path. Ordinary video
 and audio use fixed Opus/VP8 slots only when both v2 memberships negotiated the
-separately authority-signed `public_media_security_contract_v1`, both peers
+separately authority-signed `public_media_security_contract_v2`, both peers
 confirmed it over the Pair-encrypted DataChannel, and standard
 `RTCRtpScriptTransform` workers are installed DROP-first. Missing support,
 one-sided advertisement or any pre-key topology failure leaves the base Pair
 data-only; failures after possible key release close the connection. If direct
 ICE is impossible, the browser may use coturn with short-lived
 credentials; coturn relays encrypted packets and does not receive application
-plaintext. Public sessions never fall back to the local Hub relay.
+plaintext. Media-v2 binds `ananta.public-pair.media-frame.v2`: the VP8
+uncompressed prefix (10 bytes for key frames, 3 for delta frames) and the
+single Opus TOC byte remain clear only so browser packetizers can preserve the
+codec shape; those bytes are authenticated as AES-GCM additional data and the
+remaining frame is encrypted. Public sessions never fall back to the local
+Hub relay.
 
 ## Environment file
 

--- a/docs/user/pair-dev-audio-video.md
+++ b/docs/user/pair-dev-audio-video.md
@@ -27,7 +27,7 @@ Zusaetzlich gilt fuer **Public Pair**:
   Schluesselbestaetigung abgeschlossen haben.
 - Beide Browser muessen den von Ananta verwendeten WebRTC-Encoded-Transform
   unterstuetzen. Fehlt diese Browserfunktion, bleibt Capture geschlossen.
-- Der separate signierte `public_media_security_contract_v1` muss die
+- Der separate signierte `public_media_security_contract_v2` muss die
   Medien-Grants, Publikations-Slots und den E2EE-Transform fuer beide Peers
   bestaetigen. Der bestehende Public-Pair-Basisvertrag bleibt unveraendert auf
   `bulk`, `control` und `semantic` begrenzt. Die Anwendung akzeptiert keine
@@ -52,7 +52,11 @@ Video-Frames werden im sendenden Browser verschluesselt und erst im
 empfangenden Browser wieder entschluesselt. Rendezvous, STUN und TURN erhalten
 keinen Medien-Inhaltsschluessel. Kann der Pfad nicht vollstaendig eingerichtet
 werden oder geht die Sicherheitsbindung verloren, bleiben neue Freigaben
-gesperrt und laufende Public-Pair-Medien werden beendet.
+gesperrt und laufende Public-Pair-Medien werden beendet. Damit Chromium und
+Firefox die VP8-/Opus-Frames weiterhin korrekt paketieren, bleiben nur der
+VP8-Uncompressed-Prefix (10 Byte bei Keyframes, 3 Byte bei Deltaframes) bzw.
+das einzelne Opus-TOC-Byte sichtbar. Diese Bytes sind Bestandteil der
+AES-GCM-Authentifizierung; der restliche Medienframe bleibt verschluesselt.
 
 ## Ablauf in der Oberflaeche
 

--- a/frontend-angular/playwright.public-pair-media-live.config.ts
+++ b/frontend-angular/playwright.public-pair-media-live.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig } from '@playwright/test';
+import os from 'node:os';
+import path from 'node:path';
+
+const baseURL = process.env['E2E_PUBLIC_PAIR_MEDIA_BASE_URL']
+  || process.env['E2E_FRONTEND_URL']
+  || 'http://127.0.0.1:4200';
+const outputDir = process.env['E2E_PUBLIC_PAIR_MEDIA_OUTPUT_DIR']
+  || path.join(os.tmpdir(), `ananta-public-pair-media-live-${process.pid}`);
+
+export default defineConfig({
+  testDir: './tests',
+  testMatch: 'public-pair-media-live.spec.ts',
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  timeout: 300_000,
+  expect: { timeout: 60_000 },
+  outputDir,
+  preserveOutput: 'never',
+  reporter: [['line']],
+  use: {
+    baseURL,
+    actionTimeout: 30_000,
+    navigationTimeout: 120_000,
+    trace: 'off',
+    screenshot: 'off',
+    video: 'off',
+  },
+  projects: [{ name: 'public-pair-media-live' }],
+});

--- a/frontend-angular/src/app/app.component.spec.ts
+++ b/frontend-angular/src/app/app.component.spec.ts
@@ -1,0 +1,164 @@
+import { AsyncPipe } from '@angular/common';
+import { NO_ERRORS_SCHEMA, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { Capacitor } from '@capacitor/core';
+import { BehaviorSubject, of } from 'rxjs';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { AppComponent } from './app.component';
+import { AgentDirectoryService } from './services/agent-directory.service';
+import { AppShellStateService } from './services/app-shell-state.service';
+import { IdentityRegistry } from './services/identity/identity-registry';
+import type { IdentitySnapshot } from './services/identity/identity.types';
+import { MobileRuntimeService } from './services/mobile-runtime.service';
+import { ProjectContextService } from './services/project-context.service';
+import { PythonRuntimeService } from './services/python-runtime.service';
+import { SnakeOverlayService } from './services/snake-overlay.service';
+import { SystemFacade } from './features/system/system.facade';
+import { UserAuthService } from './services/user-auth.service';
+import { WindowBridgeService } from './services/window-bridge.service';
+
+function configureShell(native = false) {
+  TestBed.resetTestingModule();
+  const hubSnapshot = new BehaviorSubject<IdentitySnapshot>({ status: 'absent' });
+  const hubUser = new BehaviorSubject<Record<string, unknown> | null>(null);
+  const rawHubToken = new BehaviorSubject<string | null>(null);
+  const hubAgent = { name: 'hub', role: 'hub', url: 'https://hub.example.test' };
+  const ensureSystemEvents = vi.fn();
+  const disconnectSystemEvents = vi.fn();
+  const auth = {
+    token$: rawHubToken.asObservable(),
+    user$: hubUser.asObservable(),
+    get token() { return rawHubToken.value; },
+    get userPayload() { return hubUser.value; },
+    decodeTokenPayload: (token: string | null) => (
+      token === rawHubToken.value ? hubUser.value : null
+    ),
+    isLoggedIn: () => rawHubToken.value !== null,
+    logout: vi.fn(),
+    setTokens: vi.fn(),
+    setOidcAccessToken: vi.fn(),
+  };
+
+  TestBed.configureTestingModule({
+    providers: [
+      { provide: AgentDirectoryService, useValue: { list: () => [hubAgent], upsert: vi.fn() } },
+      { provide: UserAuthService, useValue: auth },
+      { provide: Router, useValue: { navigate: vi.fn(), url: '/' } },
+      { provide: MobileRuntimeService, useValue: { isNative: native } },
+      {
+        provide: SystemFacade,
+        useValue: {
+          disconnectSystemEvents,
+          resolveHubAgent: () => hubAgent,
+          ensureSystemEvents,
+        },
+      },
+      {
+        provide: AppShellStateService,
+        useValue: {
+          init: vi.fn(),
+          mobileNavOpen: signal(false),
+          darkMode: signal(false),
+          mode: signal<'simple' | 'advanced'>('simple'),
+          routeUrl: signal('/'),
+          navGroups: () => [{ label: 'Hub', items: [{ path: '/hub', label: 'Hub only' }] }],
+          toggleMobileNav: vi.fn(),
+          closeMobileNav: vi.fn(),
+          openMobileNav: vi.fn(),
+          toggleDarkMode: vi.fn(),
+          toggleMode: vi.fn(),
+        },
+      },
+      { provide: PythonRuntimeService, useValue: { ensureEmbeddedControlPlane: vi.fn() } },
+      {
+        provide: WindowBridgeService,
+        useValue: { initFromUrlParams: () => Promise.resolve(), tuiAuthContext: {} },
+      },
+      { provide: SnakeOverlayService, useValue: { visible$: of(false), toggle: vi.fn() } },
+      {
+        provide: ProjectContextService,
+        useValue: { selectedProjectId: signal<string | null>(null) },
+      },
+      {
+        provide: IdentityRegistry,
+        useValue: {
+          hub: {
+            snapshot$: hubSnapshot.asObservable(),
+            get current() { return hubSnapshot.value; },
+          },
+        },
+      },
+    ],
+  });
+  TestBed.overrideComponent(AppComponent, {
+    set: { imports: [AsyncPipe], schemas: [NO_ERRORS_SCHEMA] },
+  });
+
+  return {
+    hubSnapshot,
+    hubUser,
+    rawHubToken,
+    ensureSystemEvents,
+    disconnectSystemEvents,
+  };
+}
+
+describe('AppComponent Hub shell trust boundary', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    TestBed.resetTestingModule();
+  });
+
+  it('reacts to validated Hub ready/expired transitions and starts events only once per ready period', () => {
+    const state = configureShell();
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+    const host = fixture.nativeElement as HTMLElement;
+
+    expect(host.querySelector('#primary-navigation')).toBeNull();
+    expect(host.querySelector('[data-testid="assistant-feature-root"]')).toBeNull();
+
+    state.rawHubToken.next('raw-hub-token');
+    state.hubUser.next({ sub: 'hub-user', role: 'admin' });
+    state.hubSnapshot.next({
+      status: 'ready', token: 'raw-hub-token', subject: 'hub-user', issuer: 'hub',
+    });
+    fixture.detectChanges();
+
+    expect(host.querySelector('#primary-navigation')).not.toBeNull();
+    expect(host.querySelector('[data-testid="assistant-feature-root"]')).not.toBeNull();
+    expect(host.querySelector('.app-header-user')?.textContent).toContain('hub-user (admin)');
+    expect(state.ensureSystemEvents).toHaveBeenCalledOnce();
+
+    state.hubSnapshot.next({
+      status: 'ready', token: 'raw-hub-token', subject: 'hub-user', issuer: 'hub',
+    });
+    fixture.detectChanges();
+    expect(state.ensureSystemEvents).toHaveBeenCalledOnce();
+
+    state.hubSnapshot.next({ status: 'expired', error: 'hub_access_token_expired' });
+    fixture.detectChanges();
+
+    expect(host.querySelector('#primary-navigation')).toBeNull();
+    expect(host.querySelector('[data-testid="assistant-feature-root"]')).toBeNull();
+    expect(host.querySelector('.app-hright')).toBeNull();
+  });
+
+  it('does not render Android Hub navigation for an expired raw Hub token', () => {
+    vi.spyOn(Capacitor, 'getPlatform').mockReturnValue('android');
+    const state = configureShell(true);
+    state.rawHubToken.next('expired-but-still-stored');
+    state.hubUser.next({ sub: 'stale-admin', role: 'admin' });
+    state.hubSnapshot.next({ status: 'expired', error: 'hub_access_token_expired' });
+
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+    const host = fixture.nativeElement as HTMLElement;
+
+    expect(host.querySelector('.android-fullscreen-menu')).toBeNull();
+    expect(host.querySelector('.android-edge-toggle')).toBeNull();
+    expect(host.querySelector('[data-testid="assistant-feature-root"]')).toBeNull();
+  });
+});

--- a/frontend-angular/src/app/app.component.ts
+++ b/frontend-angular/src/app/app.component.ts
@@ -1,11 +1,12 @@
-import { Component, HostListener, OnInit, OnDestroy, inject, signal, computed, ChangeDetectionStrategy } from '@angular/core';
+import { Component, HostListener, OnInit, OnDestroy, inject, computed, ChangeDetectionStrategy } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { RouterLink, RouterLinkActive, RouterOutlet, Router } from '@angular/router';
 import { Capacitor } from '@capacitor/core';
 import { NotificationsComponent } from './components/notifications.component';
 import { ToastComponent } from './components/toast.component';
 import { AgentDirectoryService, usesEmbeddedAndroidHub } from './services/agent-directory.service';
 import { UserAuthService } from './services/user-auth.service';
-import { Subscription } from 'rxjs';
+import { Subscription, distinctUntilChanged, map } from 'rxjs';
 import { AsyncPipe } from '@angular/common';
 import { AiAssistantComponent } from './components/ai-assistant.component';
 import { BreadcrumbComponent } from './components/breadcrumb.component';
@@ -20,6 +21,7 @@ import { SecurityStorageBannerComponent } from './components/security-storage-ba
 import { ProjectContextSwitcherComponent } from './components/project-context-switcher.component';
 import type { AppNavItem } from './models/route-metadata';
 import { ProjectContextService } from './services/project-context.service';
+import { IdentityRegistry } from './services/identity/identity-registry';
 
 @Component({
   selector: 'app-root',
@@ -108,7 +110,7 @@ import { ProjectContextService } from './services/project-context.service';
         }
       </div>
     </header>
-    @if (isAndroidNative) {
+    @if (isAndroidNative && headerUser()) {
       <nav
         id="primary-navigation"
         class="android-fullscreen-menu"
@@ -145,7 +147,7 @@ import { ProjectContextService } from './services/project-context.service';
         <div class="mobile-nav-backdrop open" (click)="closeMobileNav()" aria-hidden="true"></div>
       }
     }
-    @if (isAndroidNative) {
+    @if (isAndroidNative && headerUser()) {
       <button
         type="button"
         class="android-edge-toggle"
@@ -317,8 +319,9 @@ export class AppComponent implements OnInit, OnDestroy {
   private pythonRuntime = inject(PythonRuntimeService);
   readonly bridge = inject(WindowBridgeService);
   readonly projectContext = inject(ProjectContextService);
+  private readonly identities = inject(IdentityRegistry);
 
-  private authSub?: Subscription;
+  private readonly subscriptions = new Subscription();
   private touchStartX = 0;
   private touchStartY = 0;
   private trackingOpenSwipe = false;
@@ -327,19 +330,21 @@ export class AppComponent implements OnInit, OnDestroy {
   private readonly swipeTriggerPx = 72;
   private readonly verticalTolerancePx = 44;
 
-  // Signals backing the template so OnPush change-detection stays consistent
-  private readonly _userPayload = signal<unknown>(null);
-  private readonly _isLoggedIn = signal<boolean>(false);
+  // Validated Hub identity and payload remain separate from the OIDC/Pair sphere.
+  private readonly hubIdentity = toSignal(this.identities.hub.snapshot$, {
+    initialValue: this.identities.hub.current,
+  });
   readonly headerUser = computed(() => {
-    const user = this._userPayload();
+    const identity = this.hubIdentity();
+    if (identity.status !== 'ready') return null;
+    const user = this.auth.decodeTokenPayload(identity.token ?? null);
     if (user && typeof user === 'object') {
       const u = user as Record<string, unknown>;
       const sub = String(u['sub'] || u['username'] || u['preferred_username'] || '').trim() || 'angemeldet';
       const role = String(u['role'] || '').trim() || 'user';
       return { sub, role };
     }
-    if (this._isLoggedIn()) return { sub: 'angemeldet', role: 'user' };
-    return null;
+    return { sub: identity.subject || 'angemeldet', role: 'user' };
   });
 
 get isAndroidNative(): boolean {
@@ -350,24 +355,20 @@ get isAndroidNative(): boolean {
     this.shell.init();
     void this.bridge.initFromUrlParams().then(() => this._applyTuiAuthIfPresent());
     void this.bootstrapEmbeddedRuntime();
-    this.authSub = this.auth.token$.subscribe((token) => {
-      if (token) {
+    this.subscriptions.add(this.identities.hub.snapshot$.pipe(
+      map((identity) => identity.status === 'ready'),
+      distinctUntilChanged(),
+    ).subscribe((ready) => {
+      if (ready) {
         this.startEventStream();
       } else {
         this.system.disconnectSystemEvents();
       }
-    });
-    // Keep signals in sync with auth state — fixes NG0100 with OnPush
-    this._userPayload.set(this.auth.userPayload);
-    this._isLoggedIn.set(this.auth.isLoggedIn());
-    this.authSub = this.auth.token$.subscribe(() => {
-      this._userPayload.set(this.auth.userPayload);
-      this._isLoggedIn.set(this.auth.isLoggedIn());
-    });
+    }));
   }
 
   ngOnDestroy() {
-    this.authSub?.unsubscribe();
+    this.subscriptions.unsubscribe();
     this.system.disconnectSystemEvents();
   }
 
@@ -531,7 +532,7 @@ get isAndroidNative(): boolean {
   }
 
   private shouldHandleMobileDrawerSwipe(): boolean {
-    return this.isAndroidNative && this.auth.isLoggedIn() && window.innerWidth <= 900;
+    return this.isAndroidNative && this.headerUser() !== null && window.innerWidth <= 900;
   }
 
   private resetSwipeTracking(): void {

--- a/frontend-angular/src/app/app.routes.spec.ts
+++ b/frontend-angular/src/app/app.routes.spec.ts
@@ -1,5 +1,7 @@
 import { routes } from './app.routes';
 import { adminGuard } from './guards/admin.guard';
+import { authGuard } from './auth.guard';
+import { publicPairGuard } from './guards/public-pair.guard';
 
 function flattenRoutes(items: typeof routes): any[] {
   return items.flatMap((route: any) => [
@@ -9,6 +11,16 @@ function flattenRoutes(items: typeof routes): any[] {
 }
 
 describe('app routes', () => {
+  it('keeps Public Pair outside the Hub-authenticated route tree', () => {
+    const pairRoute = routes.find((route) => route.path === 'pair-dev');
+    const hubShell = routes.find((route) => route.path === '' && route.children);
+
+    expect(pairRoute?.canActivate).toEqual([publicPairGuard]);
+    expect(typeof pairRoute?.loadComponent).toBe('function');
+    expect(hubShell?.canActivate).toEqual([authGuard]);
+    expect(hubShell?.children?.some((route) => route.path === 'pair-dev')).toBe(false);
+  });
+
   it('lazy-loads feature views below the authenticated shell', () => {
     const lazyRoutes = flattenRoutes(routes).filter((route: any) => typeof route.loadComponent === 'function');
     const featureRoutes = lazyRoutes.filter((route: any) => [

--- a/frontend-angular/src/app/app.routes.ts
+++ b/frontend-angular/src/app/app.routes.ts
@@ -18,10 +18,17 @@ import { modelAnalysisRoutes } from './features/model-analysis/model-analysis.ro
 import { PROJECT_ROUTES } from './features/projects/project.routes';
 import { projectContextGuard } from './guards/project-context.guard';
 import { organizationRoutes } from './features/organizations/organization.routes';
+import { publicPairGuard } from './guards/public-pair.guard';
 
 export const routes: Routes = [
   { path: 'login', component: LoginComponent },
   { path: 'oidc-callback', component: OidcCallbackComponent },
+  {
+    path: 'pair-dev',
+    canActivate: [publicPairGuard],
+    loadComponent: () => import('./features/pair/public-pair-page.component')
+      .then(m => m.PublicPairPageComponent),
+  },
   {
     path: '',
     canActivate: [authGuard],

--- a/frontend-angular/src/app/auth.guard.spec.ts
+++ b/frontend-angular/src/app/auth.guard.spec.ts
@@ -1,0 +1,46 @@
+import { TestBed } from '@angular/core/testing';
+import { provideRouter, Router, UrlTree } from '@angular/router';
+import { describe, expect, it } from 'vitest';
+
+import { authGuard } from './auth.guard';
+import { IdentityRegistry } from './services/identity/identity-registry';
+import type { IdentityStatus } from './services/identity/identity.types';
+
+function runGuard(hubStatus: IdentityStatus, unionAuthenticated: boolean): boolean | UrlTree {
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({
+    providers: [
+      provideRouter([]),
+      {
+        provide: IdentityRegistry,
+        useValue: {
+          hub: { current: { status: hubStatus } },
+          isAuthenticated: unionAuthenticated,
+        },
+      },
+    ],
+  });
+  return TestBed.runInInjectionContext(() => authGuard({} as never, {} as never)) as boolean | UrlTree;
+}
+
+describe('authGuard Hub trust boundary', () => {
+  it('preserves access for a ready Hub identity', () => {
+    expect(runGuard('ready', true)).toBe(true);
+  });
+
+  it('does not promote an OIDC-only identity into Hub-route access', () => {
+    const result = runGuard('absent', true);
+    const router = TestBed.inject(Router);
+
+    expect(result).toBeInstanceOf(UrlTree);
+    expect(router.serializeUrl(result as UrlTree)).toBe('/login');
+  });
+
+  it('fails closed for an expired Hub identity even when a raw token remains', () => {
+    const result = runGuard('expired', true);
+    const router = TestBed.inject(Router);
+
+    expect(result).toBeInstanceOf(UrlTree);
+    expect(router.serializeUrl(result as UrlTree)).toBe('/login');
+  });
+});

--- a/frontend-angular/src/app/auth.guard.ts
+++ b/frontend-angular/src/app/auth.guard.ts
@@ -6,7 +6,7 @@ export const authGuard: CanActivateFn = () => {
   const identities = inject(IdentityRegistry);
   const router = inject(Router);
   
-  if (identities.isAuthenticated) {
+  if (identities.hub.current.status === 'ready') {
     return true;
   }
   

--- a/frontend-angular/src/app/components/ai-snake-share-panel.component.spec.ts
+++ b/frontend-angular/src/app/components/ai-snake-share-panel.component.spec.ts
@@ -27,16 +27,21 @@ function configure(status: 'ready' | 'confirming' | 'legacy') {
     revokeParticipant: vi.fn(), createSession: vi.fn(), joinSession: vi.fn(),
   };
   const binding = { start: vi.fn() };
+  const core = {
+    get: vi.fn(() => of({})),
+    post: vi.fn(() => of({})),
+    delete: vi.fn(() => of({})),
+  };
   TestBed.configureTestingModule({
     imports: [AiSnakeSharePanelComponent],
     providers: [
       { provide: ShareSessionService, useValue: service },
       { provide: PairViewSessionBindingService, useValue: binding },
       { provide: AgentDirectoryService, useValue: { list: () => [] } },
-      { provide: HubApiCoreService, useValue: { get: () => of({}), post: () => of({}), delete: () => of({}) } },
+      { provide: HubApiCoreService, useValue: core },
     ],
   });
-  return { service, binding };
+  return { service, binding, core };
 }
 
 describe('AiSnakeSharePanelComponent production security host', () => {
@@ -64,5 +69,33 @@ describe('AiSnakeSharePanelComponent production security host', () => {
     const legacy = TestBed.createComponent(AiSnakeSharePanelComponent);
     legacy.detectChanges();
     expect((legacy.nativeElement as HTMLElement).textContent).toContain('Legacy-Modus: nicht Ende-zu-Ende verschlüsselt');
+  });
+
+  it('hides and fences every Hub-backed group operation in public-only mode', () => {
+    const { core } = configure('ready');
+    const fixture = TestBed.createComponent(AiSnakeSharePanelComponent);
+    fixture.componentRef.setInput('publicOnly', true);
+    fixture.detectChanges();
+    const component = fixture.componentInstance;
+    const group = { id: 'group-a', name: 'Hub group' } as never;
+    const member = { id: 'member-a', user_id: 'hub-user' } as never;
+
+    expect((fixture.nativeElement as HTMLElement).textContent).not.toContain('Gruppen');
+
+    component.switchToGroups();
+    component.startCreateGroup();
+    component.newGroupName = 'blocked';
+    component.doCreateGroup();
+    component.openGroup(group);
+    component.newMemberId = 'blocked-user';
+    component.addMember();
+    component.removeMember(member);
+    component.deleteGroup(group);
+    component.createGroupSession(group);
+
+    expect(component.mainTab).toBe('share');
+    expect(core.get).not.toHaveBeenCalled();
+    expect(core.post).not.toHaveBeenCalled();
+    expect(core.delete).not.toHaveBeenCalled();
   });
 });

--- a/frontend-angular/src/app/components/ai-snake-share-panel.component.ts
+++ b/frontend-angular/src/app/components/ai-snake-share-panel.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, inject } from '@angular/core';
+import { Component, Input, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ShareSessionService, ShareParticipant } from '../services/share-session.service';
@@ -40,7 +40,9 @@ interface PairGroupMember {
         }
         <div class="main-tabs">
           <button class="main-tab" [class.active]="mainTab === 'share'" (click)="mainTab = 'share'">Sessions</button>
-          <button class="main-tab" [class.active]="mainTab === 'groups'" (click)="switchToGroups()">Gruppen</button>
+          @if (!publicOnly) {
+            <button class="main-tab" [class.active]="mainTab === 'groups'" (click)="switchToGroups()">Gruppen</button>
+          }
         </div>
       </div>
 
@@ -377,6 +379,9 @@ export class AiSnakeSharePanelComponent implements OnInit {
   private dir = inject(AgentDirectoryService);
   private pairBinding = inject(PairViewSessionBindingService);
 
+  /** Removes and fences Hub-backed group operations on the public OIDC-only surface. */
+  @Input() publicOnly = false;
+
   mainTab: MainTab = 'share';
   view: PanelView = 'home';
   activeTab: 'chat' | 'participants' = 'chat';
@@ -425,11 +430,13 @@ export class AiSnakeSharePanelComponent implements OnInit {
   }
 
   switchToGroups(): void {
+    if (this.publicOnly) return;
     this.mainTab = 'groups';
     this.loadGroups();
   }
 
   private loadGroups(): void {
+    if (this.publicOnly) return;
     this.groupsLoading = true;
     const url = this.hubUrl;
     this.core.get<{ ok: boolean; groups: PairGroup[] }>(`${url}/pair-groups`, url).subscribe({
@@ -439,6 +446,7 @@ export class AiSnakeSharePanelComponent implements OnInit {
   }
 
   startCreateGroup(): void {
+    if (this.publicOnly) return;
     this.newGroupName = '';
     this.newGroupDesc = '';
     this.gperm_chat = true;
@@ -449,6 +457,7 @@ export class AiSnakeSharePanelComponent implements OnInit {
   }
 
   doCreateGroup(): void {
+    if (this.publicOnly) return;
     if (!this.newGroupName.trim()) { this.groupError = 'Name erforderlich'; return; }
     this.creatingGroup = true;
     this.groupError = '';
@@ -471,6 +480,7 @@ export class AiSnakeSharePanelComponent implements OnInit {
   }
 
   openGroup(g: PairGroup): void {
+    if (this.publicOnly) return;
     this.selectedGroup = g;
     this.groupMembers = [];
     this.newMemberId = '';
@@ -486,6 +496,7 @@ export class AiSnakeSharePanelComponent implements OnInit {
   }
 
   addMember(): void {
+    if (this.publicOnly) return;
     const uid = this.newMemberId.trim();
     if (!uid || !this.selectedGroup) return;
     this.memberError = '';
@@ -503,6 +514,7 @@ export class AiSnakeSharePanelComponent implements OnInit {
   }
 
   removeMember(m: PairGroupMember): void {
+    if (this.publicOnly) return;
     if (!this.selectedGroup) return;
     const url = this.hubUrl;
     this.core.delete(`${url}/pair-groups/${this.selectedGroup.id}/members/${m.user_id}`, url).subscribe({
@@ -512,6 +524,7 @@ export class AiSnakeSharePanelComponent implements OnInit {
   }
 
   deleteGroup(g: PairGroup): void {
+    if (this.publicOnly) return;
     if (!confirm(`Gruppe "${g.name}" löschen?`)) return;
     const url = this.hubUrl;
     this.core.delete(`${url}/pair-groups/${g.id}`, url).subscribe({
@@ -521,6 +534,7 @@ export class AiSnakeSharePanelComponent implements OnInit {
   }
 
   createGroupSession(g: PairGroup): void {
+    if (this.publicOnly) return;
     this.groupSessionInvite = '';
     const url = this.hubUrl;
     this.core.post<{ ok: boolean; session: any; invite_code: string }>(

--- a/frontend-angular/src/app/components/login.component.spec.ts
+++ b/frontend-angular/src/app/components/login.component.spec.ts
@@ -22,7 +22,11 @@ import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 
-function buildLogin(showRegistration: boolean, showOidc = true) {
+function buildLogin(
+  showRegistration: boolean,
+  showOidc = true,
+  oidcOverrides: Record<string, unknown> = {},
+) {
   TestBed.resetTestingModule();
   TestBed.configureTestingModule({
     imports: [LoginComponent],
@@ -32,7 +36,7 @@ function buildLogin(showRegistration: boolean, showOidc = true) {
       { provide: IdentityBridge, useValue: { showRegistration, showOidcLogin: showOidc, showHubDirectLogin: true, hubLinkEnabled: false } },
       {
         provide: OidcAuthService,
-        useValue: { registerWithKeycloak: vi.fn() },
+        useValue: { registerWithKeycloak: vi.fn(), ...oidcOverrides },
       },
       { provide: UserAuthService, useValue: { token: null, oidcAccessTokenValue: null } },
       { provide: AgentDirectoryService, useValue: { list: () => [], upsert: () => undefined, get: () => undefined } },
@@ -118,6 +122,34 @@ describe('LoginComponent — Self-Registration-Button', () => {
     expect(reg).toBeDefined();
     reg!.click();
     expect(registerWithKeycloak).toHaveBeenCalledTimes(1);
+  });
+
+  it('binds the Keycloak redirect to the dedicated Public Pair route', () => {
+    const startLogin = vi.fn();
+    const fixture = buildLogin(false, true, { startLogin });
+
+    fixture.componentInstance.loginWithKeycloak();
+
+    expect(startLogin).toHaveBeenCalledWith('/pair-dev');
+  });
+
+  it('navigates a completed OIDC device flow to the dedicated Public Pair route', async () => {
+    vi.useFakeTimers();
+    const startDeviceFlow = vi.fn().mockResolvedValue({
+      user_code: 'ABCD-EFGH',
+      verification_uri: 'https://keycloak.example/device',
+      device_code: 'device-code',
+      interval: 0,
+    });
+    const pollDeviceToken = vi.fn().mockResolvedValue(true);
+    const fixture = buildLogin(false, true, { startDeviceFlow, pollDeviceToken });
+    const router = TestBed.inject(Router);
+
+    await fixture.componentInstance.startDeviceFlow();
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(router.navigate).toHaveBeenCalledWith(['/pair-dev']);
+    vi.useRealTimers();
   });
 
   it('verwendet auf Android einen Remote-Hub ohne den Embedded Hub zu starten', async () => {

--- a/frontend-angular/src/app/components/login.component.ts
+++ b/frontend-angular/src/app/components/login.component.ts
@@ -306,7 +306,7 @@ export class LoginComponent implements OnInit {
   }
 
   loginWithKeycloak(): void {
-    void this.oidc.startLogin('/');
+    void this.oidc.startLogin('/pair-dev');
   }
 
   async linkIdentities(): Promise<void> {
@@ -347,7 +347,10 @@ export class LoginComponent implements OnInit {
       this.deviceFlowPollHandle = setInterval(async () => {
         try {
           const ok = await this.oidc.pollDeviceToken(data.device_code, data.interval);
-          if (ok) { this.stopDeviceFlow(); this.router.navigate(['/']); }
+          if (ok) {
+            this.stopDeviceFlow();
+            this.router.navigate(['/pair-dev']);
+          }
         } catch (e: any) {
           this.stopDeviceFlow();
           this.deviceFlowError = String(e?.message ?? 'Fehler');

--- a/frontend-angular/src/app/features/pair-view/webrtc-media-panel.component.spec.ts
+++ b/frontend-angular/src/app/features/pair-view/webrtc-media-panel.component.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { TestBed } from '@angular/core/testing';
 
 import { WebrtcMediaPanelComponent } from './webrtc-media-panel.component';
 
@@ -18,5 +19,18 @@ describe('WebrtcMediaPanelComponent Public Pair reasons', () => {
   it('keeps unknown codes visible under a Pair-authority fallback label', () => {
     expect(new WebrtcMediaPanelComponent().reasonLabel('media_e2ee_future_failure'))
       .toBe('Medienstatus der Pair-Autorität oder des Browsers:');
+  });
+
+  it('keeps the latest capture outcome observable while capture remains enabled', () => {
+    TestBed.configureTestingModule({ imports: [WebrtcMediaPanelComponent] });
+    const fixture = TestBed.createComponent(WebrtcMediaPanelComponent);
+    fixture.componentRef.setInput('captureEnabled', true);
+    fixture.componentRef.setInput('videoCaptureEnabled', true);
+    fixture.componentRef.setInput('captureReason', 'screen_active');
+    fixture.detectChanges();
+
+    expect((fixture.nativeElement as HTMLElement)
+      .querySelector('[data-testid="ordinary-media-operation-status"]')?.textContent)
+      .toContain('screen_active');
   });
 });

--- a/frontend-angular/src/app/features/pair-view/webrtc-media-panel.component.ts
+++ b/frontend-angular/src/app/features/pair-view/webrtc-media-panel.component.ts
@@ -25,6 +25,9 @@ import { WebrtcRemoteVideoComponent } from './webrtc-remote-video.component';
       @if (!captureEnabled || !videoCaptureEnabled) {
         <p role="note">{{ reasonLabel(captureReason) }} <code>{{ captureReason }}</code></p>
       }
+      <p class="notice" role="status" data-testid="ordinary-media-operation-status">
+        Letzter Medienstatus: <code>{{ captureReason }}</code>
+      </p>
       <article data-source="microphone" [attr.data-status]="audioState.status">
         <strong>Mikrofon</strong>
         <span>{{ statusLabel(audioState.status) }}</span>

--- a/frontend-angular/src/app/features/pair/public-pair-page.component.spec.ts
+++ b/frontend-angular/src/app/features/pair/public-pair-page.component.spec.ts
@@ -1,0 +1,94 @@
+import { Component, Input } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { BehaviorSubject, of } from 'rxjs';
+import { describe, expect, it, vi } from 'vitest';
+
+import { AiSnakeSharePanelComponent } from '../../components/ai-snake-share-panel.component';
+import { AgentDirectoryService } from '../../services/agent-directory.service';
+import { HubApiCoreService } from '../../services/hub-api-core.service';
+import { OidcAuthService } from '../../services/oidc-auth.service';
+import { PairViewSessionBindingService } from '../../services/pair-view-session-binding.service';
+import { ShareSessionService } from '../../services/share-session.service';
+import { WebrtcSignalingService } from '../../services/webrtc-signaling.service';
+import { SemanticMediaProgramHostComponent } from '../voice/semantic-media-program-host.component';
+import { PublicPairPageComponent } from './public-pair-page.component';
+
+@Component({
+  selector: 'app-semantic-media-program-host',
+  standalone: true,
+  template: '',
+})
+class SemanticMediaProgramHostStubComponent {
+  @Input() displayMode = '';
+}
+
+describe('PublicPairPageComponent', () => {
+  it('renders the direct Pair surface without initializing or exposing Hub group APIs', async () => {
+    const status$ = new BehaviorSubject('disconnected');
+    const core = {
+      get: vi.fn(() => of({})),
+      post: vi.fn(() => of({})),
+      delete: vi.fn(() => of({})),
+    };
+    const share = {
+      isActive: false,
+      state$: new BehaviorSubject(null),
+      securityState$: new BehaviorSubject({ status: 'idle' }),
+      createSession: vi.fn(),
+      joinSession: vi.fn(),
+    };
+
+    await TestBed.configureTestingModule({
+      providers: [
+        { provide: OidcAuthService, useValue: { currentUsername: 'keycloak-user' } },
+        { provide: WebrtcSignalingService, useValue: { status$ } },
+        { provide: ShareSessionService, useValue: share },
+        { provide: PairViewSessionBindingService, useValue: { start: vi.fn() } },
+        {
+          provide: AgentDirectoryService,
+          useValue: { list: () => [{ role: 'hub', url: 'https://hub.example.test' }] },
+        },
+        { provide: HubApiCoreService, useValue: core },
+      ],
+    });
+    TestBed.overrideComponent(PublicPairPageComponent, {
+      remove: { imports: [SemanticMediaProgramHostComponent] },
+      add: { imports: [SemanticMediaProgramHostStubComponent] },
+    });
+    await TestBed.compileComponents();
+
+    const fixture = TestBed.createComponent(PublicPairPageComponent);
+    fixture.detectChanges();
+    const host = fixture.nativeElement as HTMLElement;
+    const panel = fixture.debugElement.query(By.directive(AiSnakeSharePanelComponent))
+      .componentInstance as AiSnakeSharePanelComponent;
+    const media = fixture.debugElement.query(By.directive(SemanticMediaProgramHostStubComponent))
+      .componentInstance as SemanticMediaProgramHostStubComponent;
+
+    expect(host.querySelector('[data-testid="public-pair-page"]')).not.toBeNull();
+    expect(host.querySelector('[data-testid="public-pair-user"]')?.textContent).toContain('keycloak-user');
+    expect(host.querySelector('[data-testid="public-pair-webrtc-status"]')?.textContent)
+      .toContain('WebRTC: disconnected');
+    expect(panel.publicOnly).toBe(true);
+    expect(media.displayMode).toBe('pair_media');
+    expect(host.textContent).not.toContain('Gruppen');
+    expect(core.get).not.toHaveBeenCalled();
+    expect(core.post).not.toHaveBeenCalled();
+    expect(core.delete).not.toHaveBeenCalled();
+
+    panel.switchToGroups();
+    panel.startCreateGroup();
+    panel.newGroupName = 'blocked';
+    panel.doCreateGroup();
+    panel.openGroup({ id: 'group-a' } as never);
+    panel.addMember();
+    panel.removeMember({ id: 'member-a' } as never);
+    panel.deleteGroup({ id: 'group-a', name: 'blocked' } as never);
+    panel.createGroupSession({ id: 'group-a' } as never);
+
+    expect(core.get).not.toHaveBeenCalled();
+    expect(core.post).not.toHaveBeenCalled();
+    expect(core.delete).not.toHaveBeenCalled();
+  });
+});

--- a/frontend-angular/src/app/features/pair/public-pair-page.component.ts
+++ b/frontend-angular/src/app/features/pair/public-pair-page.component.ts
@@ -1,0 +1,63 @@
+import { AsyncPipe } from '@angular/common';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+
+import { AiSnakeSharePanelComponent } from '../../components/ai-snake-share-panel.component';
+import { SemanticMediaProgramHostComponent } from '../voice/semantic-media-program-host.component';
+import { OidcAuthService } from '../../services/oidc-auth.service';
+import { WebrtcSignalingService } from '../../services/webrtc-signaling.service';
+
+@Component({
+  selector: 'app-public-pair-page',
+  standalone: true,
+  imports: [AsyncPipe, AiSnakeSharePanelComponent, SemanticMediaProgramHostComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <section class="public-pair-page" data-testid="public-pair-page" aria-labelledby="public-pair-title">
+      <header class="public-pair-header">
+        <div>
+          <h1 id="public-pair-title">Public Pair Dev</h1>
+          <p>Direkte, Ende-zu-Ende-verschlüsselte Pair-Session</p>
+        </div>
+        <div class="public-pair-status" aria-label="Public-Pair-Verbindungsstatus">
+          <span data-testid="public-pair-user">{{ oidc.currentUsername || 'Angemeldet' }}</span>
+          <span data-testid="public-pair-webrtc-status">WebRTC: {{ signaling.status$ | async }}</span>
+        </div>
+      </header>
+
+      <section class="public-pair-session" aria-label="Session Sharing">
+        <app-ai-snake-share-panel [publicOnly]="true" />
+      </section>
+      <section class="public-pair-media" aria-label="Audio und Video">
+        <app-semantic-media-program-host displayMode="pair_media" />
+      </section>
+    </section>
+  `,
+  styles: [`
+    :host { display: block; min-height: 100%; }
+    .public-pair-page {
+      box-sizing: border-box; max-width: 1080px; margin: 0 auto; padding: 20px;
+      color: var(--fg); font-family: ui-monospace, Menlo, Consolas, monospace;
+    }
+    .public-pair-header {
+      display: flex; align-items: flex-start; justify-content: space-between; gap: 20px;
+      margin-bottom: 18px; padding: 16px; border: 1px solid var(--border);
+      border-radius: 8px; background: var(--card-bg);
+    }
+    h1 { margin: 0 0 4px; font-size: 20px; }
+    p { margin: 0; color: var(--muted); font-size: 12px; }
+    .public-pair-status { display: grid; gap: 4px; text-align: right; color: var(--muted); font-size: 12px; }
+    .public-pair-session, .public-pair-media {
+      margin-top: 14px; padding: 12px; border: 1px solid var(--border);
+      border-radius: 8px; background: var(--card-bg);
+    }
+    @media (max-width: 640px) {
+      .public-pair-page { padding: 10px; }
+      .public-pair-header { flex-direction: column; }
+      .public-pair-status { text-align: left; }
+    }
+  `],
+})
+export class PublicPairPageComponent {
+  readonly oidc = inject(OidcAuthService);
+  readonly signaling = inject(WebrtcSignalingService);
+}

--- a/frontend-angular/src/app/guards/public-pair.guard.spec.ts
+++ b/frontend-angular/src/app/guards/public-pair.guard.spec.ts
@@ -1,0 +1,87 @@
+import { TestBed } from '@angular/core/testing';
+import { provideRouter, Router, UrlTree } from '@angular/router';
+import { describe, expect, it } from 'vitest';
+
+import { publicPairGuard } from './public-pair.guard';
+import { NetworkProfileService } from '../services/network-profile.service';
+import { PairPublicAuthorityPolicy } from '../services/pair-public-authority.policy';
+import { PUBLIC_OIDC_ISSUER, PUBLIC_WEBRTC_BASE_URL } from '../services/public-ananta-endpoints';
+import { UserAuthService } from '../services/user-auth.service';
+
+function jwt(payload: Record<string, unknown>): string {
+  const encoded = btoa(JSON.stringify(payload))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+  return `header.${encoded}.signature`;
+}
+
+function trustedProfile(): Record<string, unknown> {
+  return {
+    profile_id: 'public-ananta',
+    require_e2e_payload_encryption: true,
+    transport_order: ['webrtc'],
+    oidc: { issuer: PUBLIC_OIDC_ISSUER },
+    rendezvous: { base_url: PUBLIC_WEBRTC_BASE_URL, transport_order: ['webrtc'] },
+  };
+}
+
+function runGuard(token: string | null, profile = trustedProfile(), optedIn = true): boolean | UrlTree {
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({
+    providers: [
+      provideRouter([]),
+      PairPublicAuthorityPolicy,
+      { provide: UserAuthService, useValue: { oidcAccessTokenValue: token } },
+      {
+        provide: NetworkProfileService,
+        useValue: { current: profile, publicPairOptedIn: optedIn },
+      },
+    ],
+  });
+  return TestBed.runInInjectionContext(() => publicPairGuard({} as never, {} as never)) as boolean | UrlTree;
+}
+
+describe('publicPairGuard', () => {
+  it('allows a current token bound to the pinned public authority', () => {
+    const result = runGuard(jwt({
+      iss: PUBLIC_OIDC_ISSUER,
+      sub: 'public-user',
+      exp: Math.floor(Date.now() / 1000) + 300,
+    }));
+
+    expect(result).toBe(true);
+  });
+
+  it.each([
+    ['missing', null],
+    ['malformed', 'not-a-jwt'],
+    ['expired', jwt({
+      iss: PUBLIC_OIDC_ISSUER,
+      sub: 'public-user',
+      exp: Math.floor(Date.now() / 1000) - 1,
+    })],
+    ['foreign issuer', jwt({
+      iss: 'https://attacker.invalid/realms/foreign',
+      sub: 'public-user',
+      exp: Math.floor(Date.now() / 1000) + 300,
+    })],
+  ])('redirects an %s OIDC identity to the pinned login entry', (_label, token) => {
+    const result = runGuard(token);
+    const router = TestBed.inject(Router);
+
+    expect(result).toBeInstanceOf(UrlTree);
+    expect(router.serializeUrl(result as UrlTree)).toBe('/login?sphere=oidc');
+  });
+
+  it('rejects a current token when the selected profile is not the trusted public profile', () => {
+    const profile = { ...trustedProfile(), profile_id: 'mutable-profile' };
+    const result = runGuard(jwt({
+      iss: PUBLIC_OIDC_ISSUER,
+      sub: 'public-user',
+      exp: Math.floor(Date.now() / 1000) + 300,
+    }), profile);
+
+    expect(result).toBeInstanceOf(UrlTree);
+  });
+});

--- a/frontend-angular/src/app/guards/public-pair.guard.ts
+++ b/frontend-angular/src/app/guards/public-pair.guard.ts
@@ -1,0 +1,14 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+
+import { PairPublicAuthorityPolicy } from '../services/pair-public-authority.policy';
+
+/** Allows the public Pair surface only for the pinned, current OIDC authority. */
+export const publicPairGuard: CanActivateFn = () => {
+  const authority = inject(PairPublicAuthorityPolicy);
+  const router = inject(Router);
+
+  return authority.ready
+    ? true
+    : router.parseUrl('/login?sphere=oidc');
+};

--- a/frontend-angular/src/app/services/auth-required-router.service.spec.ts
+++ b/frontend-angular/src/app/services/auth-required-router.service.spec.ts
@@ -7,12 +7,12 @@ import { AuthRefreshCoordinator } from './auth-refresh-coordinator.service';
 import { BehaviorSubject } from 'rxjs';
 
 describe('AuthRequiredRouter — Welle 6 redirect on authRequired', () => {
-  let router: { navigate: ReturnType<typeof vi.fn> };
+  let router: { navigate: ReturnType<typeof vi.fn>; url: string };
   let coordinator: { authRequired$: BehaviorSubject<'hub' | 'oidc' | null> };
 
   beforeEach(() => {
     TestBed.resetTestingModule();
-    router = { navigate: vi.fn() };
+    router = { navigate: vi.fn(), url: '/workspace' };
     coordinator = { authRequired$: new BehaviorSubject<'hub' | 'oidc' | null>(null) };
     TestBed.configureTestingModule({
       providers: [
@@ -35,6 +35,22 @@ describe('AuthRequiredRouter — Welle 6 redirect on authRequired', () => {
     svc.start();
     coordinator.authRequired$.next('hub');
     expect(router.navigate).toHaveBeenCalledWith(['/login'], { queryParams: { sphere: 'hub' } });
+  });
+
+  it('does not let an ambient Hub 401 evict an OIDC-only Public Pair route', () => {
+    router.url = '/pair-dev';
+    const svc = TestBed.inject(AuthRequiredRouter);
+    svc.start();
+    coordinator.authRequired$.next('hub');
+    expect(router.navigate).not.toHaveBeenCalled();
+  });
+
+  it('still routes an OIDC failure from Public Pair to the OIDC login', () => {
+    router.url = '/pair-dev';
+    const svc = TestBed.inject(AuthRequiredRouter);
+    svc.start();
+    coordinator.authRequired$.next('oidc');
+    expect(router.navigate).toHaveBeenCalledWith(['/login'], { queryParams: { sphere: 'oidc' } });
   });
 
   it('does NOT navigate on the initial null emission', () => {

--- a/frontend-angular/src/app/services/auth-required-router.service.ts
+++ b/frontend-angular/src/app/services/auth-required-router.service.ts
@@ -18,9 +18,16 @@ export class AuthRequiredRouter {
   start(): void {
     this.coordinator.authRequired$.subscribe((sphere) => {
       if (sphere === null) return;
+      // A failed ambient Hub request must not evict a valid OIDC-only Pair
+      // session from its independently authorized surface.
+      if (sphere === 'hub' && this.publicPairSurfaceActive()) return;
       // We pass the failing sphere as a query param so LoginComponent can
       // pre-select the right mask (OIDC vs Hub-direct).
       void this.router.navigate(['/login'], { queryParams: { sphere } });
     });
+  }
+
+  private publicPairSurfaceActive(): boolean {
+    return this.router.url.split(/[?#]/, 1)[0] === '/pair-dev';
   }
 }

--- a/frontend-angular/src/app/services/network-profile.service.spec.ts
+++ b/frontend-angular/src/app/services/network-profile.service.spec.ts
@@ -107,7 +107,7 @@ describe('NetworkProfileService semantic media flags', () => {
     expect(localStorage.getItem('ananta.network-profile-selection.v1')).toBeNull();
   });
 
-  it('keeps public semantic media disabled even when a Hub projection requests it', async () => {
+  it('keeps the pinned public profile independent from mutable Hub projections', async () => {
     const profile = {
       profile_id: 'public-ananta', label: 'Test', oidc: {
         issuer: '', client_id: '', audience: '', pkce_required: true,
@@ -126,17 +126,20 @@ describe('NetworkProfileService semantic media flags', () => {
         peer_evidence_sync: true,
       },
     };
+    const get = vi.fn(() => of({ ok: true, profile }));
     TestBed.configureTestingModule({
       providers: [
         NetworkProfileService,
         { provide: AgentDirectoryService, useValue: { list: () => [{ role: 'hub', url: 'http://hub' }] } },
-        { provide: HubApiCoreService, useValue: { get: () => of({ ok: true, profile }) } },
+        { provide: HubApiCoreService, useValue: { get } },
       ],
     });
     const service = TestBed.inject(NetworkProfileService);
     await service.enablePublicPair();
     await service.load();
     expect(service.current.semantic_media_feature_flags).toEqual(SEMANTIC_MEDIA_FEATURE_DEFAULTS);
+    expect(service.current.rendezvous?.base_url).toBe('https://webrtc.ananta.de');
+    expect(get).not.toHaveBeenCalled();
   });
 
   it('accepts a dependency-complete semantic media projection for a private profile', async () => {

--- a/frontend-angular/src/app/services/network-profile.service.ts
+++ b/frontend-angular/src/app/services/network-profile.service.ts
@@ -219,6 +219,9 @@ export class NetworkProfileService {
       : profileId;
     if (effectiveProfileId === PUBLIC_PROFILE_ID) {
       this.profile$.next(PUBLIC_FALLBACK);
+      // The public Pair authority is compile-time pinned and intentionally
+      // independent from Hub authentication or mutable Hub projections.
+      return;
     } else if (effectiveProfileId === LOCAL_PROFILE_ID) {
       this.profile$.next(LOCAL_FALLBACK);
     }

--- a/frontend-angular/src/app/services/oidc-auth.service.spec.ts
+++ b/frontend-angular/src/app/services/oidc-auth.service.spec.ts
@@ -57,6 +57,15 @@ function makeUserAuthStub() {
       oidcToken$.next(accessToken);
       return { committed: true, refreshTokenPersisted: refreshToken !== null };
     }),
+    decodeTokenPayload: vi.fn((token: string | null) => {
+      if (!token) return null;
+      try {
+        const payload = token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/');
+        return JSON.parse(atob(payload.padEnd(Math.ceil(payload.length / 4) * 4, '=')));
+      } catch {
+        return null;
+      }
+    }),
     userPayload: null,
     logout: vi.fn(),
   };
@@ -197,6 +206,21 @@ describe('OidcAuthService', () => {
   });
 
   describe('profile configuration', () => {
+    it('derives the displayed username from the OIDC token, never the Hub identity', () => {
+      buildSvc();
+      (userAuth as unknown as { userPayload: unknown }).userPayload = {
+        preferred_username: 'hub-user',
+      };
+      userAuth.setOidcAccessToken(unsignedJwt({
+        iss: PUBLIC_OIDC_ISSUER,
+        sub: 'oidc-subject',
+        preferred_username: 'pair-user',
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      }));
+
+      expect(svc.currentUsername).toBe('pair-user');
+    });
+
     it('does not advertise an expired stored token as an active login', () => {
       buildSvc();
       const states: boolean[] = [];

--- a/frontend-angular/src/app/services/oidc-auth.service.ts
+++ b/frontend-angular/src/app/services/oidc-auth.service.ts
@@ -148,7 +148,7 @@ export class OidcAuthService implements OnDestroy {
   }
 
   get currentUsername(): string {
-    const p = this.userAuth.userPayload;
+    const p = this.userAuth.decodeTokenPayload(this.userAuth.oidcAccessTokenValue);
     return String(p?.preferred_username || p?.email || p?.sub || '');
   }
 

--- a/frontend-angular/src/app/services/pair-media-e2ee-coordinator.service.spec.ts
+++ b/frontend-angular/src/app/services/pair-media-e2ee-coordinator.service.spec.ts
@@ -10,7 +10,7 @@ import { PairSecureSequenceService } from './pair-secure-sequence.service';
 import { PairViewSecurityBootstrapService } from './pair-view-security-bootstrap.service';
 import {
   PUBLIC_PAIR_MEDIA_SLOTS,
-  PublicPairMediaSecurityContractV1,
+  PublicPairMediaSecurityContractV2,
 } from './public-pair-media-security-contract';
 import { SemanticDataChannelMessage } from './webrtc-datachannel.service';
 import { VerifiedPeerBinding, WebrtcPeerKeyService } from './webrtc-peer-key.service';
@@ -65,6 +65,23 @@ describe('PairMediaE2eeCoordinatorService', () => {
       expect(ownerSlot.sendContext).toEqual(guestSlot.receiveContext);
       expect(ownerSlot.sendContext.connectionId).toBe(ownerSlot.receiveContext.connectionId);
     }
+  });
+
+  it('binds the exact v2 frame format into the encrypted bilateral hello', async () => {
+    const owner = node('peer:owner', 'peer:guest');
+    bindSink(owner);
+    prepareNegotiation(owner);
+
+    void owner.coordinator.activate('session-a');
+    await settle(6);
+
+    const hello = decodeControl(owner.outbound[0]);
+    expect(hello).toMatchObject({
+      schema: 'ananta.public-pair.media-hello.v2',
+      kind: 'hello',
+      frame_format: 'ananta.public-pair.media-frame.v2',
+      media_contract_digest: 'a'.repeat(64),
+    });
   });
 
   it('returns genuine failure immediately but resolves deactivate as inactive', async () => {
@@ -320,15 +337,25 @@ class TransparentEncryption {
   }
 }
 
-function contract(expiresAtMs: number): PublicPairMediaSecurityContractV1 {
+function contract(expiresAtMs: number): PublicPairMediaSecurityContractV2 {
   return {
+    domain: 'ananta.public-pair.media-security-contract.v2', version: 2,
     session_id: 'session-a', epoch: 7, digest: 'a'.repeat(64), expires_at_ms: expiresAtMs,
     transform: 'RTCRtpScriptTransform',
-  } as PublicPairMediaSecurityContractV1;
+    frame_format: 'ananta.public-pair.media-frame.v2',
+  } as PublicPairMediaSecurityContractV2;
 }
 
 function countControl(value: CoordinatorNode, kind: 'hello' | 'hello_ack'): number {
   return value.sent.filter(message => message.message_id.includes(`pair-media-${kind}-`)).length;
+}
+
+function decodeControl(message: SemanticDataChannelMessage | undefined): Record<string, unknown> {
+  if (!message) throw new Error('test_control_message_missing');
+  const envelope = JSON.parse(new TextDecoder().decode(decodeB64(message.ciphertext))) as {
+    ciphertext_b64: string;
+  };
+  return JSON.parse(new TextDecoder().decode(decodeB64(envelope.ciphertext_b64))) as Record<string, unknown>;
 }
 
 async function settle(turns = 3): Promise<void> {

--- a/frontend-angular/src/app/services/pair-media-e2ee-coordinator.service.ts
+++ b/frontend-angular/src/app/services/pair-media-e2ee-coordinator.service.ts
@@ -8,8 +8,9 @@ import { PairViewSecurityBootstrapService } from './pair-view-security-bootstrap
 import {
   PUBLIC_PAIR_MEDIA_GRANTS,
   PUBLIC_PAIR_MEDIA_SLOTS,
-  PublicPairMediaSecurityContractV1,
+  PublicPairMediaSecurityContractV2,
 } from './public-pair-media-security-contract';
+import { PUBLIC_PAIR_MEDIA_FRAME_FORMAT_V2 } from './pair-media-frame-format';
 import {
   SEMANTIC_DC_VERSION,
   SemanticDataChannelMessage,
@@ -44,27 +45,29 @@ export interface PairMediaE2eeTransportPort {
   failClosed(reasonCode: string): void;
 }
 
-interface MediaHelloV1 {
-  readonly schema: 'ananta.public-pair.media-hello.v1';
+interface MediaHelloV2 {
+  readonly schema: 'ananta.public-pair.media-hello.v2';
   readonly kind: 'hello';
   readonly session_id: string;
   readonly epoch: number;
   readonly sender_id: string;
   readonly recipient_id: string;
   readonly media_contract_digest: string;
+  readonly frame_format: typeof PUBLIC_PAIR_MEDIA_FRAME_FORMAT_V2;
   readonly connection_salt_b64: string;
   readonly slots: typeof PUBLIC_PAIR_MEDIA_GRANTS;
   readonly expires_at_ms: number;
 }
 
-interface MediaHelloAckV1 {
-  readonly schema: 'ananta.public-pair.media-hello-ack.v1';
+interface MediaHelloAckV2 {
+  readonly schema: 'ananta.public-pair.media-hello-ack.v2';
   readonly kind: 'hello_ack';
   readonly session_id: string;
   readonly epoch: number;
   readonly sender_id: string;
   readonly recipient_id: string;
   readonly media_contract_digest: string;
+  readonly frame_format: typeof PUBLIC_PAIR_MEDIA_FRAME_FORMAT_V2;
   readonly hello_digests: readonly [
     Readonly<{ peer_id: string; digest: string }>,
     Readonly<{ peer_id: string; digest: string }>,
@@ -76,18 +79,18 @@ interface Runtime {
   readonly sessionId: string;
   readonly generation: number;
   readonly adapterGeneration: number;
-  readonly contract: Readonly<PublicPairMediaSecurityContractV1>;
+  readonly contract: Readonly<PublicPairMediaSecurityContractV2>;
   readonly binding: Readonly<VerifiedPeerBinding>;
   port: PairMediaE2eeTransportPort | null;
   dataChannelOpen: boolean;
   topologyReady: boolean;
   localActivated: boolean;
-  localHello: MediaHelloV1 | null;
+  localHello: MediaHelloV2 | null;
   localHelloDigest: string;
-  remoteHello: MediaHelloV1 | null;
+  remoteHello: MediaHelloV2 | null;
   remoteHelloDigest: string;
-  localAck: MediaHelloAckV1 | null;
-  remoteAck: MediaHelloAckV1 | null;
+  localAck: MediaHelloAckV2 | null;
+  remoteAck: MediaHelloAckV2 | null;
   localAckSent: boolean;
   helloSendPromise: Promise<void> | null;
   ackSendPromise: Promise<void> | null;
@@ -136,7 +139,12 @@ export class PairMediaE2eeCoordinatorService {
 
   canActivate(sessionId: string): boolean {
     const contract = this.bootstrap.mediaContractFor(sessionId);
-    if (!contract || contract.expires_at_ms <= Date.now()) return false;
+    if (
+      !contract
+      || contract.version !== 2
+      || contract.frame_format !== PUBLIC_PAIR_MEDIA_FRAME_FORMAT_V2
+      || contract.expires_at_ms <= Date.now()
+    ) return false;
     const runtime = this.runtime;
     if (runtime?.sessionId === sessionId && (runtime.failed || runtime.installed)) return false;
     return this.transforms.isPrepared(sessionId, contract.epoch, contract.digest);
@@ -167,7 +175,7 @@ export class PairMediaE2eeCoordinatorService {
       return this.statusFor(sessionId);
     }
     runtime.localActivated = true;
-    this.emit(runtime, 'awaiting-peer');
+    this.emit(runtime, 'awaiting-peer', 'public_media_local_activation_pending');
     void this.maybeSendHello(runtime).catch(error => {
       this.failRuntime(runtime, reason(error, 'public_media_hello_send_failed'), true);
     });
@@ -293,6 +301,9 @@ export class PairMediaE2eeCoordinatorService {
       ? this.transforms.generationForSession(sessionId) : null;
     if (
       !contract
+      || contract.version !== 2
+      || contract.domain !== 'ananta.public-pair.media-security-contract.v2'
+      || contract.frame_format !== PUBLIC_PAIR_MEDIA_FRAME_FORMAT_V2
       || contract.session_id !== sessionId
       || contract.epoch !== binding.epoch
       || contract.expires_at_ms <= Date.now()
@@ -356,13 +367,14 @@ export class PairMediaE2eeCoordinatorService {
       if (expiresAtMs <= Date.now()) throw new Error('public_media_contract_expired');
       const salt = crypto.getRandomValues(new Uint8Array(16));
       const hello = parseHello({
-        schema: 'ananta.public-pair.media-hello.v1',
+        schema: 'ananta.public-pair.media-hello.v2',
         kind: 'hello',
         session_id: runtime.sessionId,
         epoch: runtime.contract.epoch,
         sender_id: runtime.binding.localPeerId,
         recipient_id: runtime.binding.remotePeerId,
         media_contract_digest: runtime.contract.digest,
+        frame_format: PUBLIC_PAIR_MEDIA_FRAME_FORMAT_V2,
         connection_salt_b64: encodeB64(salt),
         slots: PUBLIC_PAIR_MEDIA_GRANTS,
         expires_at_ms: expiresAtMs,
@@ -373,14 +385,18 @@ export class PairMediaE2eeCoordinatorService {
       // loopback/fast peer may answer before send() resolves.
       runtime.localHello = hello;
       runtime.localHelloDigest = helloDigest;
+      this.emit(runtime, 'awaiting-peer', 'public_media_local_hello_preparing');
       await this.sendControl(runtime, hello);
       this.assertCurrent(runtime);
+      if (!runtime.remoteHello) {
+        this.emit(runtime, 'awaiting-peer', 'public_media_local_hello_sent');
+      }
       await this.maybeSendAck(runtime);
     })().finally(() => { runtime.helloSendPromise = null; });
     return runtime.helloSendPromise;
   }
 
-  private async acceptHello(runtime: Runtime, hello: MediaHelloV1): Promise<void> {
+  private async acceptHello(runtime: Runtime, hello: MediaHelloV2): Promise<void> {
     const digest = await digestCanonical(hello);
     this.assertCurrent(runtime);
     if (runtime.remoteHello && runtime.remoteHelloDigest !== digest) {
@@ -401,6 +417,7 @@ export class PairMediaE2eeCoordinatorService {
     }
     runtime.remoteHello = hello;
     runtime.remoteHelloDigest = digest;
+    this.emit(runtime, 'awaiting-peer', 'public_media_remote_hello_received');
     if (runtime.localActivated) {
       await this.maybeSendHello(runtime);
       await this.maybeSendAck(runtime);
@@ -415,13 +432,14 @@ export class PairMediaE2eeCoordinatorService {
     ) return runtime.ackSendPromise ?? Promise.resolve();
     runtime.ackSendPromise = (async () => {
       const ack = parseAck({
-        schema: 'ananta.public-pair.media-hello-ack.v1',
+        schema: 'ananta.public-pair.media-hello-ack.v2',
         kind: 'hello_ack',
         session_id: runtime.sessionId,
         epoch: runtime.contract.epoch,
         sender_id: runtime.binding.localPeerId,
         recipient_id: runtime.binding.remotePeerId,
         media_contract_digest: runtime.contract.digest,
+        frame_format: PUBLIC_PAIR_MEDIA_FRAME_FORMAT_V2,
         hello_digests: helloDigestRows(runtime),
         expires_at_ms: Math.min(runtime.contract.expires_at_ms, Date.now() + CONTROL_TTL_MS),
       }, runtime, 'outbound');
@@ -432,12 +450,15 @@ export class PairMediaE2eeCoordinatorService {
       this.assertCurrent(runtime);
       runtime.localAck = ack;
       runtime.localAckSent = true;
+      if (!runtime.remoteAck) {
+        this.emit(runtime, 'awaiting-peer', 'public_media_local_ack_sent');
+      }
       await this.maybeInstall(runtime);
     })().finally(() => { runtime.ackSendPromise = null; });
     return runtime.ackSendPromise;
   }
 
-  private async acceptAck(runtime: Runtime, ack: MediaHelloAckV1): Promise<void> {
+  private async acceptAck(runtime: Runtime, ack: MediaHelloAckV2): Promise<void> {
     this.assertCurrent(runtime);
     if (!runtime.localHello || !runtime.remoteHello) throw new Error('public_media_hello_missing');
     if (canonicalSecurityJson(ack.hello_digests) !== canonicalSecurityJson(helloDigestRows(runtime))) {
@@ -447,6 +468,7 @@ export class PairMediaE2eeCoordinatorService {
       throw new Error('public_media_ack_conflict');
     }
     runtime.remoteAck = ack;
+    this.emit(runtime, 'negotiating', 'public_media_remote_ack_received');
     await this.maybeInstall(runtime);
   }
 
@@ -491,8 +513,8 @@ export class PairMediaE2eeCoordinatorService {
         runtime, connectionId, runtime.binding.remotePeerId, runtime.binding.localPeerId, definition.slot,
       );
       const [sendKey, receiveKey] = await Promise.all([
-        this.encryption.derivePurposeAesKey(runtime.binding, 'public-pair-media-frame', sendBindingId),
-        this.encryption.derivePurposeAesKey(runtime.binding, 'public-pair-media-frame', receiveBindingId),
+        this.encryption.derivePurposeAesKey(runtime.binding, 'public-pair-media-frame-v2', sendBindingId),
+        this.encryption.derivePurposeAesKey(runtime.binding, 'public-pair-media-frame-v2', receiveBindingId),
       ]);
       this.assertCurrent(runtime);
       values.push(Object.freeze({
@@ -558,13 +580,14 @@ export class PairMediaE2eeCoordinatorService {
     runtime.localAckSent = false;
   }
 
-  private async sendControl(runtime: Runtime, control: MediaHelloV1 | MediaHelloAckV1): Promise<void> {
+  private async sendControl(runtime: Runtime, control: MediaHelloV2 | MediaHelloAckV2): Promise<void> {
     this.assertCurrent(runtime);
     if (!runtime.port || !runtime.dataChannelOpen) throw new Error('public_media_transport_not_open');
     const sequence = await this.sequences.next(
       runtime.sessionId, runtime.contract.epoch, runtime.binding.localPeerId, 'media',
     );
     this.assertCurrent(runtime);
+    this.emitControlStage(runtime, control, 'sequence_reserved');
     const envelope = await this.encryption.seal(
       runtime.binding,
       new TextEncoder().encode(canonicalSecurityJson(control)),
@@ -576,6 +599,7 @@ export class PairMediaE2eeCoordinatorService {
       },
     );
     this.assertCurrent(runtime);
+    this.emitControlStage(runtime, control, 'sealed');
     const envelopeBytes = new TextEncoder().encode(canonicalSecurityJson(envelope));
     const message = await validateSemanticDcMessage({
       version: SEMANTIC_DC_VERSION,
@@ -594,14 +618,25 @@ export class PairMediaE2eeCoordinatorService {
       ciphertext: encodeB64(envelopeBytes),
     });
     this.assertCurrent(runtime);
+    this.emitControlStage(runtime, control, 'framed');
     await runtime.port.send(message);
     this.assertCurrent(runtime);
+    this.emitControlStage(runtime, control, 'queued');
+  }
+
+  private emitControlStage(
+    runtime: Runtime,
+    control: MediaHelloV2 | MediaHelloAckV2,
+    stage: 'sequence_reserved' | 'sealed' | 'framed' | 'queued',
+  ): void {
+    const kind = control.kind === 'hello_ack' ? 'ack' : 'hello';
+    this.emit(runtime, 'awaiting-peer', `public_media_local_${kind}_${stage}`);
   }
 
   private async openControl(
     runtime: Runtime,
     raw: SemanticDataChannelMessage,
-  ): Promise<MediaHelloV1 | MediaHelloAckV1> {
+  ): Promise<MediaHelloV2 | MediaHelloAckV2> {
     const message = await validateSemanticDcMessage(raw);
     this.assertCurrent(runtime);
     if (
@@ -779,17 +814,18 @@ function parseHello(
   raw: unknown,
   runtime: Runtime,
   direction: 'inbound' | 'outbound',
-): MediaHelloV1 {
+): MediaHelloV2 {
   const value = closedObject(raw, [
     'schema', 'kind', 'session_id', 'epoch', 'sender_id', 'recipient_id',
-    'media_contract_digest', 'connection_salt_b64', 'slots', 'expires_at_ms',
+    'media_contract_digest', 'frame_format', 'connection_salt_b64', 'slots', 'expires_at_ms',
   ], 'public_media_hello_invalid');
   if (
-    value['schema'] !== 'ananta.public-pair.media-hello.v1'
+    value['schema'] !== 'ananta.public-pair.media-hello.v2'
     || value['kind'] !== 'hello'
     || value['session_id'] !== runtime.sessionId
     || value['epoch'] !== runtime.contract.epoch
     || value['media_contract_digest'] !== runtime.contract.digest
+    || value['frame_format'] !== PUBLIC_PAIR_MEDIA_FRAME_FORMAT_V2
     || !exactStrings(value['slots'], PUBLIC_PAIR_MEDIA_GRANTS)
     || !validControlExpiry(value['expires_at_ms'], runtime.contract.expires_at_ms)
   ) throw new Error('public_media_hello_invalid');
@@ -798,24 +834,25 @@ function parseHello(
   if (salt.byteLength !== 16 || encodeB64(salt) !== value['connection_salt_b64']) {
     throw new Error('public_media_hello_invalid');
   }
-  return Object.freeze(value as unknown as MediaHelloV1);
+  return Object.freeze(value as unknown as MediaHelloV2);
 }
 
 function parseAck(
   raw: unknown,
   runtime: Runtime,
   direction: 'inbound' | 'outbound',
-): MediaHelloAckV1 {
+): MediaHelloAckV2 {
   const value = closedObject(raw, [
     'schema', 'kind', 'session_id', 'epoch', 'sender_id', 'recipient_id',
-    'media_contract_digest', 'hello_digests', 'expires_at_ms',
+    'media_contract_digest', 'frame_format', 'hello_digests', 'expires_at_ms',
   ], 'public_media_ack_invalid');
   if (
-    value['schema'] !== 'ananta.public-pair.media-hello-ack.v1'
+    value['schema'] !== 'ananta.public-pair.media-hello-ack.v2'
     || value['kind'] !== 'hello_ack'
     || value['session_id'] !== runtime.sessionId
     || value['epoch'] !== runtime.contract.epoch
     || value['media_contract_digest'] !== runtime.contract.digest
+    || value['frame_format'] !== PUBLIC_PAIR_MEDIA_FRAME_FORMAT_V2
     || !validControlExpiry(value['expires_at_ms'], runtime.contract.expires_at_ms)
   ) throw new Error('public_media_ack_invalid');
   validateDirectedPeers(value, runtime, direction);
@@ -831,8 +868,8 @@ function parseAck(
   });
   if (rows[0].peer_id >= rows[1].peer_id) throw new Error('public_media_ack_invalid');
   return Object.freeze({
-    ...(value as unknown as MediaHelloAckV1),
-    hello_digests: Object.freeze(rows) as MediaHelloAckV1['hello_digests'],
+    ...(value as unknown as MediaHelloAckV2),
+    hello_digests: Object.freeze(rows) as MediaHelloAckV2['hello_digests'],
   });
 }
 
@@ -850,13 +887,13 @@ function validateDirectedPeers(
   }
 }
 
-function helloDigestRows(runtime: Runtime): MediaHelloAckV1['hello_digests'] {
+function helloDigestRows(runtime: Runtime): MediaHelloAckV2['hello_digests'] {
   if (!runtime.localHelloDigest || !runtime.remoteHelloDigest) throw new Error('public_media_hello_missing');
   const rows = [
     Object.freeze({ peer_id: runtime.binding.localPeerId, digest: runtime.localHelloDigest }),
     Object.freeze({ peer_id: runtime.binding.remotePeerId, digest: runtime.remoteHelloDigest }),
   ].sort((left, right) => left.peer_id.localeCompare(right.peer_id));
-  return Object.freeze(rows) as unknown as MediaHelloAckV1['hello_digests'];
+  return Object.freeze(rows) as unknown as MediaHelloAckV2['hello_digests'];
 }
 
 function assertFreshHandshake(runtime: Runtime): void {
@@ -883,10 +920,11 @@ async function connectionDigest(runtime: Runtime): Promise<string> {
     .map(hello => ({ peer_id: hello.sender_id, salt_b64: hello.connection_salt_b64 }))
     .sort((left, right) => left.peer_id.localeCompare(right.peer_id));
   return digestCanonical({
-    domain: 'ananta.public-pair.media-connection.v1',
+    domain: 'ananta.public-pair.media-connection.v2',
     session_id: runtime.sessionId,
     epoch: runtime.contract.epoch,
     media_contract_digest: runtime.contract.digest,
+    frame_format: PUBLIC_PAIR_MEDIA_FRAME_FORMAT_V2,
     salts,
   });
 }
@@ -899,10 +937,11 @@ function frameKeyBindingDigest(
   slot: string,
 ): Promise<string> {
   return digestCanonical({
-    domain: 'ananta.public-pair.media-frame-key-binding.v1',
+    domain: 'ananta.public-pair.media-frame-key-binding.v2',
     session_id: runtime.sessionId,
     epoch: runtime.contract.epoch,
     media_contract_digest: runtime.contract.digest,
+    frame_format: PUBLIC_PAIR_MEDIA_FRAME_FORMAT_V2,
     connection_id: connectionId,
     sender_id: senderId,
     recipient_id: recipientId,

--- a/frontend-angular/src/app/services/pair-media-e2ee-frame-codec.spec.ts
+++ b/frontend-angular/src/app/services/pair-media-e2ee-frame-codec.spec.ts
@@ -23,8 +23,19 @@ async function key(): Promise<CryptoKey> {
   );
 }
 
-function counter(frame: ArrayBuffer): bigint {
-  return new DataView(frame).getBigUint64(12);
+function vp8KeyFrame(...suffix: number[]): ArrayBuffer {
+  return Uint8Array.of(
+    0x10, 0x00, 0x00, 0x9d, 0x01, 0x2a, 0x80, 0x02, 0xe0, 0x01,
+    ...suffix,
+  ).buffer;
+}
+
+function vp8DeltaFrame(...suffix: number[]): ArrayBuffer {
+  return Uint8Array.of(0x11, 0x00, 0x00, ...suffix).buffer;
+}
+
+function counter(frame: ArrayBuffer, prefixBytes = 3): bigint {
+  return new DataView(frame).getBigUint64(prefixBytes + 12);
 }
 
 describe('PairMediaE2eeFrameCipher', () => {
@@ -32,33 +43,117 @@ describe('PairMediaE2eeFrameCipher', () => {
     const aes = await key();
     const sender = new PairMediaE2eeFrameCipher(context());
     const receiver = new PairMediaE2eeFrameCipher(context());
-    const encoded = await sender.seal(aes, new TextEncoder().encode('secret').buffer, 'key');
-    await expect(receiver.open(aes, encoded, 'key')).resolves.toEqual(
-      new TextEncoder().encode('secret').buffer,
-    );
-    await expect(new PairMediaE2eeFrameCipher(context({ slot: 'screen-vp8' })).open(aes, encoded, 'key'))
+    const plaintext = vp8KeyFrame(0x73, 0x65, 0x63, 0x72, 0x65, 0x74);
+    const encoded = await sender.seal(aes, plaintext);
+    await expect(receiver.open(aes, encoded)).resolves.toEqual(plaintext);
+    await expect(new PairMediaE2eeFrameCipher(context({ slot: 'screen-vp8' })).open(aes, encoded))
       .rejects.toThrow('media_e2ee_authentication_failed');
-    await expect(new PairMediaE2eeFrameCipher(context({ connectionId: 'c'.repeat(64) })).open(aes, encoded, 'key'))
+    await expect(new PairMediaE2eeFrameCipher(context({ connectionId: 'c'.repeat(64) })).open(aes, encoded))
       .rejects.toThrow('media_e2ee_authentication_failed');
+  });
+
+  it('preserves and authenticates the complete VP8 uncompressed prefix', async () => {
+    const aes = await key();
+    const sender = new PairMediaE2eeFrameCipher(context());
+    const keySuffix = Array.from({ length: 32 }, (_, index) => 0x80 + index);
+    const keyFrame = vp8KeyFrame(...keySuffix);
+    const deltaFrame = vp8DeltaFrame(0x44, 0x55, 0x66, 0x77);
+
+    const encodedKey = await sender.seal(aes, keyFrame);
+    const encodedDelta = await sender.seal(aes, deltaFrame);
+    expect(new Uint8Array(encodedKey).slice(0, 10)).toEqual(new Uint8Array(keyFrame).slice(0, 10));
+    expect(new Uint8Array(encodedDelta).slice(0, 3)).toEqual(new Uint8Array(deltaFrame).slice(0, 3));
+    expect(new Uint8Array(encodedKey).slice(30, 30 + keySuffix.length))
+      .not.toEqual(new Uint8Array(keyFrame).slice(10));
+
+    const changed = encodedKey.slice(0);
+    new Uint8Array(changed)[1] ^= 0x01;
+    await expect(new PairMediaE2eeFrameCipher(context()).open(aes, changed))
+      .rejects.toThrow('media_e2ee_authentication_failed');
+  });
+
+  it('preserves and authenticates only the Opus TOC byte', async () => {
+    const aes = await key();
+    const audioContext = context({ slot: 'microphone-opus', codec: 'opus', kind: 'audio' });
+    const plaintext = Uint8Array.of(0xf8, 0x11, 0x22, 0x33, 0x44).buffer;
+    const encoded = await new PairMediaE2eeFrameCipher(audioContext).seal(aes, plaintext);
+    expect(new Uint8Array(encoded)[0]).toBe(0xf8);
+    expect(new Uint8Array(encoded).slice(21, 25)).not.toEqual(new Uint8Array(plaintext).slice(1));
+    await expect(new PairMediaE2eeFrameCipher(audioContext).open(aes, encoded))
+      .resolves.toEqual(plaintext);
+
+    const changed = encoded.slice(0);
+    new Uint8Array(changed)[0] ^= 0x04;
+    await expect(new PairMediaE2eeFrameCipher(audioContext).open(aes, changed))
+      .rejects.toThrow('media_e2ee_authentication_failed');
+  });
+
+  it('rejects legacy layout and every authenticated v2 header mutation', async () => {
+    const aes = await key();
+    const encoded = await new PairMediaE2eeFrameCipher(context())
+      .seal(aes, vp8DeltaFrame(0x44, 0x55));
+
+    const legacy = new Uint8Array(encoded.byteLength);
+    legacy.set(Uint8Array.of(0x41, 0x4e, 0x4d, 0x46, 0x01));
+    await expect(new PairMediaE2eeFrameCipher(context()).open(aes, legacy.buffer))
+      .rejects.toThrow('media_e2ee_header_invalid');
+
+    for (const [offset, value] of [[7, 1], [8, 1], [9, 10]] as const) {
+      const changed = encoded.slice(0);
+      new Uint8Array(changed)[offset] = value;
+      await expect(new PairMediaE2eeFrameCipher(context()).open(aes, changed))
+        .rejects.toThrow('media_e2ee_header_invalid');
+    }
+  });
+
+  it('rejects codec-prefix reclassification, ciphertext tampering and the wrong key', async () => {
+    const aes = await key();
+    const encoded = await new PairMediaE2eeFrameCipher(context())
+      .seal(aes, vp8DeltaFrame(0x44, 0x55));
+
+    const reclassified = encoded.slice(0);
+    new Uint8Array(reclassified)[0] &= 0xfe;
+    await expect(new PairMediaE2eeFrameCipher(context()).open(aes, reclassified))
+      .rejects.toThrow('media_e2ee_header_invalid');
+
+    const changedCiphertext = encoded.slice(0);
+    new Uint8Array(changedCiphertext)[changedCiphertext.byteLength - 1] ^= 0x01;
+    await expect(new PairMediaE2eeFrameCipher(context()).open(aes, changedCiphertext))
+      .rejects.toThrow('media_e2ee_authentication_failed');
+    await expect(new PairMediaE2eeFrameCipher(context()).open(await key(), encoded))
+      .rejects.toThrow('media_e2ee_authentication_failed');
+  });
+
+  it('rejects malformed VP8 codec prefixes and mismatched codec contexts', async () => {
+    const aes = await key();
+    await expect(new PairMediaE2eeFrameCipher(context()).seal(
+      aes, Uint8Array.of(0x10, 0, 0, 1, 2, 3, 4, 5, 6, 7).buffer,
+    )).rejects.toThrow('media_e2ee_codec_frame_invalid');
+    await expect(new PairMediaE2eeFrameCipher(context()).seal(
+      aes, Uint8Array.of(0x10, 0, 0).buffer,
+    )).rejects.toThrow('media_e2ee_codec_frame_invalid');
+
+    const encoded = await new PairMediaE2eeFrameCipher(context()).seal(aes, vp8KeyFrame(0xaa));
+    const audioContext = context({ slot: 'microphone-opus', codec: 'opus', kind: 'audio' });
+    await expect(new PairMediaE2eeFrameCipher(audioContext).open(aes, encoded))
+      .rejects.toThrow('media_e2ee_header_invalid');
   });
 
   it('reserves distinct counters before concurrent encryption awaits', async () => {
     const aes = await key();
     const sender = new PairMediaE2eeFrameCipher(context());
     const frames = await Promise.all([
-      sender.seal(aes, Uint8Array.of(1).buffer, 'delta'),
-      sender.seal(aes, Uint8Array.of(2).buffer, 'delta'),
-      sender.seal(aes, Uint8Array.of(3).buffer, 'delta'),
+      sender.seal(aes, vp8DeltaFrame(1)),
+      sender.seal(aes, vp8DeltaFrame(2)),
+      sender.seal(aes, vp8DeltaFrame(3)),
     ]);
-    expect(new Set(frames.map(counter))).toEqual(new Set([1n, 2n, 3n]));
+    expect(new Set(frames.map(frame => counter(frame)))).toEqual(new Set([1n, 2n, 3n]));
   });
 
-  it('authenticates an empty encoded frame without treating DTX as fatal', async () => {
+  it('rejects an empty frame before reserving encrypted output', async () => {
     const aes = await key();
-    const encoded = await new PairMediaE2eeFrameCipher(context())
-      .seal(aes, new ArrayBuffer(0), 'empty');
-    await expect(new PairMediaE2eeFrameCipher(context()).open(aes, encoded, 'empty'))
-      .resolves.toEqual(new ArrayBuffer(0));
+    await expect(new PairMediaE2eeFrameCipher(context()).seal(aes, new ArrayBuffer(0)))
+      .rejects.toThrow('media_e2ee_frame_empty');
   });
 
   it('rejects every frame at the signed contract expiry boundary', async () => {
@@ -67,12 +162,12 @@ describe('PairMediaE2eeFrameCipher', () => {
     const expiringContext = context({ contractExpiresAtMs: 100 });
     const sender = new PairMediaE2eeFrameCipher(expiringContext, () => now);
     const receiver = new PairMediaE2eeFrameCipher(expiringContext, () => now);
-    const encoded = await sender.seal(aes, Uint8Array.of(1).buffer, 'delta');
+    const encoded = await sender.seal(aes, vp8DeltaFrame(1));
     now = 100;
 
-    await expect(sender.seal(aes, Uint8Array.of(2).buffer, 'delta'))
+    await expect(sender.seal(aes, vp8DeltaFrame(2)))
       .rejects.toThrow('media_e2ee_contract_expired');
-    await expect(receiver.open(aes, encoded, 'delta'))
+    await expect(receiver.open(aes, encoded))
       .rejects.toThrow('media_e2ee_contract_expired');
   });
 
@@ -88,7 +183,7 @@ describe('PairMediaE2eeFrameCipher', () => {
     try {
       const sealing = new PairMediaE2eeFrameCipher(
         context({ contractExpiresAtMs: 100 }), () => now,
-      ).seal(aes, Uint8Array.of(1).buffer, 'delta');
+      ).seal(aes, vp8DeltaFrame(1));
       const rejected = expect(sealing).rejects.toThrow('media_e2ee_contract_expired');
       await Promise.resolve();
       now = 100;
@@ -101,7 +196,7 @@ describe('PairMediaE2eeFrameCipher', () => {
     now = 99;
     const expiringContext = context({ contractExpiresAtMs: 100 });
     const encoded = await new PairMediaE2eeFrameCipher(expiringContext, () => now)
-      .seal(aes, Uint8Array.of(2).buffer, 'delta');
+      .seal(aes, vp8DeltaFrame(2));
     const decryptGate = deferred<void>();
     const originalDecrypt = crypto.subtle.decrypt.bind(crypto.subtle);
     const decryptSpy = vi.spyOn(crypto.subtle, 'decrypt').mockImplementationOnce(async (...args) => {
@@ -110,7 +205,7 @@ describe('PairMediaE2eeFrameCipher', () => {
     });
     try {
       const opening = new PairMediaE2eeFrameCipher(expiringContext, () => now)
-        .open(aes, encoded, 'delta');
+        .open(aes, encoded);
       const rejected = expect(opening).rejects.toThrow('media_e2ee_contract_expired');
       await Promise.resolve();
       now = 100;
@@ -124,11 +219,11 @@ describe('PairMediaE2eeFrameCipher', () => {
   it('admits a ciphertext only once when concurrent opens race', async () => {
     const aes = await key();
     const encoded = await new PairMediaE2eeFrameCipher(context())
-      .seal(aes, Uint8Array.of(1, 2, 3).buffer, 'delta');
+      .seal(aes, vp8DeltaFrame(1, 2, 3));
     const receiver = new PairMediaE2eeFrameCipher(context());
     const results = await Promise.allSettled([
-      receiver.open(aes, encoded, 'delta'),
-      receiver.open(aes, encoded, 'delta'),
+      receiver.open(aes, encoded),
+      receiver.open(aes, encoded),
     ]);
     expect(results.filter(result => result.status === 'fulfilled')).toHaveLength(1);
     expect(results.filter(result => result.status === 'rejected')).toHaveLength(1);
@@ -140,13 +235,13 @@ describe('PairMediaE2eeFrameCipher', () => {
     const aes = await key();
     const sender = new PairMediaE2eeFrameCipher(context());
     const receiver = new PairMediaE2eeFrameCipher(context());
-    const first = await sender.seal(aes, Uint8Array.of(1).buffer, 'delta');
-    await receiver.open(aes, first, 'delta');
+    const first = await sender.seal(aes, vp8DeltaFrame(1));
+    await receiver.open(aes, first);
     for (let index = 0; index < 2_049; index += 1) {
-      const encoded = await sender.seal(aes, Uint8Array.of(index & 0xff).buffer, 'delta');
-      await receiver.open(aes, encoded, 'delta');
+      const encoded = await sender.seal(aes, vp8DeltaFrame(index & 0xff));
+      await receiver.open(aes, encoded);
     }
-    await expect(receiver.open(aes, first, 'delta')).rejects.toThrow('media_e2ee_replay_too_old');
+    await expect(receiver.open(aes, first)).rejects.toThrow('media_e2ee_replay_too_old');
   });
 });
 

--- a/frontend-angular/src/app/services/pair-media-e2ee-frame-codec.ts
+++ b/frontend-angular/src/app/services/pair-media-e2ee-frame-codec.ts
@@ -1,4 +1,11 @@
 import { canonicalSecurityJson } from './webrtc-secure-envelope';
+import {
+  PairMediaCanonicalFrameType,
+  PUBLIC_PAIR_MEDIA_FRAME_FORMAT_V2,
+  readPairMediaEncodedPrefix,
+  restorePairMediaPlaintext,
+  splitPairMediaPlaintext,
+} from './pair-media-frame-format';
 
 export interface PairMediaE2eeFrameContext {
   readonly sessionId: string;
@@ -14,7 +21,7 @@ export interface PairMediaE2eeFrameContext {
 }
 
 const MAGIC = Uint8Array.of(0x41, 0x4e, 0x4d, 0x46); // ANMF
-const VERSION = 1;
+const VERSION = 2;
 const HEADER_BYTES = 20;
 const TAG_BYTES = 16;
 const MAX_FRAME_BYTES = 8 * 1024 * 1024;
@@ -23,8 +30,6 @@ const REPLAY_WINDOW = 2_048n;
 const DIGEST_RE = /^[a-f0-9]{64}$/;
 const IDENTIFIER_RE = /^[A-Za-z0-9][A-Za-z0-9._:@-]{0,127}$/;
 const CODEC_RE = /^[a-z0-9][a-z0-9._+-]{0,31}$/;
-
-type FrameType = 'audio' | 'key' | 'delta' | 'empty';
 
 /**
  * Stateful AEAD codec for exactly one direction/slot/connection key.
@@ -47,40 +52,39 @@ export class PairMediaE2eeFrameCipher {
     validateContext(context);
   }
 
-  async seal(key: CryptoKey, plaintext: ArrayBuffer, frameType: string): Promise<ArrayBuffer> {
+  async seal(key: CryptoKey, plaintext: ArrayBuffer): Promise<ArrayBuffer> {
     this.assertContractLive();
     validateKey(key);
     validatePayload(plaintext);
-    const normalizedType = normalizeFrameType(frameType, this.context.kind);
+    const parts = splitPairMediaPlaintext(this.context, plaintext);
     const counter = this.sendCounter + 1n;
     if (counter > MAX_COUNTER) throw new Error('media_e2ee_counter_exhausted');
     // Reserve before the first await. Concurrent callers may leave a gap on
     // encryption failure, but can never reuse a nonce under this key.
     this.sendCounter = counter;
-    const header = encodeHeader(this.context.keyEpoch, counter, normalizedType);
+    const header = encodeHeader(
+      this.context.keyEpoch, counter, parts.frameType, parts.prefix.byteLength,
+    );
     const nonce = nonceFor(this.context.keyEpoch, counter);
     const ciphertext = await crypto.subtle.encrypt(
       {
         name: 'AES-GCM',
         iv: arrayBuffer(nonce),
-        additionalData: arrayBuffer(aad(this.context, header)),
+        additionalData: arrayBuffer(aad(this.context, header, parts.prefix)),
         tagLength: 128,
       },
       key,
-      plaintext,
+      parts.suffix,
     );
     this.assertContractLive();
-    const output = new Uint8Array(HEADER_BYTES + ciphertext.byteLength);
-    output.set(header);
-    output.set(new Uint8Array(ciphertext), HEADER_BYTES);
+    const output = new Uint8Array(parts.prefix.byteLength + HEADER_BYTES + ciphertext.byteLength);
+    output.set(parts.prefix);
+    output.set(header, parts.prefix.byteLength);
+    output.set(new Uint8Array(ciphertext), parts.prefix.byteLength + HEADER_BYTES);
     return output.buffer;
   }
 
-  async open(
-    key: CryptoKey,
-    encoded: ArrayBuffer,
-    expectedFrameType?: string,
-  ): Promise<ArrayBuffer> {
+  async open(key: CryptoKey, encoded: ArrayBuffer): Promise<ArrayBuffer> {
     this.assertContractLive();
     validateKey(key);
     if (
@@ -89,12 +93,15 @@ export class PairMediaE2eeFrameCipher {
       || encoded.byteLength > HEADER_BYTES + TAG_BYTES + MAX_FRAME_BYTES
     ) throw new Error('media_e2ee_frame_size_invalid');
     const frame = new Uint8Array(encoded);
-    const parsed = decodeHeader(frame);
+    const codecPrefix = readPairMediaEncodedPrefix(this.context, frame);
+    const headerOffset = codecPrefix.prefixBytes;
+    const header = frame.slice(headerOffset, headerOffset + HEADER_BYTES);
+    const parsed = decodeHeader(header);
     if (parsed.epoch !== this.context.keyEpoch) throw new Error('media_e2ee_epoch_stale');
-    if (expectedFrameType !== undefined) {
-      const expected = normalizeFrameType(expectedFrameType, this.context.kind);
-      if (parsed.frameType !== expected) throw new Error('media_e2ee_frame_type_mismatch');
-    }
+    if (
+      parsed.frameType !== codecPrefix.frameType
+      || parsed.prefixBytes !== codecPrefix.prefixBytes
+    ) throw new Error('media_e2ee_header_invalid');
     this.assertReplayAdmissible(parsed.counter);
     // TransformStream serializes frames in production, but the primitive is
     // independently safe when multiple callers race the same ciphertext.
@@ -105,11 +112,11 @@ export class PairMediaE2eeFrameCipher {
         {
           name: 'AES-GCM',
           iv: arrayBuffer(nonceFor(parsed.epoch, parsed.counter)),
-          additionalData: arrayBuffer(aad(this.context, frame.slice(0, HEADER_BYTES))),
+          additionalData: arrayBuffer(aad(this.context, header, codecPrefix.prefix)),
           tagLength: 128,
         },
         key,
-        frame.slice(HEADER_BYTES),
+        frame.slice(headerOffset + HEADER_BYTES),
       );
     } catch (error) {
       if (error instanceof Error && error.message.startsWith('media_e2ee_')) throw error;
@@ -119,7 +126,7 @@ export class PairMediaE2eeFrameCipher {
     }
     this.assertContractLive();
     this.claimCounter(parsed.counter);
-    return plaintext;
+    return restorePairMediaPlaintext(this.context, codecPrefix.prefix, plaintext);
   }
 
   clear(): void {
@@ -158,23 +165,33 @@ function replayFloor(highest: bigint): bigint {
   return highest >= REPLAY_WINDOW ? highest - REPLAY_WINDOW + 1n : 1n;
 }
 
-function encodeHeader(epoch: number, counter: bigint, frameType: FrameType): Uint8Array {
+function encodeHeader(
+  epoch: number,
+  counter: bigint,
+  frameType: PairMediaCanonicalFrameType,
+  prefixBytes: number,
+): Uint8Array {
   const header = new Uint8Array(HEADER_BYTES);
   header.set(MAGIC, 0);
   header[4] = VERSION;
   header[5] = frameTypeCode(frameType);
+  header[6] = prefixBytes;
   const view = new DataView(header.buffer);
   view.setUint32(8, epoch);
   view.setBigUint64(12, counter);
   return header;
 }
 
-function decodeHeader(frame: Uint8Array): { epoch: number; counter: bigint; frameType: FrameType } {
+function decodeHeader(frame: Uint8Array): {
+  epoch: number;
+  counter: bigint;
+  frameType: PairMediaCanonicalFrameType;
+  prefixBytes: number;
+} {
   if (
     frame.byteLength < HEADER_BYTES
     || !MAGIC.every((byte, index) => frame[index] === byte)
     || frame[4] !== VERSION
-    || frame[6] !== 0
     || frame[7] !== 0
   ) throw new Error('media_e2ee_header_invalid');
   const frameType = frameTypeFromCode(frame[5]);
@@ -182,7 +199,9 @@ function decodeHeader(frame: Uint8Array): { epoch: number; counter: bigint; fram
   const epoch = view.getUint32(8);
   const counter = view.getBigUint64(12);
   if (epoch < 1 || counter < 1n) throw new Error('media_e2ee_header_invalid');
-  return { epoch, counter, frameType };
+  const prefixBytes = frame[6];
+  if (prefixBytes < 1 || prefixBytes > 10) throw new Error('media_e2ee_header_invalid');
+  return { epoch, counter, frameType, prefixBytes };
 }
 
 function nonceFor(epoch: number, counter: bigint): Uint8Array {
@@ -193,9 +212,13 @@ function nonceFor(epoch: number, counter: bigint): Uint8Array {
   return nonce;
 }
 
-function aad(context: Readonly<PairMediaE2eeFrameContext>, header: Uint8Array): Uint8Array {
+function aad(
+  context: Readonly<PairMediaE2eeFrameContext>,
+  header: Uint8Array,
+  clearPrefix: Uint8Array,
+): Uint8Array {
   return new TextEncoder().encode(canonicalSecurityJson({
-    domain: 'ananta.public-pair.media-frame.v1',
+    domain: PUBLIC_PAIR_MEDIA_FRAME_FORMAT_V2,
     session_id: context.sessionId,
     media_contract_digest: context.mediaContractDigest,
     connection_id: context.connectionId,
@@ -207,32 +230,25 @@ function aad(context: Readonly<PairMediaE2eeFrameContext>, header: Uint8Array): 
     key_epoch: context.keyEpoch,
     contract_expires_at_ms: context.contractExpiresAtMs,
     header_hex: [...header].map(byte => byte.toString(16).padStart(2, '0')).join(''),
+    clear_prefix_hex: [...clearPrefix].map(byte => byte.toString(16).padStart(2, '0')).join(''),
   }));
 }
 
-function frameTypeCode(value: FrameType): number {
+function frameTypeCode(value: PairMediaCanonicalFrameType): number {
   switch (value) {
     case 'audio': return 0;
     case 'key': return 1;
     case 'delta': return 2;
-    case 'empty': return 3;
   }
 }
 
-function frameTypeFromCode(value: number): FrameType {
+function frameTypeFromCode(value: number): PairMediaCanonicalFrameType {
   switch (value) {
     case 0: return 'audio';
     case 1: return 'key';
     case 2: return 'delta';
-    case 3: return 'empty';
     default: throw new Error('media_e2ee_header_invalid');
   }
-}
-
-function normalizeFrameType(value: string, kind: 'audio' | 'video'): FrameType {
-  if (kind === 'audio') return 'audio';
-  if (value === 'key' || value === 'delta' || value === 'empty') return value;
-  throw new Error('media_e2ee_frame_type_invalid');
 }
 
 function validateContext(value: Readonly<PairMediaE2eeFrameContext>): void {
@@ -246,6 +262,10 @@ function validateContext(value: Readonly<PairMediaE2eeFrameContext>): void {
     || !IDENTIFIER_RE.test(value.slot)
     || !CODEC_RE.test(value.codec)
     || (value.kind !== 'audio' && value.kind !== 'video')
+    || !(
+      (value.kind === 'audio' && value.codec === 'opus')
+      || (value.kind === 'video' && value.codec === 'vp8')
+    )
     || !Number.isSafeInteger(value.keyEpoch)
     || value.keyEpoch < 1
     || value.keyEpoch > 0xffff_ffff

--- a/frontend-angular/src/app/services/pair-media-e2ee-transform.adapter.spec.ts
+++ b/frontend-angular/src/app/services/pair-media-e2ee-transform.adapter.spec.ts
@@ -7,7 +7,7 @@ import {
 } from './pair-media-e2ee-transform.adapter';
 import {
   PUBLIC_PAIR_MEDIA_SLOTS,
-  PublicPairMediaSecurityContractV1,
+  PublicPairMediaSecurityContractV2,
 } from './public-pair-media-security-contract';
 
 class FakeWorker {
@@ -281,11 +281,13 @@ describe('PairMediaE2eeTransformAdapter', () => {
   });
 });
 
-function contract(): PublicPairMediaSecurityContractV1 {
+function contract(): PublicPairMediaSecurityContractV2 {
   return {
+    domain: 'ananta.public-pair.media-security-contract.v2', version: 2,
     session_id: 'session-a', epoch: 7, digest: 'a'.repeat(64),
     expires_at_ms: 2_000_000_000_000, transform: 'RTCRtpScriptTransform',
-  } as PublicPairMediaSecurityContractV1;
+    frame_format: 'ananta.public-pair.media-frame.v2',
+  } as PublicPairMediaSecurityContractV2;
 }
 
 async function keySets(): Promise<readonly PublicPairMediaSlotKeySet[]> {

--- a/frontend-angular/src/app/services/pair-media-e2ee-transform.adapter.ts
+++ b/frontend-angular/src/app/services/pair-media-e2ee-transform.adapter.ts
@@ -1,9 +1,10 @@
 import { Injectable, InjectionToken, inject } from '@angular/core';
 
 import type { PairMediaE2eeFrameContext } from './pair-media-e2ee-frame-codec';
+import { PUBLIC_PAIR_MEDIA_FRAME_FORMAT_V2 } from './pair-media-frame-format';
 import {
   PUBLIC_PAIR_MEDIA_SLOTS,
-  PublicPairMediaSecurityContractV1,
+  PublicPairMediaSecurityContractV2,
   PublicPairMediaSlot,
 } from './public-pair-media-security-contract';
 
@@ -90,15 +91,18 @@ export class PairMediaE2eeTransformAdapter {
   async prepareSession(
     peer: RTCPeerConnection,
     sessionId: string,
-    contract: Readonly<PublicPairMediaSecurityContractV1>,
+    contract: Readonly<PublicPairMediaSecurityContractV2>,
     onFatal: (reasonCode: string) => void,
     role: 'offerer' | 'answerer' = 'offerer',
   ): Promise<number> {
     if (
       !sessionId
+      || contract.version !== 2
+      || contract.domain !== 'ananta.public-pair.media-security-contract.v2'
       || contract.session_id !== sessionId
       || contract.expires_at_ms <= Date.now()
       || contract.transform !== 'RTCRtpScriptTransform'
+      || contract.frame_format !== PUBLIC_PAIR_MEDIA_FRAME_FORMAT_V2
     ) throw new Error('public_media_contract_not_ready');
     if (
       this.active?.sessionId === sessionId

--- a/frontend-angular/src/app/services/pair-media-frame-format.ts
+++ b/frontend-angular/src/app/services/pair-media-frame-format.ts
@@ -1,0 +1,98 @@
+export const PUBLIC_PAIR_MEDIA_FRAME_FORMAT_V2 = 'ananta.public-pair.media-frame.v2' as const;
+
+export type PairMediaCanonicalFrameType = 'audio' | 'key' | 'delta';
+
+export interface PairMediaCodecContext {
+  readonly codec: string;
+  readonly kind: 'audio' | 'video';
+}
+
+export interface PairMediaPlaintextParts {
+  readonly prefix: Uint8Array;
+  readonly suffix: ArrayBuffer;
+  readonly frameType: PairMediaCanonicalFrameType;
+}
+
+export interface PairMediaEncodedPrefix {
+  readonly prefix: Uint8Array;
+  readonly prefixBytes: number;
+  readonly frameType: PairMediaCanonicalFrameType;
+}
+
+const VP8_DELTA_PREFIX_BYTES = 3;
+const VP8_KEY_PREFIX_BYTES = 10;
+const OPUS_PREFIX_BYTES = 1;
+
+/**
+ * Preserve only the codec bytes needed by the browser packetizer. They remain
+ * clear but are authenticated by the frame AEAD; all remaining media bytes
+ * stay confidential.
+ */
+export function splitPairMediaPlaintext(
+  context: Readonly<PairMediaCodecContext>,
+  plaintext: ArrayBuffer,
+): PairMediaPlaintextParts {
+  const frame = new Uint8Array(plaintext);
+  if (frame.byteLength === 0) throw new Error('media_e2ee_frame_empty');
+  const frameType = canonicalFrameType(context, frame[0]);
+  const prefixBytes = prefixLength(frameType);
+  if (frame.byteLength < prefixBytes) throw new Error('media_e2ee_codec_frame_invalid');
+  if (
+    frameType === 'key'
+    && (frame[3] !== 0x9d || frame[4] !== 0x01 || frame[5] !== 0x2a)
+  ) throw new Error('media_e2ee_codec_frame_invalid');
+  return Object.freeze({
+    prefix: Uint8Array.from(frame.subarray(0, prefixBytes)),
+    suffix: frame.slice(prefixBytes).buffer,
+    frameType,
+  });
+}
+
+/** Locate the authenticated clear prefix without trusting receiver metadata. */
+export function readPairMediaEncodedPrefix(
+  context: Readonly<PairMediaCodecContext>,
+  encoded: Uint8Array,
+): PairMediaEncodedPrefix {
+  if (encoded.byteLength === 0) throw new Error('media_e2ee_frame_size_invalid');
+  const frameType = canonicalFrameType(context, encoded[0]);
+  const prefixBytes = prefixLength(frameType);
+  if (encoded.byteLength < prefixBytes) throw new Error('media_e2ee_frame_size_invalid');
+  return Object.freeze({
+    prefix: Uint8Array.from(encoded.subarray(0, prefixBytes)),
+    prefixBytes,
+    frameType,
+  });
+}
+
+export function restorePairMediaPlaintext(
+  context: Readonly<PairMediaCodecContext>,
+  prefix: Uint8Array,
+  suffix: ArrayBuffer,
+): ArrayBuffer {
+  const plaintext = new Uint8Array(prefix.byteLength + suffix.byteLength);
+  plaintext.set(prefix);
+  plaintext.set(new Uint8Array(suffix), prefix.byteLength);
+  // Re-parse only after authentication so malformed clear codec bytes cannot
+  // be mistaken for a valid decoded frame.
+  splitPairMediaPlaintext(context, plaintext.buffer);
+  return plaintext.buffer;
+}
+
+function canonicalFrameType(
+  context: Readonly<PairMediaCodecContext>,
+  firstByte: number,
+): PairMediaCanonicalFrameType {
+  if (context.kind === 'audio' && context.codec === 'opus') return 'audio';
+  if (context.kind === 'video' && context.codec === 'vp8') {
+    return (firstByte & 0x01) === 0 ? 'key' : 'delta';
+  }
+  throw new Error('media_e2ee_codec_unsupported');
+}
+
+function prefixLength(frameType: PairMediaCanonicalFrameType): number {
+  switch (frameType) {
+    case 'audio': return OPUS_PREFIX_BYTES;
+    case 'key': return VP8_KEY_PREFIX_BYTES;
+    case 'delta': return VP8_DELTA_PREFIX_BYTES;
+  }
+}

--- a/frontend-angular/src/app/services/pair-session-control-plane.service.spec.ts
+++ b/frontend-angular/src/app/services/pair-session-control-plane.service.spec.ts
@@ -8,7 +8,7 @@ import { NetworkProfileService } from './network-profile.service';
 import { PairMembershipCapabilityStore } from './pair-membership-capability.store';
 import { PairSessionControlPlaneService } from './pair-session-control-plane.service';
 import { PublicPairMediaRuntimeCapabilityService } from './public-pair-media-runtime-capability.service';
-import { PUBLIC_PAIR_MEDIA_CAPABILITIES_V1 } from './public-pair-media-security-contract';
+import { PUBLIC_PAIR_MEDIA_CAPABILITIES_V2 } from './public-pair-media-security-contract';
 import { PUBLIC_OIDC_ISSUER } from './public-ananta-endpoints';
 import { UserAuthService } from './user-auth.service';
 
@@ -187,8 +187,8 @@ describe('PairSessionControlPlaneService', () => {
 
   it('adds the exact immutable media capability advertisement to public create and join', () => {
     publicMediaAdvertisement = Object.freeze({
-      public_media_e2ee_version: 1,
-      public_media_capabilities: PUBLIC_PAIR_MEDIA_CAPABILITIES_V1,
+      public_media_e2ee_version: 2,
+      public_media_capabilities: PUBLIC_PAIR_MEDIA_CAPABILITIES_V2,
     });
     const service = TestBed.inject(PairSessionControlPlaneService);
 
@@ -196,10 +196,11 @@ describe('PairSessionControlPlaneService', () => {
     service.join({ invite_code: 'INVITE' }).subscribe();
 
     for (const body of requests.map(request => request.body as Record<string, unknown>)) {
-      expect(body['public_media_e2ee_version']).toBe(1);
+      expect(body['public_media_e2ee_version']).toBe(2);
       expect(body['public_media_capabilities']).toEqual({
-        version: 1,
+        version: 2,
         transform: 'RTCRtpScriptTransform',
+        frame_format: 'ananta.public-pair.media-frame.v2',
         grants: ['microphone-opus', 'camera-vp8', 'screen-vp8'],
       });
       expect(Object.isFrozen(body)).toBe(true);
@@ -444,8 +445,8 @@ describe('PairSessionControlPlaneService', () => {
 
   it('retries an ambiguous create with the same persisted capability and exact wire body', async () => {
     publicMediaAdvertisement = Object.freeze({
-      public_media_e2ee_version: 1,
-      public_media_capabilities: PUBLIC_PAIR_MEDIA_CAPABILITIES_V1,
+      public_media_e2ee_version: 2,
+      public_media_capabilities: PUBLIC_PAIR_MEDIA_CAPABILITIES_V2,
     });
     const service = TestBed.inject(PairSessionControlPlaneService);
     const core = TestBed.inject(HubApiCoreService);
@@ -466,10 +467,11 @@ describe('PairSessionControlPlaneService', () => {
 
     expect(secondOptions?.body).toEqual(firstOptions?.body);
     expect(secondOptions?.body).toMatchObject({
-      public_media_e2ee_version: 1,
+      public_media_e2ee_version: 2,
       public_media_capabilities: {
-        version: 1,
+        version: 2,
         transform: 'RTCRtpScriptTransform',
+        frame_format: 'ananta.public-pair.media-frame.v2',
         grants: ['microphone-opus', 'camera-vp8', 'screen-vp8'],
       },
     });

--- a/frontend-angular/src/app/services/pair-view-security-bootstrap.service.spec.ts
+++ b/frontend-angular/src/app/services/pair-view-security-bootstrap.service.spec.ts
@@ -11,6 +11,7 @@ import {
   PUBLIC_PAIR_MEDIA_GRANTS,
   PUBLIC_PAIR_MEDIA_SLOTS,
 } from './public-pair-media-security-contract';
+import { PUBLIC_PAIR_MEDIA_FRAME_FORMAT_V2 } from './pair-media-frame-format';
 import { ShareSession } from './share-session.service';
 import { WebrtcPeerKeyService } from './webrtc-peer-key.service';
 import { canonicalSecurityJson } from './webrtc-secure-envelope';
@@ -184,7 +185,9 @@ describe('PairViewSecurityBootstrapService production contract seam', () => {
       acceptance.resolve();
       await expect(pending).resolves.toBe(true);
       expect(bootstrap.mediaContractFor(session.id)).toMatchObject({
-        domain: 'ananta.public-pair.media-security-contract.v1',
+        domain: 'ananta.public-pair.media-security-contract.v2',
+        version: 2,
+        frame_format: PUBLIC_PAIR_MEDIA_FRAME_FORMAT_V2,
         session_id: session.id,
         epoch: 3,
         base_security_contract_digest: response.security_contract_digest,
@@ -252,13 +255,13 @@ describe('PairViewSecurityBootstrapService production contract seam', () => {
       expect(bootstrap.mediaContractFor(session.id)).not.toBeNull();
 
       response = await mediaKeyPackageResponse();
-      response.public_media_security_contract_v1 = null;
+      response.public_media_security_contract_v2 = null;
       await expect(bootstrap.ensure(session, localMediaPeerId)).resolves.toBe(true);
       expect(bootstrap.mediaContractFor(session.id)).toBeNull();
 
       response = await mediaKeyPackageResponse();
-      response.public_media_security_contract_v1 = {
-        ...response.public_media_security_contract_v1,
+      response.public_media_security_contract_v2 = {
+        ...response.public_media_security_contract_v2,
         session_id: 'attacker-session',
       };
       const bindingCallsBeforeInvalidContract = peerKeys.verifyAndRefreshBinding.mock.calls.length;
@@ -267,6 +270,37 @@ describe('PairViewSecurityBootstrapService production contract seam', () => {
       expect(peerKeys.verifyAndRefreshBinding).toHaveBeenCalledTimes(bindingCallsBeforeInvalidContract);
       expect(bootstrap.state$.value).toMatchObject({
         status: 'failed', reasonCode: 'public_media_contract_binding_mismatch',
+      });
+    } finally {
+      verify.mockRestore();
+    }
+  });
+
+  it('keeps a legacy v1-only response data-only and rejects simultaneous v1/v2 authority', async () => {
+    let response = await mediaKeyPackageResponse();
+    const peerKeys = fakeMediaPeerKeys();
+    configure(mediaCore(() => response), peerKeys, localMediaFingerprint);
+    const bootstrap = TestBed.inject(PairViewSecurityBootstrapService);
+    const verify = vi.spyOn(crypto.subtle, 'verify').mockResolvedValue(true);
+
+    try {
+      response.public_media_security_contract_v1 = {
+        domain: 'ananta.public-pair.media-security-contract.v1', version: 1,
+      };
+      response.public_media_security_contract_v2 = null;
+      await expect(bootstrap.ensure(session, localMediaPeerId)).resolves.toBe(true);
+      expect(bootstrap.mediaContractFor(session.id)).toBeNull();
+
+      response = await mediaKeyPackageResponse();
+      response.public_media_security_contract_v1 = {
+        domain: 'ananta.public-pair.media-security-contract.v1', version: 1,
+      };
+      const bindingCalls = peerKeys.verifyAndRefreshBinding.mock.calls.length;
+      await expect(bootstrap.ensure(session, localMediaPeerId)).resolves.toBe(false);
+      expect(peerKeys.verifyAndRefreshBinding).toHaveBeenCalledTimes(bindingCalls);
+      expect(bootstrap.mediaContractFor(session.id)).toBeNull();
+      expect(bootstrap.state$.value).toMatchObject({
+        status: 'failed', reasonCode: 'public_media_contract_version_mixed',
       });
     } finally {
       verify.mockRestore();
@@ -421,8 +455,8 @@ async function mediaKeyPackageResponse(scopeId = 'session-a', epoch = 3): Promis
     device_key_fingerprint: remoteMediaFingerprint,
   }];
   const unsigned = {
-    domain: 'ananta.public-pair.media-security-contract.v1',
-    version: 1,
+    domain: 'ananta.public-pair.media-security-contract.v2',
+    version: 2,
     session_id: scopeId,
     epoch,
     identity_binding_version: 2,
@@ -431,23 +465,25 @@ async function mediaKeyPackageResponse(scopeId = 'session-a', epoch = 3): Promis
       {
         membership_id: 'owner-session-a', membership_version: 1,
         peer_id: localMediaPeerId, device_key_fingerprint: localMediaFingerprint,
-        public_media_e2ee_version: 1,
+        public_media_e2ee_version: 2,
       },
       {
         membership_id: 'participant-a', membership_version: 1,
         peer_id: remoteMediaPeerId, device_key_fingerprint: remoteMediaFingerprint,
-        public_media_e2ee_version: 1,
+        public_media_e2ee_version: 2,
       },
     ],
     grants: [...PUBLIC_PAIR_MEDIA_GRANTS],
     slots: PUBLIC_PAIR_MEDIA_SLOTS.map(slot => ({ ...slot })),
     transform: 'RTCRtpScriptTransform',
+    frame_format: PUBLIC_PAIR_MEDIA_FRAME_FORMAT_V2,
     algorithms: { aead: 'AES-256-GCM', kdf: 'HKDF-SHA-256' },
     expires_at_ms: Date.now() + 240_000,
     authority_key_id: PUBLIC_RENDEZVOUS_SIGNING_KEY_ID,
   };
   const digest = await sha256(canonicalSecurityJson(unsigned));
-  response.public_media_security_contract_v1 = {
+  response.public_media_security_contract_v1 = null;
+  response.public_media_security_contract_v2 = {
     ...unsigned,
     digest,
     signature_algorithm: 'Ed25519',
@@ -470,6 +506,7 @@ function waitingKeyPackageResponse(epoch: number): any {
     local_package_id: null,
     packages: [],
     public_media_security_contract_v1: null,
+    public_media_security_contract_v2: null,
   };
 }
 

--- a/frontend-angular/src/app/services/pair-view-security-bootstrap.service.ts
+++ b/frontend-angular/src/app/services/pair-view-security-bootstrap.service.ts
@@ -4,7 +4,7 @@ import { BehaviorSubject, firstValueFrom } from 'rxjs';
 import { PairSessionControlPlaneService } from './pair-session-control-plane.service';
 import { E2eEncryptionService } from './e2e-encryption.service';
 import {
-  PublicPairMediaSecurityContractV1,
+  PublicPairMediaSecurityContractV2,
   validatePublicPairMediaSecurityContract,
 } from './public-pair-media-security-contract';
 import type { ShareSession } from './share-session.service';
@@ -40,8 +40,10 @@ interface KeyPackageResponse {
   local_peer_id?: string;
   /** Local device package addressed to the remote peer (opposite direction). */
   local_package_id?: string | null;
-  /** Present only when both Public Pair memberships advertised exact v1 media support. */
-  public_media_security_contract_v1?: PublicPairMediaSecurityContractV1 | null;
+  /** Legacy media-v1 projection is deliberately never an execution authority. */
+  public_media_security_contract_v1?: unknown;
+  /** Present only when both Public Pair memberships advertised exact v2 media support. */
+  public_media_security_contract_v2?: PublicPairMediaSecurityContractV2 | null;
 }
 
 interface KeyConfirmation {
@@ -64,7 +66,7 @@ export class PairViewSecurityBootstrapService {
   private lastConfirmationRefreshAt = 0;
   private generation = 0;
   private activeBootstrapKey = '';
-  private readonly mediaContracts = new Map<string, PublicPairMediaSecurityContractV1>();
+  private readonly mediaContracts = new Map<string, PublicPairMediaSecurityContractV2>();
   currentEpoch = 0;
 
   readonly state$ = new BehaviorSubject<PairSecurityBootstrapState>({ status: 'idle' });
@@ -80,7 +82,7 @@ export class PairViewSecurityBootstrapService {
   }
 
   /** Returns only a currently verified, authority-signed media extension. */
-  mediaContractFor(sessionId: string): Readonly<PublicPairMediaSecurityContractV1> | null {
+  mediaContractFor(sessionId: string): Readonly<PublicPairMediaSecurityContractV2> | null {
     const contract = this.mediaContracts.get(sessionId);
     const binding = this.peerKeys.currentBinding;
     return contract
@@ -180,15 +182,18 @@ export class PairViewSecurityBootstrapService {
       if (contract.digest !== response.security_contract_digest) {
         throw new Error('security_contract_digest_mismatch');
       }
-      let mediaContract: PublicPairMediaSecurityContractV1 | null = null;
-      if (response.public_media_security_contract_v1 != null) {
+      let mediaContract: PublicPairMediaSecurityContractV2 | null = null;
+      if (response.public_media_security_contract_v2 != null) {
+        if (response.public_media_security_contract_v1 != null) {
+          throw new Error('public_media_contract_version_mixed');
+        }
         if (!publicSession || !response.local_membership_id) {
           throw new Error('public_media_contract_authority_invalid');
         }
         const localDevice = await this.encryption.ensureLocalKeyPair();
         if (generation !== this.generation) return false;
         mediaContract = await validatePublicPairMediaSecurityContract(
-          response.public_media_security_contract_v1,
+          response.public_media_security_contract_v2,
           {
             sessionId: session.id,
             epoch: response.epoch,
@@ -290,7 +295,7 @@ export class PairViewSecurityBootstrapService {
 
   private replaceMediaContract(
     sessionId: string,
-    contract: PublicPairMediaSecurityContractV1 | null,
+    contract: PublicPairMediaSecurityContractV2 | null,
   ): void {
     if (contract) this.mediaContracts.set(sessionId, contract);
     else this.mediaContracts.delete(sessionId);

--- a/frontend-angular/src/app/services/public-pair-media-runtime-capability.service.spec.ts
+++ b/frontend-angular/src/app/services/public-pair-media-runtime-capability.service.spec.ts
@@ -1,5 +1,5 @@
 import {
-  PUBLIC_PAIR_MEDIA_CAPABILITIES_V1,
+  PUBLIC_PAIR_MEDIA_CAPABILITIES_V2,
 } from './public-pair-media-security-contract';
 import {
   PublicPairMediaRuntimeCapabilityService,
@@ -28,15 +28,21 @@ describe('PublicPairMediaRuntimeCapabilityService', () => {
     RTCRtpTransceiver: { prototype: { setCodecPreferences: () => undefined } },
   });
 
-  it('advertises the exact immutable v1 profile only with the complete standard surface', () => {
+  it('advertises the exact immutable v2 frame profile only with the complete standard surface', () => {
     const service = new PublicPairMediaRuntimeCapabilityService();
     vi.spyOn(service, 'supported').mockReturnValue(true);
 
     expect(service.membershipAdvertisement()).toEqual({
-      public_media_e2ee_version: 1,
-      public_media_capabilities: PUBLIC_PAIR_MEDIA_CAPABILITIES_V1,
+      public_media_e2ee_version: 2,
+      public_media_capabilities: PUBLIC_PAIR_MEDIA_CAPABILITIES_V2,
     });
     expect(Object.isFrozen(service.membershipAdvertisement())).toBe(true);
+    expect(service.membershipAdvertisement()?.public_media_capabilities).toEqual({
+      version: 2,
+      transform: 'RTCRtpScriptTransform',
+      frame_format: 'ananta.public-pair.media-frame.v2',
+      grants: ['microphone-opus', 'camera-vp8', 'screen-vp8'],
+    });
   });
 
   it.each([

--- a/frontend-angular/src/app/services/public-pair-media-runtime-capability.service.ts
+++ b/frontend-angular/src/app/services/public-pair-media-runtime-capability.service.ts
@@ -1,10 +1,10 @@
 import { Injectable } from '@angular/core';
 
-import { PUBLIC_PAIR_MEDIA_CAPABILITIES_V1 } from './public-pair-media-security-contract';
+import { PUBLIC_PAIR_MEDIA_CAPABILITIES_V2 } from './public-pair-media-security-contract';
 
-export interface PublicPairMediaMembershipAdvertisementV1 {
-  readonly public_media_e2ee_version: 1;
-  readonly public_media_capabilities: typeof PUBLIC_PAIR_MEDIA_CAPABILITIES_V1;
+export interface PublicPairMediaMembershipAdvertisementV2 {
+  readonly public_media_e2ee_version: 2;
+  readonly public_media_capabilities: typeof PUBLIC_PAIR_MEDIA_CAPABILITIES_V2;
 }
 
 /** Runtime surface required by the standards-only first Public Pair slice. */
@@ -30,11 +30,11 @@ export class PublicPairMediaRuntimeCapabilityService {
     return supportsPublicPairMediaRuntime(globalThis as EncodedTransformRuntime);
   }
 
-  membershipAdvertisement(): PublicPairMediaMembershipAdvertisementV1 | null {
+  membershipAdvertisement(): PublicPairMediaMembershipAdvertisementV2 | null {
     if (!this.supported()) return null;
     return Object.freeze({
-      public_media_e2ee_version: 1,
-      public_media_capabilities: PUBLIC_PAIR_MEDIA_CAPABILITIES_V1,
+      public_media_e2ee_version: 2,
+      public_media_capabilities: PUBLIC_PAIR_MEDIA_CAPABILITIES_V2,
     });
   }
 }

--- a/frontend-angular/src/app/services/public-pair-media-security-contract.spec.ts
+++ b/frontend-angular/src/app/services/public-pair-media-security-contract.spec.ts
@@ -4,6 +4,7 @@ import {
   PublicPairMediaContractError,
   validatePublicPairMediaSecurityContract,
 } from './public-pair-media-security-contract';
+import { PUBLIC_PAIR_MEDIA_FRAME_FORMAT_V2 } from './pair-media-frame-format';
 import type { FinalStrictPairSecurityContractV1 } from './webrtc-security-negotiation';
 import type { SignedPeerKeyPackage } from './webrtc-peer-key.service';
 import { canonicalSecurityJson, encodeB64 } from './webrtc-secure-envelope';
@@ -28,8 +29,8 @@ async function fixture() {
   const publicBytes = new Uint8Array(await crypto.subtle.exportKey('raw', authority.publicKey));
   const authorityKeyId = `rv:${(await digestBytes(publicBytes)).slice(0, 24)}`;
   const unsigned = {
-    domain: 'ananta.public-pair.media-security-contract.v1',
-    version: 1,
+    domain: 'ananta.public-pair.media-security-contract.v2',
+    version: 2,
     session_id: 'session-a',
     epoch: 3,
     identity_binding_version: 2,
@@ -38,17 +39,18 @@ async function fixture() {
       {
         membership_id: 'member:owner', membership_version: 1,
         peer_id: `peer:${'1'.repeat(64)}`, device_key_fingerprint: LOCAL_FP,
-        public_media_e2ee_version: 1,
+        public_media_e2ee_version: 2,
       },
       {
         membership_id: 'member:guest', membership_version: 1,
         peer_id: `peer:${'2'.repeat(64)}`, device_key_fingerprint: REMOTE_FP,
-        public_media_e2ee_version: 1,
+        public_media_e2ee_version: 2,
       },
     ],
     grants: [...PUBLIC_PAIR_MEDIA_GRANTS],
     slots: PUBLIC_PAIR_MEDIA_SLOTS.map(value => ({ ...value })),
     transform: 'RTCRtpScriptTransform',
+    frame_format: PUBLIC_PAIR_MEDIA_FRAME_FORMAT_V2,
     algorithms: { aead: 'AES-256-GCM', kdf: 'HKDF-SHA-256' },
     expires_at_ms: NOW + 60_000,
     authority_key_id: authorityKeyId,
@@ -97,6 +99,31 @@ describe('Public Pair media security contract', () => {
     }, options)).rejects.toMatchObject<Partial<PublicPairMediaContractError>>({
       reasonCode: 'public_media_contract_signature_invalid',
     });
+  });
+
+  it('rejects legacy or mixed frame-format authority before signature verification', async () => {
+    const { contract, options } = await fixture();
+    await expect(validatePublicPairMediaSecurityContract({
+      ...contract,
+      domain: 'ananta.public-pair.media-security-contract.v1',
+      version: 1,
+      memberships: contract.memberships.map(member => ({
+        ...member, public_media_e2ee_version: 1,
+      })),
+    }, options)).rejects.toMatchObject<Partial<PublicPairMediaContractError>>({
+      reasonCode: 'public_media_contract_version_invalid',
+    });
+    await expect(validatePublicPairMediaSecurityContract({
+      ...contract, frame_format: 'ananta.public-pair.media-frame.v1',
+    }, options)).rejects.toMatchObject<Partial<PublicPairMediaContractError>>({
+      reasonCode: 'public_media_contract_version_invalid',
+    });
+    const withoutFrameFormat = { ...contract } as Record<string, unknown>;
+    delete withoutFrameFormat['frame_format'];
+    await expect(validatePublicPairMediaSecurityContract(withoutFrameFormat, options))
+      .rejects.toMatchObject<Partial<PublicPairMediaContractError>>({
+        reasonCode: 'public_media_contract_fields_invalid',
+      });
   });
 });
 

--- a/frontend-angular/src/app/services/public-pair-media-security-contract.ts
+++ b/frontend-angular/src/app/services/public-pair-media-security-contract.ts
@@ -1,6 +1,7 @@
 import type { FinalStrictPairSecurityContractV1 } from './webrtc-security-negotiation';
 import type { SignedPeerKeyPackage } from './webrtc-peer-key.service';
 import { canonicalSecurityJson, decodeB64 } from './webrtc-secure-envelope';
+import { PUBLIC_PAIR_MEDIA_FRAME_FORMAT_V2 } from './pair-media-frame-format';
 
 export const PUBLIC_PAIR_MEDIA_GRANTS = Object.freeze([
   'microphone-opus',
@@ -19,31 +20,33 @@ export type PublicPairMediaSlot = typeof PUBLIC_PAIR_MEDIA_SLOTS[number]['slot']
 export type PublicPairMediaKind = typeof PUBLIC_PAIR_MEDIA_SLOTS[number]['kind'];
 export type PublicPairMediaCodec = typeof PUBLIC_PAIR_MEDIA_SLOTS[number]['codec'];
 
-export const PUBLIC_PAIR_MEDIA_CAPABILITIES_V1 = Object.freeze({
-  version: 1 as const,
+export const PUBLIC_PAIR_MEDIA_CAPABILITIES_V2 = Object.freeze({
+  version: 2 as const,
   transform: 'RTCRtpScriptTransform' as const,
+  frame_format: PUBLIC_PAIR_MEDIA_FRAME_FORMAT_V2,
   grants: PUBLIC_PAIR_MEDIA_GRANTS,
 });
 
-export interface PublicPairMediaMembershipV1 {
+export interface PublicPairMediaMembershipV2 {
   readonly membership_id: string;
   readonly membership_version: number;
   readonly peer_id: string;
   readonly device_key_fingerprint: string;
-  readonly public_media_e2ee_version: 1;
+  readonly public_media_e2ee_version: 2;
 }
 
-export interface PublicPairMediaSecurityContractV1 {
-  readonly domain: 'ananta.public-pair.media-security-contract.v1';
-  readonly version: 1;
+export interface PublicPairMediaSecurityContractV2 {
+  readonly domain: 'ananta.public-pair.media-security-contract.v2';
+  readonly version: 2;
   readonly session_id: string;
   readonly epoch: number;
   readonly identity_binding_version: 2;
   readonly base_security_contract_digest: string;
-  readonly memberships: readonly [PublicPairMediaMembershipV1, PublicPairMediaMembershipV1];
+  readonly memberships: readonly [PublicPairMediaMembershipV2, PublicPairMediaMembershipV2];
   readonly grants: typeof PUBLIC_PAIR_MEDIA_GRANTS;
   readonly slots: typeof PUBLIC_PAIR_MEDIA_SLOTS;
   readonly transform: 'RTCRtpScriptTransform';
+  readonly frame_format: typeof PUBLIC_PAIR_MEDIA_FRAME_FORMAT_V2;
   readonly algorithms: Readonly<{ aead: 'AES-256-GCM'; kdf: 'HKDF-SHA-256' }>;
   readonly expires_at_ms: number;
   readonly authority_key_id: string;
@@ -72,7 +75,7 @@ export class PublicPairMediaContractError extends Error {
 const CONTRACT_FIELDS = [
   'domain', 'version', 'session_id', 'epoch', 'identity_binding_version',
   'base_security_contract_digest', 'memberships', 'grants', 'slots', 'transform',
-  'algorithms', 'expires_at_ms', 'authority_key_id', 'digest',
+  'frame_format', 'algorithms', 'expires_at_ms', 'authority_key_id', 'digest',
   'signature_algorithm', 'signature_b64',
 ] as const;
 const MEMBERSHIP_FIELDS = [
@@ -85,20 +88,21 @@ const IDENTIFIER_RE = /^[A-Za-z0-9][A-Za-z0-9._:@-]{0,127}$/;
 const DEVICE_PEER_RE = /^peer:[a-f0-9]{64}$/;
 
 /**
- * Validate the separately signed Public Pair media grant. The base Pair v1
+ * Validate the separately signed Public Pair media-v2 grant. The base Pair v1
  * contract deliberately remains data-only; this authority-signed object is
  * the sole additive authorization for encoded audio/video frames.
  */
 export async function validatePublicPairMediaSecurityContract(
   raw: unknown,
   options: PublicPairMediaContractValidationOptions,
-): Promise<PublicPairMediaSecurityContractV1> {
+): Promise<PublicPairMediaSecurityContractV2> {
   const value = closedObject(raw, CONTRACT_FIELDS, 'public_media_contract_fields_invalid');
   if (
-    value['domain'] !== 'ananta.public-pair.media-security-contract.v1'
-    || value['version'] !== 1
+    value['domain'] !== 'ananta.public-pair.media-security-contract.v2'
+    || value['version'] !== 2
     || value['identity_binding_version'] !== 2
     || value['transform'] !== 'RTCRtpScriptTransform'
+    || value['frame_format'] !== PUBLIC_PAIR_MEDIA_FRAME_FORMAT_V2
     || value['signature_algorithm'] !== 'Ed25519'
   ) throw new PublicPairMediaContractError('public_media_contract_version_invalid');
   if (
@@ -144,7 +148,7 @@ export async function validatePublicPairMediaSecurityContract(
   }
   await verifyAuthoritySignature(value, options);
   return Object.freeze({
-    ...(value as unknown as PublicPairMediaSecurityContractV1),
+    ...(value as unknown as PublicPairMediaSecurityContractV2),
     memberships,
     grants: PUBLIC_PAIR_MEDIA_GRANTS,
     slots: PUBLIC_PAIR_MEDIA_SLOTS,
@@ -155,7 +159,7 @@ export async function validatePublicPairMediaSecurityContract(
 function validateMemberships(
   raw: unknown,
   options: PublicPairMediaContractValidationOptions,
-): readonly [PublicPairMediaMembershipV1, PublicPairMediaMembershipV1] {
+): readonly [PublicPairMediaMembershipV2, PublicPairMediaMembershipV2] {
   if (!Array.isArray(raw) || raw.length !== 2) {
     throw new PublicPairMediaContractError('public_media_contract_memberships_invalid');
   }
@@ -169,10 +173,10 @@ function validateMemberships(
       || !DIGEST_RE.test(String(value['device_key_fingerprint'] ?? ''))
       || !Number.isSafeInteger(value['membership_version'])
       || (value['membership_version'] as number) < 1
-      || value['public_media_e2ee_version'] !== 1
+      || value['public_media_e2ee_version'] !== 2
     ) throw new PublicPairMediaContractError('public_media_contract_memberships_invalid');
-    return Object.freeze(value as unknown as PublicPairMediaMembershipV1);
-  }) as [PublicPairMediaMembershipV1, PublicPairMediaMembershipV1];
+    return Object.freeze(value as unknown as PublicPairMediaMembershipV2);
+  }) as [PublicPairMediaMembershipV2, PublicPairMediaMembershipV2];
   const expectedMembershipOrder = [
     options.baseContract.offer.sender_id,
     options.baseContract.offer.recipient_id,

--- a/frontend-angular/src/app/services/webrtc-public-media-lifecycle.spec.ts
+++ b/frontend-angular/src/app/services/webrtc-public-media-lifecycle.spec.ts
@@ -8,7 +8,7 @@ import { PairMediaE2eeTransformAdapter } from './pair-media-e2ee-transform.adapt
 import { PairOrdinaryMediaPolicy } from './pair-ordinary-media.policy';
 import { PairSessionControlPlaneService } from './pair-session-control-plane.service';
 import { PairViewSecurityBootstrapService } from './pair-view-security-bootstrap.service';
-import { PublicPairMediaSecurityContractV1 } from './public-pair-media-security-contract';
+import { PublicPairMediaSecurityContractV2 } from './public-pair-media-security-contract';
 import { WebrtcChunkReassemblyStore } from './webrtc-chunk-reassembly.store';
 import {
   SEMANTIC_DC_VERSION,
@@ -312,13 +312,17 @@ describe('WebrtcSessionService Public media lifecycle', () => {
     const channel = dataChannel();
     peer.ondatachannel?.({ channel } as RTCDataChannelEvent);
     const helloGate = deferred<void>();
+    const helloEntered = deferred<void>();
+    const ackEntered = deferred<void>();
     const seen: string[] = [];
     coordinator.acceptSemantic.mockImplementationOnce(async message => {
       seen.push(message.message_id);
+      helloEntered.resolve(undefined);
       await helloGate.promise;
       return true;
     }).mockImplementationOnce(async message => {
       seen.push(message.message_id);
+      ackEntered.resolve(undefined);
       return true;
     });
     const [hello, ack] = await Promise.all([
@@ -328,11 +332,11 @@ describe('WebrtcSessionService Public media lifecycle', () => {
 
     channel.onmessage?.({ data: hello } as MessageEvent);
     channel.onmessage?.({ data: ack } as MessageEvent);
-    await settleCrypto();
+    await helloEntered.promise;
     expect(seen).toEqual(['pair-media-hello-test']);
 
     helloGate.resolve(undefined);
-    await settleCrypto(4);
+    await ackEntered.promise;
     expect(seen).toEqual(['pair-media-hello-test', 'pair-media-hello_ack-test']);
   });
 
@@ -545,11 +549,13 @@ class CoordinatorMock {
   statusFor(sessionId: string): any { return { sessionId, state: 'inactive' }; }
 }
 
-function contract(): PublicPairMediaSecurityContractV1 {
+function contract(): PublicPairMediaSecurityContractV2 {
   return {
+    domain: 'ananta.public-pair.media-security-contract.v2', version: 2,
     session_id: 'session-a', epoch: 7, digest: 'a'.repeat(64),
     expires_at_ms: Date.now() + 60_000, transform: 'RTCRtpScriptTransform',
-  } as PublicPairMediaSecurityContractV1;
+    frame_format: 'ananta.public-pair.media-frame.v2',
+  } as PublicPairMediaSecurityContractV2;
 }
 
 function offer(): SignalMessage {

--- a/frontend-angular/src/app/workers/pair-media-e2ee.worker.spec.ts
+++ b/frontend-angular/src/app/workers/pair-media-e2ee.worker.spec.ts
@@ -100,6 +100,59 @@ describe('pair media E2EE worker', () => {
       harness.restore();
     }
   });
+
+  it('drops an empty codec callback without poisoning any keyed slot', async () => {
+    const harness = await createHarness();
+    try {
+      const ids = installTransforms(harness);
+      harness.message({
+        version: 1, type: 'install-keys', sessionId: 'session-a',
+        entries: await installEntries(ids),
+      });
+      await settle(6);
+
+      harness.controllers.get(ids[0])?.enqueue({ data: new ArrayBuffer(0), type: 'audio' });
+      await settle(8);
+
+      expect(harness.output.get(ids[0])).toEqual([]);
+      expect(harness.posted.some(message => message.type === 'fatal')).toBe(false);
+    } finally {
+      harness.restore();
+    }
+  });
+
+  it('decrypts VP8 from its authenticated prefix when the receiver metadata is reclassified', async () => {
+    const harness = await createHarness();
+    try {
+      const ids = installTransforms(harness);
+      const entries = await installEntries(ids);
+      // Camera send/receive use the same exact direction key only in this
+      // loopback harness. Production installs inverse peer directions.
+      entries[3] = { ...entries[3], key: entries[2].key, context: entries[2].context };
+      harness.message({ version: 1, type: 'install-keys', sessionId: 'session-a', entries });
+      await settle(6);
+
+      const plaintext = Uint8Array.of(
+        0x10, 0x00, 0x00, 0x9d, 0x01, 0x2a, 0x80, 0x02, 0xe0, 0x01, 0xaa, 0xbb,
+      ).buffer;
+      harness.controllers.get(ids[2])?.enqueue({ data: plaintext.slice(0), type: 'key' });
+      await waitForOutput(harness, ids[2]);
+      const encrypted = harness.output.get(ids[2])?.[0];
+      expect(encrypted).toBeDefined();
+
+      harness.controllers.get(ids[3])?.enqueue({
+        data: encrypted.data.slice(0),
+        // Firefox can report delta here even when Chromium sent a key frame.
+        type: 'delta',
+      });
+      await waitForOutput(harness, ids[3]);
+
+      expect(harness.output.get(ids[3])?.[0]?.data).toEqual(plaintext);
+      expect(harness.posted.some(message => message.type === 'fatal')).toBe(false);
+    } finally {
+      harness.restore();
+    }
+  });
 });
 
 async function createHarness(): Promise<WorkerHarness> {
@@ -169,6 +222,13 @@ async function installEntries(ids: readonly string[]): Promise<any[]> {
 
 async function settle(turns = 3): Promise<void> {
   for (let index = 0; index < turns; index += 1) await Promise.resolve();
+}
+
+async function waitForOutput(harness: WorkerHarness, transformId: string): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (harness.output.get(transformId)?.length) return;
+    await new Promise(resolve => setTimeout(resolve, 0));
+  }
 }
 
 function deferred<T>(): { promise: Promise<T>; resolve(value: T): void } {

--- a/frontend-angular/src/app/workers/pair-media-e2ee.worker.ts
+++ b/frontend-angular/src/app/workers/pair-media-e2ee.worker.ts
@@ -70,13 +70,15 @@ workerScope.onrtctransform = event => {
       // DROP-first: not one encoded byte leaves the transform before a
       // direction/slot/connection key is installed and acknowledged.
       if (!state.key || !state.cipher || state.failed) return;
+      // Codec DTX/empty callbacks contain no media byte and cannot carry the
+      // authenticated clear codec prefix required by frame-format v2.
+      if (frame.data.byteLength === 0) return;
       try {
         const key = state.key;
         const cipher = state.cipher;
-        const frameType = frame.type ?? (cipher.context.kind === 'audio' ? 'audio' : 'delta');
         const transformed = state.operation === 'encrypt'
-          ? await cipher.seal(key, copyBuffer(frame.data), frameType)
-          : await cipher.open(key, copyBuffer(frame.data), frameType);
+          ? await cipher.seal(key, copyBuffer(frame.data))
+          : await cipher.open(key, copyBuffer(frame.data));
         // Another slot can poison the worker while WebCrypto is in flight.
         // Recheck the global and exact local generation before publication.
         if (poisoned || state.failed || state.key !== key || state.cipher !== cipher) return;

--- a/frontend-angular/tests/public-pair-media-live.spec.ts
+++ b/frontend-angular/tests/public-pair-media-live.spec.ts
@@ -1,0 +1,585 @@
+import { chromium, expect, firefox, test } from '@playwright/test';
+import type { Browser, BrowserContext, Page, Response } from '@playwright/test';
+
+import { PUBLIC_OIDC_ISSUER } from '../src/app/services/public-ananta-endpoints';
+
+const LIVE_GATE = process.env['RUN_PUBLIC_PAIR_MEDIA_LIVE_E2E'] === '1';
+const DEVICE_PEER_ID = /^peer:[a-f0-9]{64}$/;
+const DEVICE_ID = /^[A-Za-z0-9][A-Za-z0-9._:@-]{0,127}$/;
+const PAGE_ERROR_CODES = new WeakMap<Page, string[]>();
+
+interface LiveCredentials {
+  readonly username: string;
+  readonly password: string;
+}
+
+interface PairMutationEvidence {
+  readonly sessionId: string;
+  readonly inviteCode: string;
+  readonly localPeerId: string;
+}
+
+test.describe('Public Pair media live canary', () => {
+  test.skip(
+    !LIVE_GATE,
+    'Set RUN_PUBLIC_PAIR_MEDIA_LIVE_E2E=1 and provide the existing Keycloak test credentials.',
+  );
+
+  test('connects distinct same-account Chromium and Firefox peers with bilateral E2EE media', async ({}, testInfo) => {
+    const credentials = requiredCredentials();
+    const baseURL = requiredBaseURL(testInfo.project.use.baseURL);
+    const browsers = await launchCanaryBrowsers();
+    let ownerContext: BrowserContext | null = null;
+    let guestContext: BrowserContext | null = null;
+    let ownerPage: Page | null = null;
+    let guestPage: Page | null = null;
+    let sessionCreated = false;
+
+    try {
+      [ownerContext, guestContext] = await Promise.all([
+        createMediaContext(browsers.chromium, baseURL),
+        createMediaContext(browsers.firefox, baseURL),
+      ]);
+      ownerPage = await authenticatedPairPage(ownerContext, baseURL, credentials);
+      guestPage = await authenticatedPairPage(guestContext, baseURL, credentials);
+      await Promise.all([assertMediaRuntime(ownerPage), assertMediaRuntime(guestPage)]);
+
+      const ownerDeviceId = await opaqueDeviceId(ownerPage);
+      const guestDeviceId = await opaqueDeviceId(guestPage);
+      requireCondition(ownerDeviceId !== guestDeviceId, 'pair_devices_must_be_distinct');
+
+      const owner = await createFreshPublicSession(ownerPage);
+      sessionCreated = true;
+      const guest = await joinFreshPublicSession(guestPage, owner.inviteCode, owner.sessionId);
+      requireCondition(owner.localPeerId !== guest.localPeerId, 'pair_peers_must_be_distinct');
+
+      await Promise.all([
+        expectPairSecurityReady(ownerPage, 'owner'),
+        expectPairSecurityReady(guestPage, 'guest'),
+      ]);
+      await activateMediaBilateral(ownerPage, guestPage);
+      await startBilateralCapture(ownerPage, guestPage);
+      await expectBilateralReception(ownerPage, guestPage);
+
+      await revokeMediaFromOwner(ownerPage, guestPage);
+
+      await endOwnerSession(ownerPage, owner.sessionId);
+      sessionCreated = false;
+      await leaveGuestSession(guestPage);
+    } finally {
+      if (sessionCreated && ownerPage) await bestEffortEndOwnerSession(ownerPage);
+      if (guestPage) await bestEffortLeaveGuestSession(guestPage);
+      await Promise.all([
+        ownerContext?.close().catch(() => undefined),
+        guestContext?.close().catch(() => undefined),
+      ]);
+      await Promise.all([
+        browsers.chromium.close().catch(() => undefined),
+        browsers.firefox.close().catch(() => undefined),
+      ]);
+    }
+  });
+});
+
+function requiredCredentials(): LiveCredentials {
+  const username = String(process.env['E2E_OIDC_USERNAME'] || '').trim();
+  const password = String(process.env['E2E_OIDC_PASSWORD'] || '');
+  requireCondition(Boolean(username && password), 'public_oidc_credentials_required');
+  return Object.freeze({ username, password });
+}
+
+function requiredBaseURL(value: unknown): string {
+  const raw = String(value || '').trim();
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new Error('public_pair_media_base_url_invalid');
+  }
+  const loopback = parsed.hostname === '127.0.0.1' || parsed.hostname === 'localhost';
+  requireCondition(parsed.protocol === 'https:' || loopback, 'public_pair_media_secure_context_required');
+  requireCondition(parsed.username === '' && parsed.password === '', 'public_pair_media_base_url_credentials_forbidden');
+  return parsed.origin;
+}
+
+async function launchCanaryBrowsers(): Promise<Readonly<{ chromium: Browser; firefox: Browser }>> {
+  const headless = process.env['E2E_HEADED'] !== '1';
+  const chromiumBrowser = await chromium.launch({
+    headless,
+    args: [
+      '--autoplay-policy=no-user-gesture-required',
+      '--use-fake-device-for-media-stream',
+      '--use-fake-ui-for-media-stream',
+    ],
+  });
+  try {
+    const firefoxBrowser = await firefox.launch({
+      headless,
+      firefoxUserPrefs: {
+        'media.autoplay.blocking_policy': 0,
+        'media.autoplay.default': 0,
+        'media.navigator.permission.disabled': true,
+        'media.navigator.streams.fake': true,
+      },
+    });
+    return Object.freeze({ chromium: chromiumBrowser, firefox: firefoxBrowser });
+  } catch (error) {
+    await chromiumBrowser.close();
+    throw error;
+  }
+}
+
+async function createMediaContext(browser: Browser, baseURL: string): Promise<BrowserContext> {
+  const context = await browser.newContext({ baseURL });
+  await context.addInitScript(installSyntheticDisplayCapture, { appOrigin: baseURL });
+  return context;
+}
+
+function installSyntheticDisplayCapture({ appOrigin }: { appOrigin: string }): void {
+  if (location.origin !== appOrigin) return;
+  const devices = navigator.mediaDevices;
+  if (!devices || typeof HTMLCanvasElement.prototype.captureStream !== 'function') return;
+  Object.defineProperty(devices, 'getDisplayMedia', {
+    configurable: true,
+    value: async (): Promise<MediaStream> => {
+      const canvas = document.createElement('canvas');
+      canvas.width = 640;
+      canvas.height = 360;
+      const drawing = canvas.getContext('2d');
+      if (!drawing) throw new Error('synthetic_display_canvas_unavailable');
+      let frame = 0;
+      const paint = () => {
+        frame = (frame + 1) % 360;
+        drawing.fillStyle = `hsl(${frame} 70% 35%)`;
+        drawing.fillRect(0, 0, canvas.width, canvas.height);
+        drawing.fillStyle = '#ffffff';
+        drawing.fillRect((frame * 3) % canvas.width, 120, 80, 80);
+      };
+      paint();
+      const timer = window.setInterval(paint, 100);
+      const stream = canvas.captureStream(10);
+      const track = stream.getVideoTracks()[0];
+      if (!track) {
+        window.clearInterval(timer);
+        throw new Error('synthetic_display_track_unavailable');
+      }
+      const nativeStop = track.stop.bind(track);
+      track.stop = () => {
+        window.clearInterval(timer);
+        nativeStop();
+      };
+      return stream;
+    },
+  });
+}
+
+async function authenticatedPairPage(
+  context: BrowserContext,
+  baseURL: string,
+  credentials: LiveCredentials,
+): Promise<Page> {
+  const page = await context.newPage();
+  const pageErrorCodes: string[] = [];
+  PAGE_ERROR_CODES.set(page, pageErrorCodes);
+  page.on('pageerror', error => pageErrorCodes.push(classifyPageError(error)));
+  await page.goto(`${baseURL}/login?sphere=oidc`, { waitUntil: 'domcontentloaded' });
+  const keycloakButton = page.getByRole('button', { name: /Bei Keycloak anmelden/i });
+  if (!await keycloakButton.isEnabled().catch(() => false)) {
+    const optIn = page.getByRole('button', { name: /Öffentlichen Pair-\/WebRTC-Zugang aktivieren/i });
+    await expect(optIn).toBeVisible();
+    await optIn.click();
+    await page.waitForFunction(() => (
+      localStorage.getItem('ananta.network-profile-selection.v1') === 'public-ananta'
+    ));
+    await page.reload({ waitUntil: 'domcontentloaded' });
+  }
+  await expect(keycloakButton).toBeVisible();
+  await expect(keycloakButton).toBeEnabled();
+  await keycloakButton.click();
+  const issuer = String(process.env['E2E_OIDC_ISSUER'] || PUBLIC_OIDC_ISSUER).replace(/\/$/, '');
+  await page.waitForURL(url => url.href.startsWith(`${issuer}/`), { timeout: 120_000 });
+  await submitKeycloakCredentials(page, credentials);
+
+  const oidcReturn = page.waitForURL(url => url.origin === baseURL, { timeout: 180_000 })
+    .then(() => 'returned' as const);
+  const loginRejected = page.locator('#input-error, #kc-error-message, .alert-error').first()
+    .waitFor({ state: 'visible', timeout: 180_000 })
+    .then(() => 'rejected' as const);
+  requireCondition(await Promise.race([oidcReturn, loginRejected]) === 'returned', 'public_oidc_login_rejected');
+  await page.waitForFunction(() => Boolean(localStorage.getItem('ananta.oidc.access_token')), undefined, {
+    timeout: 60_000,
+  });
+  await page.waitForURL(url => url.origin === baseURL && url.pathname === '/pair-dev', {
+    timeout: 60_000,
+  });
+  await openPairPanel(page);
+  return page;
+}
+
+async function submitKeycloakCredentials(authPage: Page, credentials: LiveCredentials): Promise<void> {
+  const username = authPage.locator('#username, input[name="username"]').first();
+  const password = authPage.locator('#password, input[name="password"]').first();
+  await expect(username).toBeVisible();
+  await expect(password).toBeVisible();
+  await username.fill(credentials.username);
+  await password.fill(credentials.password);
+  const submit = authPage.locator('#kc-login, button[type="submit"], input[type="submit"]').first();
+  await expect(submit).toBeVisible();
+  await submit.click();
+}
+
+async function openPairPanel(page: Page): Promise<void> {
+  if (new URL(page.url()).pathname !== '/pair-dev') {
+    await page.goto('/pair-dev', { waitUntil: 'domcontentloaded' });
+  }
+  await expect(page.getByTestId('public-pair-page')).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Audio und Video für Pair Dev' })).toBeVisible();
+}
+
+async function opaqueDeviceId(page: Page): Promise<string> {
+  const value = await page.evaluate(() => localStorage.getItem('ananta.pair-device-id.v1') || '');
+  requireCondition(DEVICE_ID.test(value), 'pair_device_id_invalid');
+  return value;
+}
+
+async function assertMediaRuntime(page: Page): Promise<void> {
+  const supported = await page.evaluate(() => {
+    const sender = globalThis.RTCRtpSender;
+    const receiver = globalThis.RTCRtpReceiver;
+    const transceiver = globalThis.RTCRtpTransceiver;
+    return typeof globalThis.RTCRtpScriptTransform === 'function'
+      && typeof globalThis.Worker === 'function'
+      && typeof globalThis.TransformStream === 'function'
+      && Boolean(sender && 'transform' in sender.prototype)
+      && Boolean(receiver && 'transform' in receiver.prototype)
+      && typeof transceiver?.prototype.setCodecPreferences === 'function'
+      && sender.getCapabilities?.('audio')?.codecs.some(codec => codec.mimeType.toLowerCase() === 'audio/opus') === true
+      && sender.getCapabilities?.('video')?.codecs.some(codec => codec.mimeType.toLowerCase() === 'video/vp8') === true;
+  });
+  requireCondition(supported, 'public_media_runtime_unsupported');
+}
+
+async function createFreshPublicSession(page: Page): Promise<PairMutationEvidence> {
+  const share = sharePanel(page);
+  const createButton = share.getByRole('button', { name: /Session erstellen/i });
+  if (!await waitVisible(createButton, 30_000)) {
+    const [pageCount, routeHostCount, shareHostCount, nestedCount, panelCount, activeCount] = await Promise.all([
+      page.getByTestId('public-pair-page').count(),
+      page.locator('app-public-pair-page').count(),
+      page.locator('app-ai-snake-share-panel').count(),
+      share.count(),
+      share.locator('.share-panel').count(),
+      share.locator('.share-badge.active').count(),
+    ]);
+    const pageErrors = PAGE_ERROR_CODES.get(page) ?? [];
+    const pathCode = new URL(page.url()).pathname.replace(/[^A-Za-z0-9/_-]/g, '').replaceAll('/', '_') || '_';
+    throw new Error(
+      `public_share_create_unavailable_path_${pathCode}_page_${pageCount}_route_${routeHostCount}`
+      + `_share_${shareHostCount}_nested_${nestedCount}_panel_${panelCount}_active_${activeCount}`
+      + `_page_errors_${pageErrors.join('-') || 'none'}`,
+    );
+  }
+  await createButton.click();
+  await share.getByLabel('Titel').fill(`public-media-canary-${Date.now()}`);
+  await share.getByLabel('Ablauf').selectOption('3600');
+  const response = page.waitForResponse(isCreateMutation);
+  await share.getByRole('button', { name: 'Erstellen', exact: true }).click();
+  return validateMutation(await response, 'create');
+}
+
+async function joinFreshPublicSession(
+  page: Page,
+  inviteCode: string,
+  expectedSessionId: string,
+): Promise<PairMutationEvidence> {
+  const share = sharePanel(page);
+  await share.getByRole('button', { name: 'Code eingeben', exact: true }).click();
+  await share.getByLabel('Invite-Code').fill(inviteCode);
+  const response = page.waitForResponse(isJoinMutation);
+  await share.getByRole('button', { name: 'Beitreten', exact: true }).click();
+  const evidence = await validateMutation(await response, 'join');
+  requireCondition(evidence.sessionId === expectedSessionId, 'public_join_session_mismatch');
+  return evidence;
+}
+
+function isCreateMutation(response: Response): boolean {
+  return response.request().method() === 'POST'
+    && new URL(response.url()).pathname === '/rendezvous/sessions';
+}
+
+function isJoinMutation(response: Response): boolean {
+  return response.request().method() === 'POST'
+    && new URL(response.url()).pathname === '/rendezvous/sessions/join';
+}
+
+async function validateMutation(
+  response: Response,
+  kind: 'create' | 'join',
+): Promise<PairMutationEvidence> {
+  requireCondition(response.ok(), `public_${kind}_request_failed`);
+  let requestBody: Record<string, unknown> | null = null;
+  try {
+    const raw = response.request().postDataJSON();
+    if (raw && typeof raw === 'object' && !Array.isArray(raw)) requestBody = raw as Record<string, unknown>;
+  } catch { /* malformed request evidence fails closed below */ }
+  requireCondition(requestBody?.['identity_binding_version'] === 2, `public_${kind}_v2_request_required`);
+  requireCondition(requestBody?.['public_media_e2ee_version'] === 2, `public_${kind}_media_v2_request_required`);
+  requireCondition(exactMediaCapabilities(requestBody?.['public_media_capabilities']), `public_${kind}_media_capabilities_invalid`);
+
+  const payload = await response.json().catch(() => null) as Record<string, unknown> | null;
+  const session = payload?.['session'] as Record<string, unknown> | undefined;
+  const sessionId = String(session?.['id'] || '');
+  const inviteCode = String(session?.['invite_code'] || '');
+  const localPeerId = String(payload?.['local_peer_id'] || '');
+  const createdAtMs = Number(session?.['created_at']) * 1_000;
+  requireCondition(payload?.['ok'] === true, `public_${kind}_response_invalid`);
+  requireCondition(Boolean(sessionId && inviteCode), `public_${kind}_session_invalid`);
+  requireCondition(DEVICE_PEER_ID.test(localPeerId), `public_${kind}_peer_invalid`);
+  requireCondition(session?.['local_peer_id'] === localPeerId, `public_${kind}_peer_binding_invalid`);
+  requireCondition(session?.['identity_binding_version'] === 2, `public_${kind}_identity_binding_invalid`);
+  requireCondition(session?.['security_contract_version'] === 1, `public_${kind}_security_version_invalid`);
+  requireCondition(session?.['security_mode'] === 'strict_e2ee', `public_${kind}_security_mode_invalid`);
+  requireCondition(session?.['mode'] === 'p2p' && session?.['transport'] === 'webrtc', `public_${kind}_transport_invalid`);
+  requireCondition(session?.['revoked_at'] === null, `public_${kind}_session_revoked`);
+  requireCondition(Number.isFinite(createdAtMs) && Math.abs(Date.now() - createdAtMs) < 120_000, `public_${kind}_session_not_fresh`);
+  return Object.freeze({ sessionId, inviteCode, localPeerId });
+}
+
+function exactMediaCapabilities(value: unknown): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const row = value as Record<string, unknown>;
+  const keys = Object.keys(row).sort();
+  return keys.join(',') === 'frame_format,grants,transform,version'
+    && row['version'] === 2
+    && row['transform'] === 'RTCRtpScriptTransform'
+    && row['frame_format'] === 'ananta.public-pair.media-frame.v2'
+    && Array.isArray(row['grants'])
+    && row['grants'].join(',') === 'microphone-opus,camera-vp8,screen-vp8';
+}
+
+async function expectPairSecurityReady(page: Page, peerRole: 'owner' | 'guest'): Promise<void> {
+  await expect(page, `${peerRole}_pair_route_missing`).toHaveURL(/\/pair-dev$/);
+  await expect(page.getByTestId('public-pair-page'), `${peerRole}_pair_page_missing`).toBeVisible();
+  await expect(sharePanel(page), `${peerRole}_share_panel_missing`).toBeVisible();
+  await expect(
+    sharePanel(page).locator('.share-badge.active'),
+    `${peerRole}_share_session_inactive`,
+  ).toBeVisible();
+  await expect(
+    sharePanel(page).getByTestId('share-security-status'),
+    `${peerRole}_share_security_missing`,
+  ).toHaveClass(/\bready\b/);
+  await expect(
+    page.getByTestId('public-pair-webrtc-status'),
+    `${peerRole}_webrtc_not_connected`,
+  ).toHaveText(/WebRTC:\s*connected/i);
+}
+
+async function activateMediaBilateral(owner: Page, guest: Page): Promise<void> {
+  const buttons = [owner, guest].map(page => mediaCapability(page)
+    .getByRole('button', { name: 'Aktivieren', exact: true }));
+  await Promise.all(buttons.map(button => expect(button).toBeEnabled()));
+  await Promise.all(buttons.map(button => button.click()));
+  const peers = [
+    ['owner', owner],
+    ['guest', guest],
+  ] as const;
+  const readiness = await Promise.all(peers.map(([, page]) => (
+    waitVisible(page.getByTestId('public-media-e2ee-ready'), 60_000)
+  )));
+  if (readiness.some(ready => !ready)) {
+    const diagnostics = await Promise.all(peers.map(async ([role, page]) => (
+      `${role}_${await mediaActivationDiagnostic(page)}`
+    )));
+    throw new Error(`public_media_activation_failed_${diagnostics.join('_')}`);
+  }
+}
+
+async function mediaActivationDiagnostic(page: Page): Promise<string> {
+  const capabilityState = await mediaCapability(page).locator('p').filter({ hasText: 'Status:' })
+    .locator('strong').textContent().catch(() => 'missing');
+  const capabilityReason = await mediaCapability(page).locator('p[role="status"] code')
+    .textContent().catch(() => 'missing');
+  const operationReason = await mediaPanel(page).getByTestId('ordinary-media-operation-status')
+    .locator('code').textContent().catch(() => 'media_panel_unavailable');
+  const pendingCount = await page.getByTestId('public-media-e2ee-pending').count();
+  const webrtc = await page.getByTestId('public-pair-webrtc-status').textContent().catch(() => 'missing');
+  return `cap_${safeStatusCode(capabilityState)}_cap_reason_${safeReasonCode(capabilityReason)}`
+    + `_operation_${safeReasonCode(operationReason)}_pending_${pendingCount}`
+    + `_webrtc_${safeStatusCode(webrtc)}`;
+}
+
+async function startBilateralCapture(owner: Page, guest: Page): Promise<void> {
+  const pages = [owner, guest] as const;
+  await Promise.all(pages.map(page => mediaPanel(page).getByRole('button', { name: 'Mikrofon freigeben' }).click()));
+  await Promise.all(pages.map(page => expect(mediaPanel(page).locator('article[data-source="microphone"]'))
+    .toHaveAttribute('data-status', 'active')));
+  await Promise.all(pages.map(page => mediaPanel(page).getByRole('button', { name: 'Kamera freigeben' }).click()));
+  await Promise.all(pages.map(page => expect(mediaPanel(page).locator('article[data-source="camera"]'))
+    .toHaveAttribute('data-status', 'active')));
+  await expectBilateralRenderedMedia(owner, guest, false);
+  await Promise.all(pages.map(page => mediaPanel(page).getByRole('button', { name: 'Bildschirm freigeben' }).click()));
+  for (const [index, page] of pages.entries()) {
+    const screen = mediaPanel(page).locator('article[data-source="screen"]');
+    if (!await waitVisible(screen, 60_000)) {
+      const reason = await mediaPanel(page).getByTestId('ordinary-media-operation-status')
+        .locator('code').textContent().catch(() => 'media_panel_unavailable');
+      throw new Error(`public_screen_capture_missing_peer_${index}_${safeReasonCode(reason)}`);
+    }
+    await expect(screen).toHaveAttribute('data-status', 'active');
+  }
+}
+
+async function expectBilateralReception(owner: Page, guest: Page): Promise<void> {
+  await expectBilateralRenderedMedia(owner, guest, true);
+}
+
+async function expectBilateralRenderedMedia(owner: Page, guest: Page, requireTwoVideos: boolean): Promise<void> {
+  await Promise.all(([
+    ['owner', owner],
+    ['guest', guest],
+  ] as const).map(async ([role, page]) => {
+    const remoteVideo = mediaPanel(page).locator('article[data-source="remote_video"][data-status="active"]');
+    if (requireTwoVideos) await expect(remoteVideo).toHaveCount(2);
+    await expect(page.getByText('Ordinary Audio empfangen.', { exact: true })).toBeVisible();
+    const requiredVideoCount = requireTwoVideos ? 2 : 1;
+    try {
+      await expect.poll(() => page.locator('app-webrtc-remote-video video').evaluateAll((elements, required) => (
+        elements.length >= required && elements.filter(element => {
+          const video = element as HTMLVideoElement;
+          return video.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA && video.currentTime > 0;
+        }).length >= required
+      ), requiredVideoCount)).toBe(true);
+    } catch {
+      throw new Error(`public_remote_video_unavailable_${role}_${await remoteVideoDiagnostic(page)}`);
+    }
+    try {
+      await expect.poll(() => page.locator('app-semantic-remote-audio audio').evaluate(element => {
+        const audio = element as HTMLAudioElement;
+        return audio.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA && audio.currentTime > 0;
+      })).toBe(true);
+    } catch {
+      throw new Error(`public_remote_audio_unavailable_${role}_${await remoteAudioDiagnostic(page)}`);
+    }
+  }));
+}
+
+async function remoteVideoDiagnostic(page: Page): Promise<string> {
+  const videoStates = await page.locator('app-webrtc-remote-video video').evaluateAll(elements => elements.map(element => {
+    const video = element as HTMLVideoElement;
+    const tracks = video.srcObject instanceof MediaStream ? video.srcObject.getVideoTracks() : [];
+    return [
+      video.readyState,
+      video.paused ? 1 : 0,
+      video.currentTime > 0 ? 1 : 0,
+      tracks.length,
+      tracks.some(track => !track.muted) ? 1 : 0,
+      tracks.every(track => track.readyState === 'live') ? 1 : 0,
+    ].join('');
+  })).catch(() => [] as string[]);
+  const remoteStatuses = await mediaPanel(page).locator('article[data-source="remote_video"]')
+    .evaluateAll(elements => elements.map(element => element.getAttribute('data-status') || 'none'))
+    .catch(() => [] as string[]);
+  const reason = await mediaPanel(page).getByTestId('ordinary-media-operation-status')
+    .locator('code').textContent().catch(() => 'media_panel_unavailable');
+  const capabilityState = await mediaCapability(page).locator('p').filter({ hasText: 'Status:' })
+    .locator('strong').textContent().catch(() => 'missing');
+  const capabilityReason = await mediaCapability(page).locator('p[role="status"] code')
+    .textContent().catch(() => 'missing');
+  const readyCount = await page.getByTestId('public-media-e2ee-ready').count();
+  const webrtc = await page.getByTestId('public-pair-webrtc-status').textContent().catch(() => 'missing');
+  return `videos_${videoStates.join('-') || 'none'}_rows_${remoteStatuses.join('-') || 'none'}`
+    + `_reason_${safeReasonCode(reason)}_cap_${safeStatusCode(capabilityState)}`
+    + `_cap_reason_${safeReasonCode(capabilityReason)}_ready_${readyCount}`
+    + `_webrtc_${safeStatusCode(webrtc)}`;
+}
+
+async function remoteAudioDiagnostic(page: Page): Promise<string> {
+  const state = await page.locator('app-semantic-remote-audio audio').evaluate(element => {
+    const audio = element as HTMLAudioElement;
+    const tracks = audio.srcObject instanceof MediaStream ? audio.srcObject.getAudioTracks() : [];
+    return [audio.readyState, audio.paused ? 1 : 0, audio.currentTime > 0 ? 1 : 0, tracks.length,
+      tracks.some(track => !track.muted) ? 1 : 0, tracks.every(track => track.readyState === 'live') ? 1 : 0].join('');
+  }).catch(() => 'missing');
+  return `audio_${state}`;
+}
+
+async function revokeMediaFromOwner(owner: Page, guest: Page): Promise<void> {
+  await mediaCapability(owner).getByRole('button', { name: 'Widerrufen', exact: true }).click();
+  await Promise.all([owner, guest].map(page => expect(mediaPanel(page)).toHaveCount(0)));
+  await Promise.all([owner, guest].map(page => expect(page.getByTestId('public-media-e2ee-ready')).toHaveCount(0)));
+  await Promise.all([owner, guest].map(page => expect(page.getByTestId('public-pair-webrtc-status'))
+    .toHaveText(/WebRTC:\s*(disconnected|failed)/i)));
+}
+
+async function endOwnerSession(page: Page, sessionId: string): Promise<void> {
+  const response = page.waitForResponse(candidate => candidate.request().method() === 'DELETE'
+    && new URL(candidate.url()).pathname === `/rendezvous/sessions/${encodeURIComponent(sessionId)}`);
+  page.once('dialog', dialog => void dialog.accept());
+  await sharePanel(page).getByRole('button', { name: 'Session beenden', exact: true }).click();
+  requireCondition((await response).ok(), 'public_session_cleanup_failed');
+  await expect(sharePanel(page).getByRole('button', { name: /Session erstellen/i })).toBeVisible();
+}
+
+async function leaveGuestSession(page: Page): Promise<void> {
+  await sharePanel(page).getByRole('button', { name: 'Verlassen', exact: true }).click();
+  await expect(sharePanel(page).getByRole('button', { name: /Session erstellen/i })).toBeVisible();
+}
+
+async function bestEffortEndOwnerSession(page: Page): Promise<void> {
+  const button = sharePanel(page).getByRole('button', { name: 'Session beenden', exact: true });
+  if (!await button.isVisible().catch(() => false)) return;
+  page.once('dialog', dialog => void dialog.accept());
+  await button.click({ timeout: 5_000 }).catch(() => undefined);
+}
+
+async function bestEffortLeaveGuestSession(page: Page): Promise<void> {
+  const button = sharePanel(page).getByRole('button', { name: 'Verlassen', exact: true });
+  if (await button.isVisible().catch(() => false)) {
+    await button.click({ timeout: 5_000 }).catch(() => undefined);
+  }
+}
+
+function sharePanel(page: Page) {
+  return page.locator('app-public-pair-page app-ai-snake-share-panel');
+}
+
+function mediaCapability(page: Page) {
+  return page.locator('app-public-pair-page [data-capability="ordinary_media"]');
+}
+
+function mediaPanel(page: Page) {
+  return page.locator('app-public-pair-page app-webrtc-media-panel');
+}
+
+function requireCondition(condition: unknown, reasonCode: string): asserts condition {
+  if (!condition) throw new Error(reasonCode);
+}
+
+function safeReasonCode(value: string | null): string {
+  const normalized = String(value || '').trim();
+  return /^[a-z][a-z0-9_]{2,119}$/.test(normalized) ? normalized : 'unknown';
+}
+
+function safeStatusCode(value: string | null): string {
+  const normalized = String(value || '').toLowerCase();
+  for (const state of ['authoritatively_active', 'degraded', 'failed', 'revoked', 'expired', 'locally_desired']) {
+    if (normalized.includes(state)) return state;
+  }
+  if (normalized.includes('connected')) return 'connected';
+  if (normalized.includes('failed')) return 'failed';
+  if (normalized.includes('disconnected')) return 'disconnected';
+  return 'unknown';
+}
+
+async function waitVisible(locator: ReturnType<Page['locator']>, timeout: number): Promise<boolean> {
+  return locator.waitFor({ state: 'visible', timeout }).then(() => true).catch(() => false);
+}
+
+function classifyPageError(error: Error): string {
+  const message = String(error.message || '');
+  return message.match(/\bNG\d{3,}\b/)?.[0]
+    ?? message.match(/\b(?:public|pair|webrtc|media|oidc)_[a-z0-9_]+\b/)?.[0]
+    ?? error.name.replace(/[^A-Za-z0-9_-]/g, '').slice(0, 40)
+    ?? 'unknown';
+}

--- a/public-rendezvous/rendezvous/app.py
+++ b/public-rendezvous/rendezvous/app.py
@@ -30,6 +30,7 @@ from typing import Any
 import service as svc
 from flask import Flask, jsonify, request
 from oidc_auth import AuthContext, verify_bearer_token
+from pair_security import SUPPORTED_PUBLIC_MEDIA_E2EE_VERSIONS
 
 import config as cfg
 
@@ -170,7 +171,7 @@ def info():
             "turn_urls": cfg.TURN_URLS,
             "session_max_minutes": cfg.SESSION_MAX_DURATION_SECONDS // 60,
             "supported_identity_binding_versions": [1, 2],
-            "supported_public_media_e2ee_versions": [1],
+            "supported_public_media_e2ee_versions": list(SUPPORTED_PUBLIC_MEDIA_E2EE_VERSIONS),
         }
     ), 200
 

--- a/public-rendezvous/rendezvous/pair_security.py
+++ b/public-rendezvous/rendezvous/pair_security.py
@@ -2,8 +2,8 @@
 
 The service authenticates membership and device public keys.  It never sees
 the derived ECDH secret or encrypted application payloads. Public audio/video
-remains disabled unless both peers negotiate the separately signed media-v1
-contract and enforce it through browser encoded-media transforms.
+remains disabled unless both peers negotiate one exact, separately signed
+media contract and enforce it through browser encoded-media transforms.
 """
 
 from __future__ import annotations
@@ -21,7 +21,13 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 TENANT_ID = "public-ananta"
 PUBLIC_MEDIA_E2EE_VERSION = 1
+PUBLIC_MEDIA_E2EE_VERSION_V2 = 2
+SUPPORTED_PUBLIC_MEDIA_E2EE_VERSIONS = (
+    PUBLIC_MEDIA_E2EE_VERSION,
+    PUBLIC_MEDIA_E2EE_VERSION_V2,
+)
 PUBLIC_MEDIA_TRANSFORM = "RTCRtpScriptTransform"
+PUBLIC_PAIR_MEDIA_FRAME_FORMAT_V2 = "ananta.public-pair.media-frame.v2"
 PUBLIC_MEDIA_GRANTS = (
     "microphone-opus",
     "camera-vp8",
@@ -43,37 +49,69 @@ def public_media_capabilities_v1() -> dict[str, Any]:
     }
 
 
+def public_media_capabilities_v2() -> dict[str, Any]:
+    """Return the one closed capability advertisement supported by v2."""
+    return {
+        "version": PUBLIC_MEDIA_E2EE_VERSION_V2,
+        "transform": PUBLIC_MEDIA_TRANSFORM,
+        "frame_format": PUBLIC_PAIR_MEDIA_FRAME_FORMAT_V2,
+        "grants": list(PUBLIC_MEDIA_GRANTS),
+    }
+
+
+def public_media_capabilities_for_version(version: int) -> dict[str, Any] | None:
+    """Project a persisted media version back to its immutable capability."""
+    if type(version) is not int:
+        return None
+    if version == PUBLIC_MEDIA_E2EE_VERSION:
+        return public_media_capabilities_v1()
+    if version == PUBLIC_MEDIA_E2EE_VERSION_V2:
+        return public_media_capabilities_v2()
+    return None
+
+
 def normalize_public_media_advertisement(version: Any, capabilities: Any) -> int:
     """Validate an optional, fail-closed Public Pair media advertisement.
 
-    Version zero is the backward-compatible data-only state. Version one is
-    accepted only together with the complete closed capability object, so a
-    partial or future-shaped request can never accidentally broaden a grant.
+    Version zero is the backward-compatible data-only state. Media versions
+    are accepted only with their complete closed capability object, so a
+    partial, mixed, or future-shaped request can never broaden a grant or
+    silently select a wire-incompatible framing format.
     """
     normalized_version = 0 if version is None else version
     if (
         isinstance(normalized_version, bool)
         or not isinstance(normalized_version, int)
-        or normalized_version not in {0, PUBLIC_MEDIA_E2EE_VERSION}
+        or normalized_version not in {0, *SUPPORTED_PUBLIC_MEDIA_E2EE_VERSIONS}
     ):
         raise ValueError("public_media_e2ee_version_unsupported")
     if normalized_version == 0:
         if capabilities is not None:
             raise ValueError("public_media_capabilities_without_version")
         return 0
+    expected = public_media_capabilities_for_version(normalized_version)
+    if expected is None:
+        raise ValueError("public_media_e2ee_version_unsupported")
+    if not isinstance(capabilities, dict) or set(capabilities) != set(expected):
+        raise ValueError("public_media_capabilities_invalid")
     if (
-        not isinstance(capabilities, dict)
-        or set(capabilities) != {"version", "transform", "grants"}
-        or type(capabilities.get("version")) is not int
-        or capabilities.get("version") != PUBLIC_MEDIA_E2EE_VERSION
+        type(capabilities.get("version")) is not int
+        or capabilities.get("version") != normalized_version
         or type(capabilities.get("transform")) is not str
         or capabilities.get("transform") != PUBLIC_MEDIA_TRANSFORM
         or not isinstance(capabilities.get("grants"), list)
         or any(type(grant) is not str for grant in capabilities["grants"])
         or capabilities["grants"] != list(PUBLIC_MEDIA_GRANTS)
+        or (
+            normalized_version == PUBLIC_MEDIA_E2EE_VERSION_V2
+            and (
+                type(capabilities.get("frame_format")) is not str
+                or capabilities.get("frame_format") != PUBLIC_PAIR_MEDIA_FRAME_FORMAT_V2
+            )
+        )
     ):
         raise ValueError("public_media_capabilities_invalid")
-    return PUBLIC_MEDIA_E2EE_VERSION
+    return normalized_version
 
 
 def canonical(value: Any) -> bytes:
@@ -170,11 +208,17 @@ class PairSecurityAuthority:
         owner: dict[str, Any],
         guest: dict[str, Any],
         base_security_contract_digest: str,
+        public_media_e2ee_version: int = PUBLIC_MEDIA_E2EE_VERSION,
     ) -> dict[str, Any]:
         """Issue the stable, separately signed Public Pair media contract."""
+        if (
+            type(public_media_e2ee_version) is not int
+            or public_media_e2ee_version not in SUPPORTED_PUBLIC_MEDIA_E2EE_VERSIONS
+        ):
+            raise ValueError("public_media_e2ee_version_unsupported")
         unsigned = {
-            "domain": "ananta.public-pair.media-security-contract.v1",
-            "version": PUBLIC_MEDIA_E2EE_VERSION,
+            "domain": f"ananta.public-pair.media-security-contract.v{public_media_e2ee_version}",
+            "version": public_media_e2ee_version,
             "session_id": session["id"],
             "epoch": int(session["security_epoch"]),
             "identity_binding_version": 2,
@@ -199,6 +243,8 @@ class PairSecurityAuthority:
             "expires_at_ms": int(float(session["expires_at"]) * 1000),
             "authority_key_id": self.key_id,
         }
+        if public_media_e2ee_version == PUBLIC_MEDIA_E2EE_VERSION_V2:
+            unsigned["frame_format"] = PUBLIC_PAIR_MEDIA_FRAME_FORMAT_V2
         digest = hashlib.sha256(canonical(unsigned)).hexdigest()
         signed = {
             **unsigned,

--- a/public-rendezvous/rendezvous/service.py
+++ b/public-rendezvous/rendezvous/service.py
@@ -22,10 +22,11 @@ from typing import Any
 
 from pair_security import (
     PUBLIC_MEDIA_E2EE_VERSION,
+    PUBLIC_MEDIA_E2EE_VERSION_V2,
     TENANT_ID,
     PairSecurityAuthority,
     normalize_public_media_advertisement,
-    public_media_capabilities_v1,
+    public_media_capabilities_for_version,
     spki_fingerprint,
 )
 from peer_identity import (
@@ -106,11 +107,11 @@ def _owner_create_request_digest(
         "title": title,
     }
     # Preserve the byte-for-byte v2 digest for pre-media clients and already
-    # persisted idempotency records. The media fields are bound only when the
-    # owner explicitly opts into the closed v1 capability set.
-    if public_media_e2ee_version == PUBLIC_MEDIA_E2EE_VERSION:
+    # persisted idempotency records. Media fields are bound only when the
+    # owner explicitly opts into one complete closed capability set.
+    if public_media_e2ee_version:
         payload["public_media_e2ee_version"] = public_media_e2ee_version
-        payload["public_media_capabilities"] = public_media_capabilities_v1()
+        payload["public_media_capabilities"] = public_media_capabilities_for_version(public_media_e2ee_version)
     material = b"ananta.public-rendezvous.owner-create-request.v2\0" + json.dumps(
         payload,
         sort_keys=True,
@@ -375,11 +376,7 @@ def _row_to_session(row: sqlite3.Row) -> dict[str, Any]:
         "security_contract_version": row["security_contract_version"],
         "identity_binding_version": row["identity_binding_version"],
         "public_media_e2ee_version": row["public_media_e2ee_version"],
-        "public_media_capabilities": (
-            public_media_capabilities_v1()
-            if int(row["public_media_e2ee_version"] or 0) == PUBLIC_MEDIA_E2EE_VERSION
-            else None
-        ),
+        "public_media_capabilities": public_media_capabilities_for_version(int(row["public_media_e2ee_version"] or 0)),
         "security_mode": row["security_mode"],
         "mode": "p2p",
         "transport": "webrtc",
@@ -425,10 +422,8 @@ def _list_participants(
                 "peer_id": row["peer_id"],
                 "_membership_capability_hash": row["membership_capability_hash"],
                 "public_media_e2ee_version": row["public_media_e2ee_version"],
-                "public_media_capabilities": (
-                    public_media_capabilities_v1()
-                    if int(row["public_media_e2ee_version"] or 0) == PUBLIC_MEDIA_E2EE_VERSION
-                    else None
+                "public_media_capabilities": public_media_capabilities_for_version(
+                    int(row["public_media_e2ee_version"] or 0)
                 ),
             }
         )
@@ -1066,10 +1061,8 @@ def join_session(
                 "account_id": existing["account_id"] or existing["user_id"],
                 "peer_id": existing["peer_id"] or existing["user_id"],
                 "public_media_e2ee_version": int(existing["public_media_e2ee_version"] or 0),
-                "public_media_capabilities": (
-                    public_media_capabilities_v1()
-                    if int(existing["public_media_e2ee_version"] or 0) == PUBLIC_MEDIA_E2EE_VERSION
-                    else None
+                "public_media_capabilities": public_media_capabilities_for_version(
+                    int(existing["public_media_e2ee_version"] or 0)
                 ),
             }
             conn.execute("COMMIT")
@@ -1103,9 +1096,7 @@ def join_session(
             "account_id": user_id,
             "peer_id": peer_id,
             "public_media_e2ee_version": normalized_media_version,
-            "public_media_capabilities": (
-                public_media_capabilities_v1() if normalized_media_version == PUBLIC_MEDIA_E2EE_VERSION else None
-            ),
+            "public_media_capabilities": public_media_capabilities_for_version(normalized_media_version),
         }
         if identity_binding_version == 2:
             if not membership_capability:
@@ -1490,17 +1481,18 @@ def _strict_pair_material(
     return members, authority, authority.contract(session, owner, guest)
 
 
-def _public_media_contract_v1(
+def _public_media_contract(
     *,
     session: dict[str, Any],
     members: list[dict[str, Any]],
     authority: PairSecurityAuthority,
     base_contract: dict[str, Any],
+    public_media_e2ee_version: int,
 ) -> dict[str, Any] | None:
-    """Negotiate media only for an exact v2 pair with two v1 adverts."""
+    """Negotiate one media contract only for an exact bilateral advert."""
     if int(session.get("identity_binding_version") or 0) != 2 or len(members) != 2:
         return None
-    if any(int(member.get("public_media_e2ee_version") or 0) != PUBLIC_MEDIA_E2EE_VERSION for member in members):
+    if any(int(member.get("public_media_e2ee_version") or 0) != public_media_e2ee_version for member in members):
         return None
     owner = next(member for member in members if member["owner"])
     guest = next(member for member in members if not member["owner"])
@@ -1509,6 +1501,7 @@ def _public_media_contract_v1(
         owner=owner,
         guest=guest,
         base_security_contract_digest=str(base_contract["digest"]),
+        public_media_e2ee_version=public_media_e2ee_version,
     )
 
 
@@ -1571,6 +1564,7 @@ def get_key_packages(
                 "security_contract_digest": None,
                 "security_contract": None,
                 "public_media_security_contract_v1": None,
+                "public_media_security_contract_v2": None,
                 "hub_key_id": authority.key_id,
                 "hub_public_key_b64": authority.public_key_b64,
                 "packages": [],
@@ -1598,11 +1592,19 @@ def get_key_packages(
             sender_peer_id=remote["peer_id"],
             recipient_peer_id=requester["peer_id"],
         )
-        public_media_contract = _public_media_contract_v1(
+        public_media_contract_v1 = _public_media_contract(
             session=session,
             members=members,
             authority=authority,
             base_contract=contract,
+            public_media_e2ee_version=PUBLIC_MEDIA_E2EE_VERSION,
+        )
+        public_media_contract_v2 = _public_media_contract(
+            session=session,
+            members=members,
+            authority=authority,
+            base_contract=contract,
+            public_media_e2ee_version=PUBLIC_MEDIA_E2EE_VERSION_V2,
         )
         return {
             "ok": True,
@@ -1610,7 +1612,8 @@ def get_key_packages(
             "tenant_id": TENANT_ID,
             "security_contract_digest": contract["digest"],
             "security_contract": contract,
-            "public_media_security_contract_v1": public_media_contract,
+            "public_media_security_contract_v1": public_media_contract_v1,
+            "public_media_security_contract_v2": public_media_contract_v2,
             "hub_key_id": authority.key_id,
             "hub_public_key_b64": authority.public_key_b64,
             "packages": [package],

--- a/tests/contracts/test_public_rendezvous_image.py
+++ b/tests/contracts/test_public_rendezvous_image.py
@@ -106,7 +106,7 @@ assert response.get_json() == {'ok': True, 'service': 'ananta-rendezvous'}
 assert response.headers['Access-Control-Allow-Origin'] == 'https://localhost'
 info = client.get('/info')
 assert info.status_code == 200
-assert info.get_json()['supported_public_media_e2ee_versions'] == [1]
+assert info.get_json()['supported_public_media_e2ee_versions'] == [1, 2]
 preflight = client.options('/rendezvous/sessions', headers={
     'Origin': 'http://localhost:4200',
     'Access-Control-Request-Method': 'GET',

--- a/tests/test_public_rendezvous_service_contract.py
+++ b/tests/test_public_rendezvous_service_contract.py
@@ -575,6 +575,49 @@ def test_public_media_v1_requires_the_exact_closed_capability_advertisement(publ
         )
 
 
+def test_public_media_v2_requires_the_exact_frame_format_capability(public_service):
+    base_kwargs = {
+        "subject": "media-v2-owner-sub",
+        "identity_binding_version": 2,
+        "membership_capability": "W" * 43,
+    }
+    exact = _public_media_capabilities_v2()
+
+    session = _create_session(
+        public_service,
+        **base_kwargs,
+        public_media_e2ee_version=2,
+        public_media_capabilities=exact,
+    )
+
+    assert session["public_media_e2ee_version"] == 2
+    assert session["public_media_capabilities"] == exact
+    invalid_capabilities = (
+        {key: value for key, value in exact.items() if key != "frame_format"},
+        {**exact, "frame_format": "ananta.public-pair.media-frame.v1"},
+        {**exact, "frame_format": True},
+        {**exact, "version": 1},
+        {**exact, "future": True},
+        _public_media_capabilities_v1(),
+    )
+    for capabilities in invalid_capabilities:
+        with pytest.raises(ValueError, match="public_media_capabilities_invalid"):
+            _create_session(
+                public_service,
+                **base_kwargs,
+                public_media_e2ee_version=2,
+                public_media_capabilities=capabilities,
+            )
+
+    with pytest.raises(ValueError, match="public_media_e2ee_version_unsupported"):
+        _create_session(
+            public_service,
+            **base_kwargs,
+            public_media_e2ee_version=3,
+            public_media_capabilities=exact,
+        )
+
+
 def test_public_media_v1_contract_is_stable_exact_and_ed25519_signed(public_service):
     pair = _public_media_pair(public_service, owner_media_version=1, guest_media_version=1)
     owner_response = pair["owner_packages"]
@@ -582,6 +625,8 @@ def test_public_media_v1_contract_is_stable_exact_and_ed25519_signed(public_serv
     contract = owner_response["public_media_security_contract_v1"]
 
     assert contract == guest_response["public_media_security_contract_v1"]
+    assert owner_response["public_media_security_contract_v2"] is None
+    assert guest_response["public_media_security_contract_v2"] is None
     repeated = public_service.get_key_packages(
         session_id=pair["session"]["id"],
         requester_user_id=pair["account_id"],
@@ -665,8 +710,75 @@ def test_public_media_v1_contract_is_stable_exact_and_ed25519_signed(public_serv
             _verify_public_media_contract(tampered, owner_response["hub_public_key_b64"])
 
 
-@pytest.mark.parametrize(("owner_version", "guest_version"), [(1, 0), (0, 1), (0, 0)])
-def test_public_media_contract_is_null_unless_both_v2_members_advertise_v1(
+def test_public_media_v2_contract_binds_exact_frame_format_and_is_ed25519_signed(public_service):
+    pair = _public_media_pair(public_service, owner_media_version=2, guest_media_version=2)
+    owner_response = pair["owner_packages"]
+    guest_response = pair["guest_packages"]
+    contract = owner_response["public_media_security_contract_v2"]
+
+    assert contract == guest_response["public_media_security_contract_v2"]
+    assert owner_response["public_media_security_contract_v1"] is None
+    assert guest_response["public_media_security_contract_v1"] is None
+    repeated = public_service.get_key_packages(
+        session_id=pair["session"]["id"],
+        requester_user_id=pair["account_id"],
+        requester_peer_id=pair["owner_peer_id"],
+        membership_capability=pair["owner_capability"],
+    )
+    assert repeated["public_media_security_contract_v2"] == contract
+    assert set(contract) == {
+        "domain",
+        "version",
+        "session_id",
+        "epoch",
+        "identity_binding_version",
+        "base_security_contract_digest",
+        "memberships",
+        "grants",
+        "slots",
+        "transform",
+        "algorithms",
+        "expires_at_ms",
+        "authority_key_id",
+        "frame_format",
+        "digest",
+        "signature_algorithm",
+        "signature_b64",
+    }
+    assert contract["domain"] == "ananta.public-pair.media-security-contract.v2"
+    assert contract["version"] == 2
+    assert contract["frame_format"] == "ananta.public-pair.media-frame.v2"
+    assert contract["identity_binding_version"] == 2
+    assert contract["base_security_contract_digest"] == owner_response["security_contract_digest"]
+    assert all(member["membership_version"] == 1 for member in contract["memberships"])
+    assert all(member["public_media_e2ee_version"] == 2 for member in contract["memberships"])
+    assert contract["grants"] == ["microphone-opus", "camera-vp8", "screen-vp8"]
+    assert contract["transform"] == "RTCRtpScriptTransform"
+    _verify_public_media_contract(contract, owner_response["hub_public_key_b64"])
+
+    from cryptography.exceptions import InvalidSignature
+
+    for path, value in (
+        (("version",), 1),
+        (("frame_format",), "ananta.public-pair.media-frame.v1"),
+        (("memberships", 0, "public_media_e2ee_version"), 1),
+    ):
+        tampered = json.loads(json.dumps(contract))
+        cursor = tampered
+        for key in path[:-1]:
+            cursor = cursor[key]
+        cursor[path[-1]] = value
+        with pytest.raises(InvalidSignature):
+            _verify_public_media_contract(tampered, owner_response["hub_public_key_b64"], check_digest=False)
+        with pytest.raises(AssertionError):
+            _verify_public_media_contract(tampered, owner_response["hub_public_key_b64"])
+
+
+@pytest.mark.parametrize(
+    ("owner_version", "guest_version"),
+    [(1, 0), (0, 1), (0, 0), (2, 0), (0, 2), (1, 2), (2, 1)],
+)
+def test_public_media_contract_is_null_unless_both_members_advertise_the_same_version(
     public_service,
     owner_version,
     guest_version,
@@ -679,16 +791,48 @@ def test_public_media_contract_is_null_unless_both_v2_members_advertise_v1(
 
     assert pair["owner_packages"]["public_media_security_contract_v1"] is None
     assert pair["guest_packages"]["public_media_security_contract_v1"] is None
+    assert pair["owner_packages"]["public_media_security_contract_v2"] is None
+    assert pair["guest_packages"]["public_media_security_contract_v2"] is None
+    assert pair["owner_packages"]["security_contract"] is not None
+    assert pair["guest_packages"]["security_contract"] is not None
 
 
-def test_public_media_version_is_bound_to_create_and_join_idempotency(public_service):
-    pair = _public_media_pair(public_service, owner_media_version=1, guest_media_version=1)
-    exact = _public_media_capabilities_v1()
+@pytest.mark.parametrize("media_version", [1, 2])
+def test_public_media_version_is_bound_to_create_and_join_idempotency(public_service, media_version):
+    pair = _public_media_pair(
+        public_service,
+        owner_media_version=media_version,
+        guest_media_version=media_version,
+    )
+    exact = _public_media_capabilities_for_version(media_version)
 
     recovered_owner = public_service.create_session(**pair["create_kwargs"])
     recovered_guest = public_service.join_session(**pair["join_kwargs"])
     assert recovered_owner["_idempotent"] is True
     assert recovered_guest["idempotent"] is True
+    assert public_service.is_owner_create_recovery(
+        account_id=pair["account_id"],
+        device_fingerprint=pair["owner_fingerprint"],
+        membership_capability=pair["owner_capability"],
+        public_media_e2ee_version=media_version,
+    )
+    assert public_service.is_join_recovery(
+        invite_code=pair["session"]["invite_code"],
+        account_id=pair["account_id"],
+        device_fingerprint=pair["guest_fingerprint"],
+        membership_capability=pair["guest_capability"],
+        public_media_e2ee_version=media_version,
+    )
+    with public_service._db() as conn:
+        persisted_owner_version = conn.execute(
+            "SELECT public_media_e2ee_version FROM sessions WHERE id = ?",
+            (pair["session"]["id"],),
+        ).fetchone()[0]
+        persisted_guest_version = conn.execute(
+            "SELECT public_media_e2ee_version FROM participants WHERE session_id = ?",
+            (pair["session"]["id"],),
+        ).fetchone()[0]
+    assert (persisted_owner_version, persisted_guest_version) == (media_version, media_version)
     with pytest.raises(ValueError, match="membership_capability_conflict"):
         public_service.create_session(
             **{
@@ -1594,6 +1738,18 @@ def test_http_v2_same_account_pair_requires_membership_capabilities(monkeypatch,
             },
         },
     )
+    invalid_v2_frame_format = client.post(
+        "/rendezvous/sessions",
+        headers=owner_headers,
+        json={
+            **create_body,
+            "public_media_e2ee_version": 2,
+            "public_media_capabilities": {
+                **_public_media_capabilities_v2(),
+                "frame_format": "ananta.public-pair.media-frame.v1",
+            },
+        },
+    )
     created = client.post("/rendezvous/sessions", headers=owner_headers, json=create_body)
     recovered_create = client.post(
         "/rendezvous/sessions",
@@ -1605,12 +1761,16 @@ def test_http_v2_same_account_pair_requires_membership_capabilities(monkeypatch,
     invite_code = created_payload["session"]["invite_code"]
     owner_peer_id = created_payload["local_peer_id"]
     assert created.status_code == 201
-    assert info.get_json()["supported_public_media_e2ee_versions"] == [1]
+    assert info.get_json()["supported_public_media_e2ee_versions"] == [1, 2]
     assert (missing_media_capabilities.status_code, missing_media_capabilities.get_json()) == (
         400,
         {"error": "public_media_capabilities_invalid"},
     )
     assert (reordered_media_grants.status_code, reordered_media_grants.get_json()) == (
+        400,
+        {"error": "public_media_capabilities_invalid"},
+    )
+    assert (invalid_v2_frame_format.status_code, invalid_v2_frame_format.get_json()) == (
         400,
         {"error": "public_media_capabilities_invalid"},
     )
@@ -2357,6 +2517,23 @@ def _public_media_capabilities_v1() -> dict:
     }
 
 
+def _public_media_capabilities_v2() -> dict:
+    return {
+        "version": 2,
+        "transform": "RTCRtpScriptTransform",
+        "frame_format": "ananta.public-pair.media-frame.v2",
+        "grants": ["microphone-opus", "camera-vp8", "screen-vp8"],
+    }
+
+
+def _public_media_capabilities_for_version(version: int) -> dict | None:
+    if version == 1:
+        return _public_media_capabilities_v1()
+    if version == 2:
+        return _public_media_capabilities_v2()
+    return None
+
+
 def _public_media_pair(public_service, *, owner_media_version: int, guest_media_version: int) -> dict:
     subject = f"media-pair-{owner_media_version}-{guest_media_version}"
     account_id = _peer_id(subject)
@@ -2364,7 +2541,6 @@ def _public_media_pair(public_service, *, owner_media_version: int, guest_media_
     guest_spki, guest_fp = _device_key()
     owner_capability = "R" * 43
     guest_capability = "S" * 43
-    exact = _public_media_capabilities_v1()
     create_kwargs = {
         "owner_user_id": account_id,
         "owner_user_sub": subject,
@@ -2375,7 +2551,7 @@ def _public_media_pair(public_service, *, owner_media_version: int, guest_media_
         "identity_binding_version": 2,
         "membership_capability": owner_capability,
         "public_media_e2ee_version": owner_media_version,
-        "public_media_capabilities": exact if owner_media_version == 1 else None,
+        "public_media_capabilities": _public_media_capabilities_for_version(owner_media_version),
     }
     session = public_service.create_session(**create_kwargs)
     join_kwargs = {
@@ -2389,7 +2565,7 @@ def _public_media_pair(public_service, *, owner_media_version: int, guest_media_
         "expected_identity_binding_version": 2,
         "membership_capability": guest_capability,
         "public_media_e2ee_version": guest_media_version,
-        "public_media_capabilities": exact if guest_media_version == 1 else None,
+        "public_media_capabilities": _public_media_capabilities_for_version(guest_media_version),
     }
     joined = public_service.join_session(**join_kwargs)
     assert joined["ok"] is True


### PR DESCRIPTION
## Summary

- isolate the public OIDC Pair surface from Hub-authoritative routes and APIs
- add an additive, separately signed Public Pair media-v2 contract while retaining media-v1/data-only compatibility
- introduce an interoperable VP8/Opus encoded-frame format: required codec prefixes remain clear but AES-GCM-authenticated; all remaining frame bytes stay encrypted
- add a gated Chromium/Firefox live canary for same-account, distinct-device public Pair audio/video

## Why

The first real Chromium-to-Firefox media canary proved that encrypting the complete VP8 frame changed browser frame classification before decryption. Firefox received Chromium keyframes as delta frames and could not decode them. Media-v2 preserves only the codec prefix required by packetizers (VP8 10 bytes for keyframes, 3 for delta frames; one Opus TOC byte), binds it into AEAD additional data, and encrypts the suffix.

The public shell changes also ensure OIDC-only Pair access never grants ambient Hub authority or triggers Hub profile/group calls.

## Security and compatibility

- backend must roll out before the new frontend
- v1 remains unchanged; old, asymmetric, mixed, or unsupported peers remain data-only
- only the exact Ed25519-signed v2 contract can authorize the v2 media pipeline
- v2 is bound into the authority contract, bilateral hello/ack, connection digest, key derivation, frame header, and AEAD context
- no raw media fallback; invalid/auth/replay/expiry paths remain fail-closed
- no Hub/worker orchestration boundary changed

## Verification

- frontend focused: 184 tests passed
- independent security review: P0=0, P1=0
- backend contract/image: 61 tests passed
- adjacent public Rendezvous/OIDC/profile: 35 tests passed
- app/spec TypeScript checks passed
- scoped ESLint and Ruff passed
- Angular production build passed
- diff and secret-pattern checks passed
- Playwright live canary collects exactly one gated test

## Rollout

1. merge and deploy the additive Rendezvous backend; verify `/info.supported_public_media_e2ee_versions == [1,2]`
2. serve the v2 frontend
3. run the disposable same-account Chromium/Firefox canary
4. promote only after bilateral microphone, camera, screen, revoke, and cleanup gates pass

The live canary is intentionally not run against the current v1-only backend.