### PR TITLE
fix(pair-media): reconcile DataChannel readiness

### DIFF
--- a/frontend-angular/src/app/features/pair/public-pair-page.component.spec.ts
+++ b/frontend-angular/src/app/features/pair/public-pair-page.component.spec.ts
@@ -11,6 +11,7 @@ import { OidcAuthService } from '../../services/oidc-auth.service';
 import { PairViewSessionBindingService } from '../../services/pair-view-session-binding.service';
 import { ShareSessionService } from '../../services/share-session.service';
 import { WebrtcSignalingService } from '../../services/webrtc-signaling.service';
+import { WebrtcSessionService } from '../../services/webrtc-session.service';
 import { SemanticMediaProgramHostComponent } from '../voice/semantic-media-program-host.component';
 import { PublicPairPageComponent } from './public-pair-page.component';
 
@@ -25,7 +26,9 @@ class SemanticMediaProgramHostStubComponent {
 
 describe('PublicPairPageComponent', () => {
   it('renders the direct Pair surface without initializing or exposing Hub group APIs', async () => {
-    const status$ = new BehaviorSubject('disconnected');
+    const signalingStatus$ = new BehaviorSubject('disconnected');
+    const webrtcStatus$ = new BehaviorSubject('idle');
+    const dataChannelStatus$ = new BehaviorSubject('absent');
     const core = {
       get: vi.fn(() => of({})),
       post: vi.fn(() => of({})),
@@ -42,7 +45,11 @@ describe('PublicPairPageComponent', () => {
     await TestBed.configureTestingModule({
       providers: [
         { provide: OidcAuthService, useValue: { currentUsername: 'keycloak-user' } },
-        { provide: WebrtcSignalingService, useValue: { status$ } },
+        { provide: WebrtcSignalingService, useValue: { status$: signalingStatus$ } },
+        {
+          provide: WebrtcSessionService,
+          useValue: { state$: webrtcStatus$, dataChannelState$: dataChannelStatus$ },
+        },
         { provide: ShareSessionService, useValue: share },
         { provide: PairViewSessionBindingService, useValue: { start: vi.fn() } },
         {
@@ -68,8 +75,12 @@ describe('PublicPairPageComponent', () => {
 
     expect(host.querySelector('[data-testid="public-pair-page"]')).not.toBeNull();
     expect(host.querySelector('[data-testid="public-pair-user"]')?.textContent).toContain('keycloak-user');
+    expect(host.querySelector('[data-testid="public-pair-signaling-status"]')?.textContent)
+      .toContain('Signaling: disconnected');
     expect(host.querySelector('[data-testid="public-pair-webrtc-status"]')?.textContent)
-      .toContain('WebRTC: disconnected');
+      .toContain('WebRTC: idle');
+    expect(host.querySelector('[data-testid="public-pair-datachannel-status"]')?.textContent)
+      .toContain('DataChannel: absent');
     expect(panel.publicOnly).toBe(true);
     expect(media.displayMode).toBe('pair_media');
     expect(host.textContent).not.toContain('Gruppen');

--- a/frontend-angular/src/app/features/pair/public-pair-page.component.ts
+++ b/frontend-angular/src/app/features/pair/public-pair-page.component.ts
@@ -4,6 +4,7 @@ import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { AiSnakeSharePanelComponent } from '../../components/ai-snake-share-panel.component';
 import { SemanticMediaProgramHostComponent } from '../voice/semantic-media-program-host.component';
 import { OidcAuthService } from '../../services/oidc-auth.service';
+import { WebrtcSessionService } from '../../services/webrtc-session.service';
 import { WebrtcSignalingService } from '../../services/webrtc-signaling.service';
 
 @Component({
@@ -20,7 +21,9 @@ import { WebrtcSignalingService } from '../../services/webrtc-signaling.service'
         </div>
         <div class="public-pair-status" aria-label="Public-Pair-Verbindungsstatus">
           <span data-testid="public-pair-user">{{ oidc.currentUsername || 'Angemeldet' }}</span>
-          <span data-testid="public-pair-webrtc-status">WebRTC: {{ signaling.status$ | async }}</span>
+          <span data-testid="public-pair-signaling-status">Signaling: {{ signaling.status$ | async }}</span>
+          <span data-testid="public-pair-webrtc-status">WebRTC: {{ webrtc.state$ | async }}</span>
+          <span data-testid="public-pair-datachannel-status">DataChannel: {{ webrtc.dataChannelState$ | async }}</span>
         </div>
       </header>
 
@@ -60,4 +63,5 @@ import { WebrtcSignalingService } from '../../services/webrtc-signaling.service'
 export class PublicPairPageComponent {
   readonly oidc = inject(OidcAuthService);
   readonly signaling = inject(WebrtcSignalingService);
+  readonly webrtc = inject(WebrtcSessionService);
 }

--- a/frontend-angular/src/app/features/voice/semantic-media-program.facade.spec.ts
+++ b/frontend-angular/src/app/features/voice/semantic-media-program.facade.spec.ts
@@ -409,6 +409,35 @@ describe('SemanticMediaProgramFacade', () => {
     expect(facade.view$.value.ordinaryMediaCaptureEnabled).toBe(true);
   });
 
+  it('keeps the active Public media request fenced while transient status updates arrive', async () => {
+    directory.list.mockReturnValue([]);
+    pairControlPlane.authorityKindForSession.mockReturnValue('public');
+    profile$.next({
+      ...profile,
+      profile_id: 'public-ananta',
+      public_rendezvous: true,
+      semantic_media_feature_flags: { ...flags, ordinary_media_publication: false },
+    });
+    let resolveActivation!: (state: any) => void;
+    pairMediaE2ee.activate.mockReturnValueOnce(new Promise(resolve => { resolveActivation = resolve; }));
+
+    const activation = facade.handleProgramIntent({
+      capability: 'ordinary_media', desired: 'activate', requestId: 'public-media-pending',
+    });
+    await Promise.resolve();
+    pairMediaE2eeStatus$.next({
+      sessionId: 'session-a', state: 'awaiting-peer', reasonCode: 'public_media_local_activation_pending',
+    });
+
+    expect(facade.view$.value.capabilities.find(row => row.capability === 'ordinary_media'))
+      .toMatchObject({ state: 'degraded', requestId: 'public-media-pending' });
+
+    resolveActivation({ sessionId: 'session-a', state: 'awaiting-peer' });
+    await activation;
+    expect(facade.view$.value.capabilities.find(row => row.capability === 'ordinary_media'))
+      .toMatchObject({ state: 'degraded', requestId: null });
+  });
+
   it('does not let a superseded Public activation overwrite an explicit revoke', async () => {
     directory.list.mockReturnValue([]);
     pairControlPlane.authorityKindForSession.mockReturnValue('public');

--- a/frontend-angular/src/app/features/voice/semantic-media-program.facade.ts
+++ b/frontend-angular/src/app/features/voice/semantic-media-program.facade.ts
@@ -955,7 +955,7 @@ export class SemanticMediaProgramFacade implements OnDestroy {
       this.setCapability(
         'ordinary_media',
         'degraded',
-        null,
+        current?.requestId ?? null,
         status.reasonCode || this.ordinaryMediaPolicyReason(sessionId),
       );
       return;

--- a/frontend-angular/src/app/services/pair-media-e2ee-coordinator.service.spec.ts
+++ b/frontend-angular/src/app/services/pair-media-e2ee-coordinator.service.spec.ts
@@ -25,6 +25,8 @@ interface CoordinatorNode {
   readonly closed: ReturnType<typeof vi.fn>;
   readonly outbound: SemanticDataChannelMessage[];
   readonly sent: SemanticDataChannelMessage[];
+  portOpen: boolean;
+  portOpenError: Error | null;
 }
 
 describe('PairMediaE2eeCoordinatorService', () => {
@@ -65,6 +67,59 @@ describe('PairMediaE2eeCoordinatorService', () => {
       expect(ownerSlot.sendContext).toEqual(guestSlot.receiveContext);
       expect(ownerSlot.sendContext.connectionId).toBe(ownerSlot.receiveContext.connectionId);
     }
+  });
+
+  it('reconciles an already-open consent port without an explicit open event', async () => {
+    const owner = node('peer:owner', 'peer:guest');
+    const guest = node('peer:guest', 'peer:owner');
+    owner.portOpen = true;
+    guest.portOpen = true;
+    connect(owner, guest);
+    owner.coordinator.markTopologyNegotiated('session-a');
+    guest.coordinator.markTopologyNegotiated('session-a');
+    expect(owner.coordinator.canActivate('session-a')).toBe(true);
+
+    const ownerActivation = owner.coordinator.activate('session-a');
+    const guestActivation = guest.coordinator.activate('session-a');
+    await pump(owner, guest);
+
+    await expect(ownerActivation).resolves.toMatchObject({ state: 'ready' });
+    await expect(guestActivation).resolves.toMatchObject({ state: 'ready' });
+    expect(countControl(owner, 'hello')).toBe(1);
+    expect(countControl(guest, 'hello')).toBe(1);
+  });
+
+  it('keeps activation pending while the consent port remains closed', async () => {
+    const owner = node('peer:owner', 'peer:guest');
+    bindSink(owner);
+    owner.coordinator.markTopologyNegotiated('session-a');
+    expect(owner.coordinator.canActivate('session-a')).toBe(false);
+
+    const activation = owner.coordinator.activate('session-a');
+    await settle(4);
+
+    expect(owner.outbound).toEqual([]);
+    expect(owner.coordinator.statusFor('session-a')).toMatchObject({
+      state: 'awaiting-peer', reasonCode: 'public_media_local_activation_pending',
+    });
+
+    owner.coordinator.deactivate('session-a', 'test_cleanup');
+    await expect(activation).resolves.toMatchObject({ state: 'inactive', reasonCode: 'test_cleanup' });
+  });
+
+  it('fails closed when consent-port readiness cannot be read', async () => {
+    const owner = node('peer:owner', 'peer:guest');
+    owner.portOpenError = new Error('public_media_consent_channel_state_failed');
+    bindSink(owner);
+    owner.coordinator.markTopologyNegotiated('session-a');
+
+    const activation = owner.coordinator.activate('session-a');
+
+    await expect(activation).resolves.toMatchObject({
+      state: 'failed', reasonCode: 'public_media_consent_channel_state_failed',
+    });
+    expect(owner.closed).toHaveBeenCalledWith('public_media_consent_channel_state_failed');
+    expect(owner.transforms.prepared).toBe(false);
   });
 
   it('binds the exact v2 frame format into the encrypted bilateral hello', async () => {
@@ -215,6 +270,7 @@ function node(localPeerId: string, remotePeerId: string, expiresAtMs = 2_000_000
   const value: CoordinatorNode = {
     coordinator, transforms, crypto: encryption, binding,
     disabled: vi.fn(), closed: vi.fn(), outbound: [], sent: [],
+    portOpen: false, portOpenError: null,
   };
   activeNode(value);
   return value;
@@ -244,6 +300,10 @@ function bindSink(value: CoordinatorNode): void {
 
 function port(value: CoordinatorNode): PairMediaE2eeTransportPort {
   return {
+    isOpen: () => {
+      if (value.portOpenError) throw value.portOpenError;
+      return value.portOpen;
+    },
     send: async message => { value.outbound.push(message); value.sent.push(message); },
     disableMedia: value.disabled,
     failClosed: value.closed,

--- a/frontend-angular/src/app/services/pair-media-e2ee-coordinator.service.ts
+++ b/frontend-angular/src/app/services/pair-media-e2ee-coordinator.service.ts
@@ -40,6 +40,8 @@ export interface PublicPairMediaE2eeState {
 
 /** Lower-level port registered by WebrtcSessionService; no reverse DI edge. */
 export interface PairMediaE2eeTransportPort {
+  /** Generation-bound consent-channel readiness; never infer this from signaling. */
+  isOpen(): boolean;
   send(message: SemanticDataChannelMessage): Promise<void>;
   disableMedia(reasonCode: string): void;
   failClosed(reasonCode: string): void;
@@ -146,8 +148,20 @@ export class PairMediaE2eeCoordinatorService {
       || contract.expires_at_ms <= Date.now()
     ) return false;
     const runtime = this.runtime;
-    if (runtime?.sessionId === sessionId && (runtime.failed || runtime.installed)) return false;
-    return this.transforms.isPrepared(sessionId, contract.epoch, contract.digest);
+    if (runtime?.sessionId === sessionId && !runtime.dataChannelOpen) {
+      this.reconcileDataChannelOpen(runtime);
+    }
+    if (
+      !runtime
+      || runtime.sessionId !== sessionId
+      || runtime.failed
+      || runtime.installed
+      || !runtime.topologyReady
+      || !runtime.dataChannelOpen
+    ) return false;
+    return this.transforms.isPrepared(
+      sessionId, contract.epoch, contract.digest, runtime.adapterGeneration,
+    );
   }
 
   async activate(sessionId: string): Promise<PublicPairMediaE2eeState> {
@@ -206,7 +220,7 @@ export class PairMediaE2eeCoordinatorService {
   bindTransport(sessionId: string, port: PairMediaE2eeTransportPort): void {
     const runtime = this.ensureRuntime(sessionId);
     runtime.port = port;
-    if (runtime.localActivated && runtime.dataChannelOpen) {
+    if (runtime.localActivated) {
       void this.maybeSendHello(runtime).catch(error => {
         this.failRuntime(runtime, reason(error, 'public_media_hello_send_failed'), true);
       });
@@ -234,6 +248,8 @@ export class PairMediaE2eeCoordinatorService {
       void this.maybeSendHello(runtime).catch(error => {
         this.failRuntime(runtime, reason(error, 'public_media_hello_send_failed'), true);
       });
+    } else {
+      this.emit(runtime, 'inactive');
     }
   }
 
@@ -242,6 +258,7 @@ export class PairMediaE2eeCoordinatorService {
     try {
       this.transforms.validateFinalTopology(sessionId);
       runtime.topologyReady = true;
+      if (!runtime.localActivated) this.emit(runtime, 'inactive');
       void this.maybeInstall(runtime);
     } catch (error) {
       // A peer that could not advertise the optional media extension may
@@ -358,6 +375,7 @@ export class PairMediaE2eeCoordinatorService {
   private async maybeSendHello(runtime: Runtime): Promise<void> {
     this.assertCurrent(runtime);
     this.refreshExpiredPreKeyHandshake(runtime);
+    this.reconcileDataChannelOpen(runtime);
     if (
       runtime.failed || !runtime.localActivated || !runtime.dataChannelOpen || !runtime.port
       || runtime.helloSendPromise || runtime.localHello
@@ -394,6 +412,19 @@ export class PairMediaE2eeCoordinatorService {
       await this.maybeSendAck(runtime);
     })().finally(() => { runtime.helloSendPromise = null; });
     return runtime.helloSendPromise;
+  }
+
+  private reconcileDataChannelOpen(runtime: Runtime): void {
+    if (runtime.dataChannelOpen || !runtime.port || runtime.failed || runtime.poisoned) return;
+    try {
+      runtime.dataChannelOpen = runtime.port.isOpen() === true;
+    } catch (error) {
+      this.failRuntime(
+        runtime,
+        reason(error, 'public_media_consent_channel_state_failed'),
+        true,
+      );
+    }
   }
 
   private async acceptHello(runtime: Runtime, hello: MediaHelloV2): Promise<void> {

--- a/frontend-angular/src/app/services/webrtc-public-media-lifecycle.spec.ts
+++ b/frontend-angular/src/app/services/webrtc-public-media-lifecycle.spec.ts
@@ -20,6 +20,7 @@ import { WebrtcSessionService } from './webrtc-session.service';
 
 class PublicPeerConnection {
   static instances: PublicPeerConnection[] = [];
+  static nextDataChannelReadyState: RTCDataChannelState = 'connecting';
   connectionState: RTCPeerConnectionState = 'new';
   signalingState: RTCSignalingState = 'stable';
   onicecandidate: ((event: RTCPeerConnectionIceEvent) => void) | null = null;
@@ -38,7 +39,9 @@ class PublicPeerConnection {
     await this.remoteDescriptionGate?.promise;
   });
   readonly addIceCandidate = vi.fn(async () => undefined);
-  readonly createDataChannel = vi.fn(() => dataChannel());
+  readonly createDataChannel = vi.fn(() => Object.assign(dataChannel(), {
+    readyState: PublicPeerConnection.nextDataChannelReadyState,
+  }));
   readonly getTransceivers = vi.fn(() => this.remoteOfferTransceivers as unknown as RTCRtpTransceiver[]);
 
   constructor(readonly configuration?: RTCConfiguration) {
@@ -87,6 +90,7 @@ describe('WebrtcSessionService Public media lifecycle', () => {
 
   beforeEach(() => {
     PublicPeerConnection.instances = [];
+    PublicPeerConnection.nextDataChannelReadyState = 'connecting';
     signalHandler = null;
     signaling = {
       status$: new BehaviorSubject('disconnected'),
@@ -138,6 +142,64 @@ describe('WebrtcSessionService Public media lifecycle', () => {
     await signalHandler?.(offer());
     expect(PublicPeerConnection.instances[1].createAnswer).toHaveBeenCalledOnce();
     expect(signaling.send).toHaveBeenCalledWith(expect.objectContaining({ type: 'answer' }));
+  });
+
+  it('reconciles an already-open generation-bound DataChannel exactly once', async () => {
+    PublicPeerConnection.nextDataChannelReadyState = 'open';
+
+    await service.startSession('session-a', true, 'peer:remote');
+    await settle();
+
+    const peer = PublicPeerConnection.instances[0];
+    const channel = peer.createDataChannel.mock.results[0].value as RTCDataChannel;
+    const oldPort = coordinator.port;
+    expect(oldPort?.isOpen()).toBe(true);
+    expect(coordinator.markDataChannelOpen).toHaveBeenCalledTimes(1);
+
+    channel.onopen?.(new Event('open'));
+    expect(coordinator.markDataChannelOpen).toHaveBeenCalledTimes(1);
+
+    await service.startSession('session-a', true, 'peer:remote');
+    expect(oldPort?.isOpen()).toBe(false);
+    expect(coordinator.port?.isOpen()).toBe(true);
+  });
+
+  it('reconciles an already-open answerer DataChannel exactly once', async () => {
+    await service.startSession('session-a', false, 'peer:remote');
+    const peer = PublicPeerConnection.instances[0];
+    const channel = Object.assign(dataChannel(), { readyState: 'open' as const });
+
+    peer.ondatachannel?.({ channel } as RTCDataChannelEvent);
+    await settle();
+
+    expect(service.dataChannelState$.value).toBe('open');
+    expect(coordinator.port?.isOpen()).toBe(true);
+    expect(coordinator.markDataChannelOpen).toHaveBeenCalledTimes(1);
+
+    channel.onopen?.(new Event('open'));
+    expect(coordinator.markDataChannelOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it('reopens a revoked media contract as data-only with a fresh connection generation', async () => {
+    PublicPeerConnection.nextDataChannelReadyState = 'open';
+    await service.startSession('session-a', true, 'peer:remote');
+    await settle();
+    const mediaPeer = PublicPeerConnection.instances[0];
+    const oldPort = coordinator.port;
+
+    coordinator.deactivate('session-a', 'ordinary_media_capability_revoked');
+    expect(mediaPeer.close).toHaveBeenCalledOnce();
+    expect(oldPort?.isOpen()).toBe(false);
+
+    await service.startSession('session-a', true, 'peer:remote');
+    await settle();
+    const dataOnlyPeer = PublicPeerConnection.instances[1];
+
+    expect(transforms.prepareSession).toHaveBeenCalledTimes(1);
+    expect(dataOnlyPeer.close).not.toHaveBeenCalled();
+    expect(service.state$.value).toBe('connecting');
+    expect(service.dataChannelState$.value).toBe('open');
+    expect(coordinator.port).toBeNull();
   });
 
   it('fences an old same-session prepare continuation and fatal callback from its replacement', async () => {

--- a/frontend-angular/src/app/services/webrtc-session.service.ts
+++ b/frontend-angular/src/app/services/webrtc-session.service.ts
@@ -92,6 +92,7 @@ export class WebrtcSessionService {
   private pairMediaTransforms = inject(PairMediaE2eeTransformAdapter);
 
   readonly state$ = new BehaviorSubject<PeerState>('idle');
+  readonly dataChannelState$ = new BehaviorSubject<RTCDataChannelState | 'absent'>('absent');
   readonly dcMessage$ = new Subject<DcMessage>();
   readonly semanticMessage$ = new Subject<SemanticDataChannelMessage>();
   readonly remoteTrack$ = new Subject<RTCTrackEvent>();
@@ -141,6 +142,7 @@ export class WebrtcSessionService {
     this.localDescriptionPublicationPending = false;
     this.pendingLocalIce = [];
     this.state$.next('connecting');
+    this.dataChannelState$.next('absent');
     this.sessionStarted$.next(sessionId);
     this.audit('session_start', `initiator=${isInitiator}`);
 
@@ -225,6 +227,8 @@ export class WebrtcSessionService {
             && this.isCurrentSession(preparedPeer, sessionId, generation);
         };
         this.pairMediaE2ee.bindTransport(sessionId, {
+          isOpen: () => matchesPreparedContext()
+            && this.dc?.readyState === 'open',
           send: async message => {
             if (!matchesPreparedContext()) throw new Error('public_media_runtime_superseded');
             const channel = this.dc;
@@ -337,6 +341,7 @@ export class WebrtcSessionService {
     const closingDataChannel = this.dc;
     this.dc = null;
     closingDataChannel?.close();
+    this.dataChannelState$.next('absent');
     this.pc?.close();
     this.pc = null;
     this.signaling.disconnect();
@@ -793,21 +798,28 @@ export class WebrtcSessionService {
     let receiveChain = Promise.resolve();
     let queuedMessages = 0;
     let queuedBytes = 0;
+    let openObserved = false;
     this.sendQueue.bind(dc);
+    this.dataChannelState$.next(dc.readyState);
     dc.onbufferedamountlow = () => {
       if (this.isCurrentSession(pc, sessionId, generation) && this.dc === dc) this.sendQueue.flush();
     };
-    dc.onopen = () => {
+    const handleOpen = () => {
       if (!this.isCurrentSession(pc, sessionId, generation) || this.dc !== dc) return;
+      if (openObserved) return;
+      openObserved = true;
+      this.dataChannelState$.next('open');
       this.audit('datachannel_opened');
       this.sendDc('hello', { version: 1 });
       if (this.pairMediaTransforms.isPrepared(sessionId)) {
         this.pairMediaE2ee.markDataChannelOpen(sessionId);
       }
     };
+    dc.onopen = handleOpen;
     dc.onclose = () => {
       if (!this.isCurrentSession(pc, sessionId, generation) || this.dc !== dc) return;
       this.sendQueue.unbind();
+      this.dataChannelState$.next('closed');
       this.audit('datachannel_closed');
       if (this.pairMediaTransforms.isPrepared(sessionId)) {
         this.pairMediaE2ee.fail(sessionId, 'public_media_consent_channel_closed');
@@ -818,6 +830,7 @@ export class WebrtcSessionService {
     dc.onerror = () => {
       if (!this.isCurrentSession(pc, sessionId, generation) || this.dc !== dc) return;
       this.audit('datachannel_error');
+      this.dataChannelState$.next(dc.readyState);
       if (this.pairMediaTransforms.isPrepared(sessionId)) {
         this.pairMediaE2ee.fail(sessionId, 'public_media_consent_channel_failed');
       } else if (this.controlPlane.isPublicSession(sessionId)) {
@@ -858,6 +871,10 @@ export class WebrtcSessionService {
         queuedBytes -= incomingBytes;
       });
     };
+    // Some implementations may dispatch `open` before a late answerer has
+    // finished wiring every callback. Reconcile the level state after all
+    // handlers are installed; `openObserved` keeps the edge path idempotent.
+    if (dc.readyState === 'open') queueMicrotask(handleOpen);
   }
 
   private isCurrentSession(

--- a/frontend-angular/tests/public-pair-media-live.spec.ts
+++ b/frontend-angular/tests/public-pair-media-live.spec.ts
@@ -65,7 +65,7 @@ test.describe('Public Pair media live canary', () => {
 
       await endOwnerSession(ownerPage, owner.sessionId);
       sessionCreated = false;
-      await leaveGuestSession(guestPage);
+      await bestEffortLeaveGuestSession(guestPage);
     } finally {
       if (sessionCreated && ownerPage) await bestEffortEndOwnerSession(ownerPage);
       if (guestPage) await bestEffortLeaveGuestSession(guestPage);
@@ -373,6 +373,10 @@ async function expectPairSecurityReady(page: Page, peerRole: 'owner' | 'guest'):
     page.getByTestId('public-pair-webrtc-status'),
     `${peerRole}_webrtc_not_connected`,
   ).toHaveText(/WebRTC:\s*connected/i);
+  await expect(
+    page.getByTestId('public-pair-datachannel-status'),
+    `${peerRole}_datachannel_not_open`,
+  ).toHaveText(/DataChannel:\s*open/i);
 }
 
 async function activateMediaBilateral(owner: Page, guest: Page): Promise<void> {
@@ -404,9 +408,13 @@ async function mediaActivationDiagnostic(page: Page): Promise<string> {
     .locator('code').textContent().catch(() => 'media_panel_unavailable');
   const pendingCount = await page.getByTestId('public-media-e2ee-pending').count();
   const webrtc = await page.getByTestId('public-pair-webrtc-status').textContent().catch(() => 'missing');
+  const dataChannel = await page.getByTestId('public-pair-datachannel-status')
+    .textContent().catch(() => 'missing');
+  const pageErrors = (PAGE_ERROR_CODES.get(page) ?? []).slice(-4);
   return `cap_${safeStatusCode(capabilityState)}_cap_reason_${safeReasonCode(capabilityReason)}`
     + `_operation_${safeReasonCode(operationReason)}_pending_${pendingCount}`
-    + `_webrtc_${safeStatusCode(webrtc)}`;
+    + `_webrtc_${safeStatusCode(webrtc)}_datachannel_${safeChannelState(dataChannel)}`
+    + `_page_errors_${pageErrors.join('-') || 'none'}`;
 }
 
 async function startBilateralCapture(owner: Page, guest: Page): Promise<void> {
@@ -508,8 +516,13 @@ async function revokeMediaFromOwner(owner: Page, guest: Page): Promise<void> {
   await mediaCapability(owner).getByRole('button', { name: 'Widerrufen', exact: true }).click();
   await Promise.all([owner, guest].map(page => expect(mediaPanel(page)).toHaveCount(0)));
   await Promise.all([owner, guest].map(page => expect(page.getByTestId('public-media-e2ee-ready')).toHaveCount(0)));
+  // Revocation destroys the keyed media PC/worker generation. Session polling
+  // may then reopen the same Pair as data-only; media stays quarantined for
+  // the signed contract digest while chat/view remain usable.
   await Promise.all([owner, guest].map(page => expect(page.getByTestId('public-pair-webrtc-status'))
-    .toHaveText(/WebRTC:\s*(disconnected|failed)/i)));
+    .toHaveText(/WebRTC:\s*connected/i)));
+  await Promise.all([owner, guest].map(page => expect(page.getByTestId('public-pair-datachannel-status'))
+    .toHaveText(/DataChannel:\s*open/i)));
 }
 
 async function endOwnerSession(page: Page, sessionId: string): Promise<void> {
@@ -518,11 +531,6 @@ async function endOwnerSession(page: Page, sessionId: string): Promise<void> {
   page.once('dialog', dialog => void dialog.accept());
   await sharePanel(page).getByRole('button', { name: 'Session beenden', exact: true }).click();
   requireCondition((await response).ok(), 'public_session_cleanup_failed');
-  await expect(sharePanel(page).getByRole('button', { name: /Session erstellen/i })).toBeVisible();
-}
-
-async function leaveGuestSession(page: Page): Promise<void> {
-  await sharePanel(page).getByRole('button', { name: 'Verlassen', exact: true }).click();
   await expect(sharePanel(page).getByRole('button', { name: /Session erstellen/i })).toBeVisible();
 }
 
@@ -569,6 +577,14 @@ function safeStatusCode(value: string | null): string {
   if (normalized.includes('connected')) return 'connected';
   if (normalized.includes('failed')) return 'failed';
   if (normalized.includes('disconnected')) return 'disconnected';
+  return 'unknown';
+}
+
+function safeChannelState(value: string | null): string {
+  const normalized = String(value || '').toLowerCase();
+  for (const state of ['open', 'connecting', 'closing', 'closed', 'absent']) {
+    if (normalized.includes(state)) return state;
+  }
   return 'unknown';
 }
 


### PR DESCRIPTION
## Summary

- reconcile generation-bound DataChannel readiness at activation instead of relying on a single `open` edge
- gate Public media activation on verified topology and the real DataChannel, with separate Signaling/WebRTC/DataChannel UI status
- preserve activation request fencing through transient media states and harden the Chromium/Firefox live canary cleanup/revoke assertions

## Verification

- 160/160 broader Pair-media tests passed
- 55/55 final focused regression tests passed
- app and spec TypeScript passed
- scoped ESLint and diff/secret checks passed
- production Angular build passed
- live same-account Chromium/Firefox canary passed: bilateral mic, camera, screen, revoke to data-only reconnect, owner delete
- live cleanup audit: zero disposable users, browser/harness processes, or fixture directories; no server errors/restarts